### PR TITLE
feat: enqueue post-clone follow-up tasks

### DIFF
--- a/.github/agents/codetether.agent.md
+++ b/.github/agents/codetether.agent.md
@@ -1,0 +1,24 @@
+---
+name: codetether
+description: Repository-specific coding agent for CodeTether Agent that completes issues end-to-end with production-ready Rust changes and verification.
+target: github-copilot
+tools: ["execute", "read", "edit", "search", "github/*"]
+disable-model-invocation: true
+---
+
+You are the `codetether` custom agent for the `codetether-agent` repository.
+
+When you are assigned an issue or selected for a GitHub task:
+
+- Read `AGENTS.md` first, then inspect the affected modules and existing tests before editing.
+- Complete the issue end-to-end: reproduce, implement, test, and prepare a pull request that closes the issue.
+- Prefer the smallest focused change that fully satisfies the issue without unrelated refactors.
+- Follow repository standards exactly: Rust 2024, `anyhow::Result` for application fallible paths, `thiserror` for library error types, and structured `tracing` fields instead of `println!`.
+- Enforce modular cohesion and single responsibility. Split work into smaller modules before a code file exceeds the repository's 50-line limit.
+- Add or preserve the required module docs and multi-line rustdoc comments for public items.
+- Never hardcode secrets. Use Vault-based provider loading and existing secret management paths.
+- Add or update tests whenever behavior changes.
+- Before finishing, run the relevant verification commands: `cargo fmt`, `cargo clippy --all-features`, `cargo test`, and `cargo build --release`. If any step is skipped or blocked, explain exactly why in the pull request summary.
+- In the pull request summary, include the issue linkage, user-visible impact, verification performed, and any remaining risks or follow-up work.
+
+If the issue is ambiguous, choose the safest narrow interpretation, state that assumption in the pull request, and avoid speculative product changes.

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -60,11 +60,19 @@ jobs:
           fi
           echo "mode=${mode}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review_comment') && github.event.pull_request.head.sha || (github.event_name == 'issue_comment' && github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number)) || github.sha }}
+      - name: Checkout repository
+        shell: bash
+        env:
+          CHECKOUT_REF: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review_comment') && github.event.pull_request.head.sha || (github.event_name == 'issue_comment' && github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number)) || github.sha }}
+          RAW_GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git init .
+          git remote add origin "https://x-access-token:${RAW_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --prune --no-recurse-submodules origin \
+            +refs/heads/*:refs/remotes/origin/* \
+            +refs/tags/*:refs/tags/*
+          git fetch --no-recurse-submodules origin "${CHECKOUT_REF}"
+          git checkout --force FETCH_HEAD
 
       # Get a GitHub App installation token so comments come from the bot identity
       - name: Get App Token

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -7,13 +7,15 @@ on:
     types: [assigned, labeled]
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
 
 concurrency:
   group: codetether-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 
@@ -32,11 +34,37 @@ jobs:
       )) ||
       (github.event_name == 'issue_comment' && (
         contains(github.event.comment.body, '@codetether')
+      )) ||
+      (github.event_name == 'pull_request_review_comment' && (
+        contains(github.event.comment.body, '@codetether')
       ))
     steps:
+      - name: Classify request
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          ISSUE_PR_URL: ${{ github.event.issue.pull_request.url || '' }}
+        run: |
+          mode="server"
+          body="$(printf '%s' "${COMMENT_BODY}" | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')"
+          is_pr_comment="false"
+          if [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+            is_pr_comment="true"
+          elif [ "$EVENT_NAME" = "issue_comment" ] && [ -n "$ISSUE_PR_URL" ]; then
+            is_pr_comment="true"
+          fi
+          if [ "$is_pr_comment" = "true" ] && printf '%s' "$body" | grep -Eq '(@codetether([^[:alnum:]_-]|$).*(fix|apply|address|implement|patch))|((fix|apply|address|implement|patch).+@codetether([^[:alnum:]_-]|$))'; then
+            mode="local"
+          fi
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review_comment') && github.event.pull_request.head.sha || (github.event_name == 'issue_comment' && github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number)) || github.sha }}
 
       # Get a GitHub App installation token so comments come from the bot identity
       - name: Get App Token
@@ -49,5 +77,9 @@ jobs:
       - name: CodeTether Review
         uses: ./
         with:
+          mode: ${{ steps.classify.outputs.mode }}
           token: ${{ secrets.CODETETHER_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
+          vault_addr: ${{ secrets.VAULT_ADDR }}
+          vault_token: ${{ secrets.VAULT_TOKEN }}
+          max_steps: "60"

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -24,8 +24,4 @@ jobs:
       - name: CodeTether Review
         uses: ./
         with:
-          vault_addr: ${{ secrets.VAULT_ADDR }}
-          vault_token: ${{ secrets.VAULT_TOKEN }}
-          model: "zai/glm-5.1"
-          max_steps: "15"
-          auto_comment: "true"
+          token: ${{ secrets.CODETETHER_TOKEN }}

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -31,7 +31,7 @@ jobs:
         contains(github.event.issue.labels.*.name, 'codetether')
       )) ||
       (github.event_name == 'issue_comment' && (
-        contains(github.event.comment.body, '@jenkins-quantum-forge')
+        contains(github.event.comment.body, '@codetether')
       ))
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize, reopened]
   issues:
     types: [assigned, labeled]
+  issue_comment:
+    types: [created]
 
 concurrency:
   group: codetether-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
@@ -19,12 +21,17 @@ jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Run on PRs always, or on issues when the bot is assigned/labeled
+    # PRs: always run
+    # Issues: when assigned or labeled 'codetether'
+    # Issue comments: when @mentioning the bot
     if: >
       github.event_name == 'pull_request' ||
       (github.event_name == 'issues' && (
         github.event.action == 'assigned' ||
         contains(github.event.issue.labels.*.name, 'codetether')
+      )) ||
+      (github.event_name == 'issue_comment' && (
+        contains(github.event.comment.body, '@jenkins-quantum-forge')
       ))
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -1,0 +1,31 @@
+name: CodeTether Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: codetether-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: CodeTether Review
+        uses: ./
+        with:
+          vault_addr: ${{ secrets.VAULT_ADDR }}
+          vault_token: ${{ secrets.VAULT_TOKEN }}
+          model: "glm-5.1"
+          max_steps: "15"
+          auto_comment: "true"

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -3,25 +3,44 @@ name: CodeTether Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  issues:
+    types: [assigned, labeled]
 
 concurrency:
-  group: codetether-review-${{ github.event.pull_request.number }}
+  group: codetether-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Run on PRs always, or on issues when the bot is assigned/labeled
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issues' && (
+        github.event.action == 'assigned' ||
+        contains(github.event.issue.labels.*.name, 'codetether')
+      ))
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      # Get a GitHub App installation token so comments come from the bot identity
+      - name: Get App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: CodeTether Review
         uses: ./
         with:
           token: ${{ secrets.CODETETHER_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           vault_addr: ${{ secrets.VAULT_ADDR }}
           vault_token: ${{ secrets.VAULT_TOKEN }}
-          model: "glm-5.1"
+          model: "zai/glm-5.1"
           max_steps: "15"
           auto_comment: "true"

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           vault_addr: ${{ secrets.VAULT_ADDR }}
           vault_token: ${{ secrets.VAULT_TOKEN }}
-          copilot_token: ${{ secrets.GITHUB_COPILOT_TOKEN }}
-          model: "copilot/gpt-4o"
+          model: "glm-5.1"
           max_steps: "15"
           auto_comment: "true"

--- a/.github/workflows/codetether-review.yml
+++ b/.github/workflows/codetether-review.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           vault_addr: ${{ secrets.VAULT_ADDR }}
           vault_token: ${{ secrets.VAULT_TOKEN }}
-          model: "glm-5.1"
+          copilot_token: ${{ secrets.GITHUB_COPILOT_TOKEN }}
+          model: "copilot/gpt-4o"
           max_steps: "15"
           auto_comment: "true"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,100 @@
+name: "CodeTether Code Review"
+description: "AI-powered code review for pull requests — like Copilot and Gemini, self-hosted."
+author: "rileyseaburg"
+
+branding:
+  icon: "code"
+  color: "blue"
+
+inputs:
+  mode:
+    description: >
+      "local" runs the agent directly in the runner.
+      "server" dispatches to your A2A server (K8s worker picks it up).
+    required: false
+    default: "local"
+
+  # --- Local mode inputs ---
+  vault_addr:
+    description: "HashiCorp Vault address for LLM API keys (local mode)"
+    required: false
+  vault_token:
+    description: "Vault auth token (local mode)"
+    required: false
+  model:
+    description: "LLM model to use (e.g. glm-5.1, gpt-4o, claude-sonnet-4-20250514)"
+    required: false
+    default: "glm-5.1"
+  max_steps:
+    description: "Maximum agentic loop iterations"
+    required: false
+    default: "30"
+  extra_prompt:
+    description: "Additional instructions appended to the review prompt"
+    required: false
+    default: ""
+  auto_comment:
+    description: "Post review as a PR comment (true/false)"
+    required: false
+    default: "true"
+  version:
+    description: "CodeTether version to install (default: latest)"
+    required: false
+    default: "latest"
+
+  # --- Server mode inputs ---
+  server_url:
+    description: "A2A server URL (server mode)"
+    required: false
+  server_token:
+    description: "A2A server bearer token (server mode)"
+    required: false
+  agent_type:
+    description: "Agent type for task dispatch (server mode)"
+    required: false
+    default: "build"
+
+outputs:
+  review:
+    description: "The full review text output"
+    value: ${{ steps.review.outputs.review }}
+  exit_code:
+    description: "Agent exit code (0 = success)"
+    value: ${{ steps.review.outputs.exit_code }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install CodeTether
+      if: inputs.mode == 'local'
+      shell: bash
+      run: |
+        if command -v codetether &>/dev/null; then
+          echo "CodeTether already installed: $(codetether --version 2>/dev/null || echo 'unknown')"
+        else
+          echo "Installing CodeTether..."
+          curl -fsSL https://raw.githubusercontent.com/rileyseaburg/codetether-agent/main/install.sh | sh
+        fi
+
+    - name: Run review
+      id: review
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        VAULT_ADDR: ${{ inputs.vault_addr }}
+        VAULT_TOKEN: ${{ inputs.vault_token }}
+        CODETETHER_DEFAULT_MODEL: ${{ inputs.model }}
+        CODETETHER_SERVER: ${{ inputs.server_url }}
+        CODETETHER_TOKEN: ${{ inputs.server_token }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_MAX_STEPS: ${{ inputs.max_steps }}
+        INPUT_EXTRA_PROMPT: ${{ inputs.extra_prompt }}
+        INPUT_AUTO_COMMENT: ${{ inputs.auto_comment }}
+        INPUT_AGENT_TYPE: ${{ inputs.agent_type }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+        PR_BASE: ${{ github.event.pull_request.base.ref }}
+        PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        REPO_FULL_NAME: ${{ github.repository }}
+      run: ${{ github.action_path }}/action/entrypoint.sh

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ branding:
   color: "blue"
 
 inputs:
+  github_token:
+    description: "GitHub App installation token for posting comments as the bot identity (auto-set by workflow)"
+    required: false
+    default: ""
   token:
     description: "CodeTether API token (from https://codetether.run → Settings → API Tokens)"
     required: true
@@ -113,7 +117,7 @@ runs:
       id: review
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
         CODETETHER_SERVER: ${{ inputs.server_url }}
         CODETETHER_TOKEN: ${{ inputs.token }}
         VAULT_ADDR: ${{ inputs.vault_addr }}
@@ -125,10 +129,11 @@ runs:
         INPUT_EXTRA_PROMPT: ${{ inputs.extra_prompt }}
         INPUT_AUTO_COMMENT: ${{ inputs.auto_comment }}
         INPUT_AGENT_TYPE: ${{ inputs.agent_type }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-        PR_TITLE: ${{ github.event.pull_request.title }}
-        PR_BODY: ${{ github.event.pull_request.body }}
-        PR_BASE: ${{ github.event.pull_request.base.ref }}
-        PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        PR_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
+        PR_BODY: ${{ github.event.pull_request.body || github.event.issue.body }}
+        PR_BASE: ${{ github.event.pull_request.base.ref || '' }}
+        PR_HEAD: ${{ github.event.pull_request.head.ref || '' }}
         REPO_FULL_NAME: ${{ github.repository }}
       run: ${{ github.action_path }}/action/entrypoint.sh

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,19 @@ runs:
           echo "CodeTether already installed: $(codetether --version 2>/dev/null || echo 'unknown')"
         else
           echo "Installing CodeTether..."
-          curl -fsSL https://raw.githubusercontent.com/rileyseaburg/codetether-agent/main/install.sh | sh
+          VERSION="${{ inputs.version }}"
+          REPO="rileyseaburg/codetether-agent"
+          if [ "$VERSION" = "latest" ]; then
+            VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*"v\(.*\)".*/\1/')
+          fi
+          ARCHIVE="codetether-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+          echo "Downloading ${URL}"
+          curl -fsSL "$URL" -o "/tmp/${ARCHIVE}"
+          tar -xzf "/tmp/${ARCHIVE}" -C /tmp
+          sudo install -m 755 /tmp/codetether /usr/local/bin/codetether
+          rm -f "/tmp/${ARCHIVE}" /tmp/codetether
+          echo "Installed: $(codetether --version 2>/dev/null || echo 'v'${VERSION})"
         fi
 
     - name: Run review

--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,13 @@ inputs:
   vault_token:
     description: "Vault auth token (local mode)"
     required: false
-  model:
-    description: "LLM model to use (e.g. glm-5.1, gpt-4o, claude-sonnet-4-20250514)"
+  copilot_token:
+    description: "GitHub Copilot API token (from `codetether auth copilot`). Alternative to Vault."
     required: false
-    default: "glm-5.1"
+  model:
+    description: "LLM model to use (e.g. copilot/gpt-4o, glm-5.1, gpt-4o)"
+    required: false
+    default: "copilot/gpt-4o"
   max_steps:
     description: "Maximum agentic loop iterations"
     required: false
@@ -88,8 +91,19 @@ runs:
           echo "Downloading ${URL}"
           curl -fsSL "$URL" -o "/tmp/${ARCHIVE}"
           tar -xzf "/tmp/${ARCHIVE}" -C /tmp
-          sudo install -m 755 /tmp/codetether /usr/local/bin/codetether
-          rm -f "/tmp/${ARCHIVE}" /tmp/codetether
+          # Binary inside tarball may be named with version/platform suffix
+          BINARY=$(tar -tzf "/tmp/${ARCHIVE}" 2>/dev/null | head -1 || true)
+          if [ -f "/tmp/${BINARY}" ]; then
+            sudo install -m 755 "/tmp/${BINARY}" /usr/local/bin/codetether
+          elif [ -f "/tmp/codetether" ]; then
+            sudo install -m 755 /tmp/codetether /usr/local/bin/codetether
+          else
+            echo "::error::Could not find codetether binary in archive"
+            tar -tzf "/tmp/${ARCHIVE}" || true
+            ls -la /tmp/codetether* || true
+            exit 1
+          fi
+          rm -f "/tmp/${ARCHIVE}" "/tmp/${BINARY}" /tmp/codetether
           echo "Installed: $(codetether --version 2>/dev/null || echo 'v'${VERSION})"
         fi
 
@@ -100,6 +114,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         VAULT_ADDR: ${{ inputs.vault_addr }}
         VAULT_TOKEN: ${{ inputs.vault_token }}
+        GITHUB_COPILOT_TOKEN: ${{ inputs.copilot_token }}
         CODETETHER_DEFAULT_MODEL: ${{ inputs.model }}
         CODETETHER_SERVER: ${{ inputs.server_url }}
         CODETETHER_TOKEN: ${{ inputs.server_token }}

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ author: "rileyseaburg"
 
 branding:
   icon: "code"
-  color: "green"
+  color: "blue"
 
 inputs:
   github_token:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,8 @@
 name: "CodeTether Code Review"
-description: "AI-powered code review for pull requests — like Copilot and Gemini, self-hosted."
+description: >-
+  AI-powered code review for pull requests.
+  Add this action to any repo — no API keys needed.
+  Sign up at https://codetether.run, grab your token, and go.
 author: "rileyseaburg"
 
 branding:
@@ -7,31 +10,13 @@ branding:
   color: "blue"
 
 inputs:
-  mode:
-    description: >
-      "local" runs the agent directly in the runner.
-      "server" dispatches to your A2A server (K8s worker picks it up).
+  token:
+    description: "CodeTether API token (from https://codetether.run → Settings → API Tokens)"
+    required: true
+  server_url:
+    description: "CodeTether server URL (default: https://api.codetether.run)"
     required: false
-    default: "local"
-
-  # --- Local mode inputs ---
-  vault_addr:
-    description: "HashiCorp Vault address for LLM API keys (local mode)"
-    required: false
-  vault_token:
-    description: "Vault auth token (local mode)"
-    required: false
-  copilot_token:
-    description: "GitHub Copilot API token (from `codetether auth copilot`). Alternative to Vault."
-    required: false
-  model:
-    description: "LLM model to use (e.g. copilot/gpt-4o, glm-5.1, gpt-4o)"
-    required: false
-    default: "copilot/gpt-4o"
-  max_steps:
-    description: "Maximum agentic loop iterations"
-    required: false
-    default: "30"
+    default: "https://api.codetether.run"
   extra_prompt:
     description: "Additional instructions appended to the review prompt"
     required: false
@@ -40,22 +25,39 @@ inputs:
     description: "Post review as a PR comment (true/false)"
     required: false
     default: "true"
+  agent_type:
+    description: "Agent type for task dispatch"
+    required: false
+    default: "code-review"
+
+  # --- Advanced: self-hosted / BYOK mode ---
+  mode:
+    description: >-
+      "server" (default) dispatches to CodeTether cloud.
+      "local" runs the agent in the runner (requires your own LLM keys).
+    required: false
+    default: "server"
+  vault_addr:
+    description: "HashiCorp Vault address (local mode only)"
+    required: false
+  vault_token:
+    description: "Vault auth token (local mode only)"
+    required: false
+  api_key:
+    description: "LLM API key for BYOK (local mode only)"
+    required: false
+  model:
+    description: "LLM model (local mode only, e.g. gpt-4o, claude-sonnet-4-20250514)"
+    required: false
+    default: "glm-5.1"
+  max_steps:
+    description: "Maximum agentic loop iterations (local mode only)"
+    required: false
+    default: "30"
   version:
-    description: "CodeTether version to install (default: latest)"
+    description: "CodeTether version to install (local mode only)"
     required: false
     default: "latest"
-
-  # --- Server mode inputs ---
-  server_url:
-    description: "A2A server URL (server mode)"
-    required: false
-  server_token:
-    description: "A2A server bearer token (server mode)"
-    required: false
-  agent_type:
-    description: "Agent type for task dispatch (server mode)"
-    required: false
-    default: "build"
 
 outputs:
   review:
@@ -112,12 +114,12 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        CODETETHER_SERVER: ${{ inputs.server_url }}
+        CODETETHER_TOKEN: ${{ inputs.token }}
         VAULT_ADDR: ${{ inputs.vault_addr }}
         VAULT_TOKEN: ${{ inputs.vault_token }}
-        GITHUB_COPILOT_TOKEN: ${{ inputs.copilot_token }}
+        CODETETHER_API_KEY: ${{ inputs.api_key }}
         CODETETHER_DEFAULT_MODEL: ${{ inputs.model }}
-        CODETETHER_SERVER: ${{ inputs.server_url }}
-        CODETETHER_TOKEN: ${{ inputs.server_token }}
         INPUT_MODE: ${{ inputs.mode }}
         INPUT_MAX_STEPS: ${{ inputs.max_steps }}
         INPUT_EXTRA_PROMPT: ${{ inputs.extra_prompt }}

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,8 @@ runs:
     - name: Install CodeTether
       if: inputs.mode == 'local'
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         if command -v codetether &>/dev/null; then
           echo "CodeTether already installed: $(codetether --version 2>/dev/null || echo 'unknown')"
@@ -76,7 +78,10 @@ runs:
           VERSION="${{ inputs.version }}"
           REPO="rileyseaburg/codetether-agent"
           if [ "$VERSION" = "latest" ]; then
-            VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*"v\(.*\)".*/\1/')
+            VERSION=$(curl -fsSL \
+              -H "Authorization: token ${GH_TOKEN}" \
+              "https://api.github.com/repos/${REPO}/releases/latest" \
+              | grep '"tag_name"' | head -1 | sed 's/.*"v\(.*\)".*/\1/')
           fi
           ARCHIVE="codetether-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
           URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARCHIVE}"

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ author: "rileyseaburg"
 
 branding:
   icon: "code"
-  color: "blue"
+  color: "green"
 
 inputs:
   github_token:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "CodeTether Code Review"
 description: >-
-  AI-powered code review for pull requests.
+  AI-powered code review and PR fix automation.
   Add this action to any repo — no API keys needed.
   Sign up at https://codetether.run, grab your token, and go.
 author: "rileyseaburg"
@@ -118,6 +118,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
+        GH_ACTIONS_TOKEN: ${{ github.token }}
         CODETETHER_SERVER: ${{ inputs.server_url }}
         CODETETHER_TOKEN: ${{ inputs.token }}
         VAULT_ADDR: ${{ inputs.vault_addr }}

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -11,6 +11,19 @@ set -euo pipefail
 [ -z "${VAULT_TOKEN:-}" ] && unset VAULT_TOKEN
 [ -z "${GITHUB_COPILOT_TOKEN:-}" ] && unset GITHUB_COPILOT_TOKEN
 
+# ── Map generic API key to provider-specific env var ─────────────
+if [ -n "${CODETETHER_API_KEY:-}" ]; then
+  MODEL="${CODETETHER_DEFAULT_MODEL:-glm-5.1}"
+  case "$MODEL" in
+    glm*|zhipu*)   export ZAI_API_KEY="$CODETETHER_API_KEY" ;;
+    gpt*|o1*|o3*)  export OPENAI_API_KEY="$CODETETHER_API_KEY" ;;
+    claude*)       export ANTHROPIC_API_KEY="$CODETETHER_API_KEY" ;;
+    copilot/*)     export GITHUB_COPILOT_TOKEN="$CODETETHER_API_KEY" ;;
+    *)             export OPENAI_API_KEY="$CODETETHER_API_KEY" ;;
+  esac
+  unset CODETETHER_API_KEY
+fi
+
 # ── Gather PR diff ───────────────────────────────────────────────
 echo "::group::Fetching PR diff"
 DIFF_FILE="$(mktemp)"
@@ -61,17 +74,21 @@ if [ "$INPUT_MODE" = "server" ]; then
     echo "::error::server_url is required in server mode"
     exit 1
   fi
+  if [ -z "${CODETETHER_TOKEN:-}" ]; then
+    echo "::error::token is required in server mode"
+    exit 1
+  fi
 
   TASK_PAYLOAD=$(jq -n \
-    --arg prompt "$PROMPT" \
+    --arg description "$PROMPT" \
     --arg agent_type "$INPUT_AGENT_TYPE" \
     --arg title "PR Review: #${PR_NUMBER} ${PR_TITLE}" \
     --arg repo "$REPO_FULL_NAME" \
     --arg pr_number "$PR_NUMBER" \
     '{
-      prompt: $prompt,
-      agent_type: $agent_type,
       title: $title,
+      description: $description,
+      agent_type: $agent_type,
       metadata: {
         source: "github-actions",
         repo: $repo,
@@ -80,16 +97,93 @@ if [ "$INPUT_MODE" = "server" ]; then
     }')
 
   RESPONSE=$(curl -fsSL \
-    -X POST "${CODETETHER_SERVER}/v1/automation/tasks" \
+    -X POST "${CODETETHER_SERVER}/v1/tasks/dispatch" \
     -H "Authorization: Bearer ${CODETETHER_TOKEN}" \
     -H "Content-Type: application/json" \
     -H "Idempotency-Key: pr-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${GITHUB_SHA:0:8}" \
     -d "$TASK_PAYLOAD")
 
-  TASK_ID=$(echo "$RESPONSE" | jq -r '.task_id // .id // "unknown"')
+  TASK_ID=$(echo "$RESPONSE" | jq -r '.task_id // "unknown"')
   echo "Task dispatched: ${TASK_ID}"
-  echo "review=Review task dispatched to server: ${TASK_ID}" >> "$GITHUB_OUTPUT"
+
+  if [ "$TASK_ID" = "unknown" ]; then
+    echo "::error::Failed to dispatch task: ${RESPONSE}"
+    echo "review=Failed to dispatch review task." >> "$GITHUB_OUTPUT"
+    echo "exit_code=1" >> "$GITHUB_OUTPUT"
+    exit 1
+  fi
+
+  # ── Poll for task completion ─────────────────────────────────
+  echo "Waiting for task to complete..."
+  MAX_POLL=60
+  POLL_INTERVAL=5
+  POLL_COUNT=0
+  TASK_STATUS="pending"
+
+  while [ "$POLL_COUNT" -lt "$MAX_POLL" ] && [ "$TASK_STATUS" != "completed" ] && [ "$TASK_STATUS" != "failed" ] && [ "$TASK_STATUS" != "canceled" ]; do
+    sleep "$POLL_INTERVAL"
+    POLL_COUNT=$((POLL_COUNT + 1))
+
+    TASK_RESPONSE=$(curl -fsSL \
+      -H "Authorization: Bearer ${CODETETHER_TOKEN}" \
+      "${CODETETHER_SERVER}/v1/tasks/dispatch/${TASK_ID}" 2>/dev/null || echo '{}')
+
+    TASK_STATUS=$(echo "$TASK_RESPONSE" | jq -r '.status // "unknown"')
+    echo "  Poll ${POLL_COUNT}/${MAX_POLL}: status=${TASK_STATUS}"
+  done
+
+  if [ "$TASK_STATUS" = "completed" ]; then
+    # Extract result from the A2A task
+    RESULT_TEXT=$(curl -fsSL \
+      -X POST "${CODETETHER_SERVER}/" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n --arg id "$TASK_ID" '{"jsonrpc":"2.0","id":"poll","method":"tasks/get","params":{"id":$id}}')" \
+      2>/dev/null | jq -r '.result.task.messages[-1].parts[0].text // "No review text returned."')
+
+    REVIEW_TEXT=$(echo "$RESULT_TEXT" | head -c 65000)
+  elif [ "$TASK_STATUS" = "failed" ]; then
+    REVIEW_TEXT="Review task failed. Check server logs for task ${TASK_ID}."
+  else
+    REVIEW_TEXT="Review task timed out after $((MAX_POLL * POLL_INTERVAL))s (status: ${TASK_STATUS}). Task ID: ${TASK_ID}"
+  fi
+
   echo "exit_code=0" >> "$GITHUB_OUTPUT"
+  {
+    echo "review<<CODETETHER_EOF"
+    echo "$REVIEW_TEXT"
+    echo "CODETETHER_EOF"
+  } >> "$GITHUB_OUTPUT"
+
+  # ── Post PR comment (server mode) ─────────────────────────────
+  if [ "${INPUT_AUTO_COMMENT}" = "true" ] && [ -n "${PR_NUMBER:-}" ] && [ "$TASK_STATUS" = "completed" ]; then
+    COMMENT_BODY="## 🔍 CodeTether Review
+
+<details>
+<summary>PR #${PR_NUMBER}: ${PR_TITLE}</summary>
+
+Mode: server · Task: \`${TASK_ID}\`
+
+</details>
+
+${REVIEW_TEXT}"
+
+    if [ ${#COMMENT_BODY} -gt 65000 ]; then
+      COMMENT_BODY="${COMMENT_BODY:0:64900}
+
+..._truncated (review exceeded comment size limit)_"
+    fi
+
+    curl -fsSL \
+      -X POST \
+      -H "Authorization: token ${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/comments" \
+      -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')" \
+      > /dev/null
+
+    echo "Review posted to PR #${PR_NUMBER}"
+  fi
+
   echo "::endgroup::"
   exit 0
 fi

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -24,6 +24,128 @@ if [ -n "${CODETETHER_API_KEY:-}" ]; then
   unset CODETETHER_API_KEY
 fi
 
+# ── Issue mode: use issue body directly as prompt ────────────────
+if [ "${GITHUB_EVENT_NAME:-}" = "issues" ]; then
+  echo "::group::Processing issue #${PR_NUMBER}"
+
+  PROMPT="You are responding to GitHub Issue #${PR_NUMBER}: \"${PR_TITLE}\" in ${REPO_FULL_NAME}.
+
+Analyze the issue and provide a thorough response. If it's a bug report, suggest a fix. If it's a feature request, discuss implementation approach.
+
+${INPUT_EXTRA_PROMPT:+Additional instructions: ${INPUT_EXTRA_PROMPT}}
+
+Issue body:
+${PR_BODY:-No description provided.}"
+
+  REVIEW_TEXT=""
+
+  # ── Dispatch to server (issue mode) ─────────────────────────
+  if [ "$INPUT_MODE" = "server" ]; then
+    echo "Dispatching issue task to A2A server..."
+
+    TASK_PAYLOAD=$(jq -n \
+      --arg description "$PROMPT" \
+      --arg agent_type "$INPUT_AGENT_TYPE" \
+      --arg title "Issue #${PR_NUMBER}: ${PR_TITLE}" \
+      --arg repo "$REPO_FULL_NAME" \
+      --arg pr_number "$PR_NUMBER" \
+      '{
+        title: $title,
+        description: $description,
+        agent_type: $agent_type,
+        metadata: {
+          source: "github-actions",
+          repo: $repo,
+          issue_number: ($pr_number | tonumber)
+        }
+      }')
+
+    RESPONSE=$(curl -fsSL \
+      -X POST "${CODETETHER_SERVER}/v1/tasks/dispatch" \
+      -H "Authorization: Bearer ${CODETETHER_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$TASK_PAYLOAD")
+
+    TASK_ID=$(echo "$RESPONSE" | jq -r '.task_id // "unknown"')
+    echo "Task dispatched: ${TASK_ID}"
+
+    if [ "$TASK_ID" = "unknown" ]; then
+      echo "::error::Failed to dispatch task: ${RESPONSE}"
+      echo "review=Failed to dispatch task." >> "$GITHUB_OUTPUT"
+      echo "exit_code=1" >> "$GITHUB_OUTPUT"
+      exit 1
+    fi
+
+    # Poll for completion
+    MAX_POLL=60
+    POLL_INTERVAL=5
+    POLL_COUNT=0
+    TASK_STATUS="pending"
+
+    while [ "$POLL_COUNT" -lt "$MAX_POLL" ] && [ "$TASK_STATUS" != "completed" ] && [ "$TASK_STATUS" != "failed" ] && [ "$TASK_STATUS" != "canceled" ]; do
+      sleep "$POLL_INTERVAL"
+      POLL_COUNT=$((POLL_COUNT + 1))
+      TASK_RESPONSE=$(curl -fsSL \
+        -H "Authorization: Bearer ${CODETETHER_TOKEN}" \
+        "${CODETETHER_SERVER}/v1/tasks/dispatch/${TASK_ID}" 2>/dev/null || echo '{}')
+      TASK_STATUS=$(echo "$TASK_RESPONSE" | jq -r '.status // "unknown"')
+      echo "  Poll ${POLL_COUNT}/${MAX_POLL}: status=${TASK_STATUS}"
+    done
+
+    if [ "$TASK_STATUS" = "completed" ]; then
+      RESULT_RESPONSE=$(curl -fsSL \
+        -H "Authorization: Bearer ${CODETETHER_TOKEN}" \
+        "${CODETETHER_SERVER}/v1/tasks/dispatch/${TASK_ID}")
+      RESULT_TEXT=$(echo "$RESULT_RESPONSE" | jq -r '.result // "No response returned."')
+      REVIEW_TEXT=$(echo "$RESULT_TEXT" | head -c 65000)
+    elif [ "$TASK_STATUS" = "failed" ]; then
+      REVIEW_TEXT="Issue task failed. Check server logs for task ${TASK_ID}."
+    else
+      REVIEW_TEXT="Issue task timed out after $((MAX_POLL * POLL_INTERVAL))s (status: ${TASK_STATUS}). Task ID: ${TASK_ID}"
+    fi
+  fi
+
+  # ── Post issue comment ──────────────────────────────────────
+  if [ "${INPUT_AUTO_COMMENT}" = "true" ] && [ -n "${PR_NUMBER:-}" ] && [ -n "$REVIEW_TEXT" ]; then
+    COMMENT_BODY="## 🤖 CodeTether Response
+
+<details>
+<summary>Issue #${PR_NUMBER}: ${PR_TITLE}</summary>
+
+Task: \`${TASK_ID:-local}\`
+
+</details>
+
+${REVIEW_TEXT}"
+
+    if [ ${#COMMENT_BODY} -gt 65000 ]; then
+      COMMENT_BODY="${COMMENT_BODY:0:64900}
+
+..._truncated (response exceeded comment size limit)_"
+    fi
+
+    curl -fsSL \
+      -X POST \
+      -H "Authorization: token ${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/comments" \
+      -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')" \
+      > /dev/null
+
+    echo "Response posted to Issue #${PR_NUMBER}"
+  fi
+
+  echo "exit_code=0" >> "$GITHUB_OUTPUT"
+  {
+    echo "review<<CODETETHER_EOF"
+    echo "$REVIEW_TEXT"
+    echo "CODETETHER_EOF"
+  } >> "$GITHUB_OUTPUT"
+
+  echo "::endgroup::"
+  exit 0
+fi
+
 # ── Gather PR diff ───────────────────────────────────────────────
 echo "::group::Fetching PR diff"
 DIFF_FILE="$(mktemp)"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -93,8 +93,14 @@ echo "::group::Running CodeTether review"
 
 REVIEW_FILE="$(mktemp)"
 
+# Build args — --max-steps only available in >= 4.5.0
+RUN_ARGS=()
+if codetether run --help 2>&1 | grep -q -- '--max-steps'; then
+  RUN_ARGS+=(--max-steps "${INPUT_MAX_STEPS}")
+fi
+
 codetether run \
-  --max-steps "${INPUT_MAX_STEPS}" \
+  "${RUN_ARGS[@]}" \
   "$PROMPT" \
   2>&1 | tee "$REVIEW_FILE"
 

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# CodeTether GitHub Action entrypoint
+# Supports two modes:
+#   local  — runs the agent in the GH Actions runner
+#   server — dispatches a review task to an A2A server
+set -euo pipefail
+
+# ── Gather PR diff ───────────────────────────────────────────────
+echo "::group::Fetching PR diff"
+DIFF_FILE="$(mktemp)"
+git diff "origin/${PR_BASE}...HEAD" -- '*.rs' '*.py' '*.ts' '*.js' '*.go' '*.java' '*.tsx' '*.jsx' '*.yml' '*.yaml' '*.toml' > "$DIFF_FILE" 2>/dev/null || true
+
+DIFF_LINES=$(wc -l < "$DIFF_FILE")
+echo "Diff: ${DIFF_LINES} lines"
+
+if [ "$DIFF_LINES" -eq 0 ]; then
+  echo "No code changes detected — skipping review."
+  echo "review=No code changes to review." >> "$GITHUB_OUTPUT"
+  echo "exit_code=0" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Truncate massive diffs to avoid blowing context limits
+MAX_DIFF_LINES=3000
+if [ "$DIFF_LINES" -gt "$MAX_DIFF_LINES" ]; then
+  echo "⚠ Diff truncated to ${MAX_DIFF_LINES} lines (was ${DIFF_LINES})"
+  head -n "$MAX_DIFF_LINES" "$DIFF_FILE" > "${DIFF_FILE}.trunc"
+  mv "${DIFF_FILE}.trunc" "$DIFF_FILE"
+fi
+echo "::endgroup::"
+
+# ── Build review prompt ──────────────────────────────────────────
+PROMPT="You are reviewing PR #${PR_NUMBER}: \"${PR_TITLE}\" (${PR_HEAD} → ${PR_BASE}).
+
+Review the following diff and report:
+1. **Bugs** — logic errors, off-by-one, null/unwrap safety
+2. **Security** — OWASP Top 10, injection, auth bypass, secrets exposure
+3. **Performance** — unnecessary allocations, O(n²) patterns, missing indexes
+4. **Style** — naming, dead code, missing error handling
+
+Be concise. Only comment on real issues, not nitpicks.
+If the code looks good, say so briefly.
+
+${INPUT_EXTRA_PROMPT:+Additional instructions: ${INPUT_EXTRA_PROMPT}}
+
+\`\`\`diff
+$(cat "$DIFF_FILE")
+\`\`\`"
+
+# ── Mode: server ─────────────────────────────────────────────────
+if [ "$INPUT_MODE" = "server" ]; then
+  echo "::group::Dispatching review task to A2A server"
+
+  if [ -z "${CODETETHER_SERVER:-}" ]; then
+    echo "::error::server_url is required in server mode"
+    exit 1
+  fi
+
+  TASK_PAYLOAD=$(jq -n \
+    --arg prompt "$PROMPT" \
+    --arg agent_type "$INPUT_AGENT_TYPE" \
+    --arg title "PR Review: #${PR_NUMBER} ${PR_TITLE}" \
+    --arg repo "$REPO_FULL_NAME" \
+    --arg pr_number "$PR_NUMBER" \
+    '{
+      prompt: $prompt,
+      agent_type: $agent_type,
+      title: $title,
+      metadata: {
+        source: "github-actions",
+        repo: $repo,
+        pr_number: ($pr_number | tonumber)
+      }
+    }')
+
+  RESPONSE=$(curl -fsSL \
+    -X POST "${CODETETHER_SERVER}/v1/automation/tasks" \
+    -H "Authorization: Bearer ${CODETETHER_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -H "Idempotency-Key: pr-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${GITHUB_SHA:0:8}" \
+    -d "$TASK_PAYLOAD")
+
+  TASK_ID=$(echo "$RESPONSE" | jq -r '.task_id // .id // "unknown"')
+  echo "Task dispatched: ${TASK_ID}"
+  echo "review=Review task dispatched to server: ${TASK_ID}" >> "$GITHUB_OUTPUT"
+  echo "exit_code=0" >> "$GITHUB_OUTPUT"
+  echo "::endgroup::"
+  exit 0
+fi
+
+# ── Mode: local ──────────────────────────────────────────────────
+echo "::group::Running CodeTether review"
+
+REVIEW_FILE="$(mktemp)"
+
+codetether run \
+  --max-steps "${INPUT_MAX_STEPS}" \
+  "$PROMPT" \
+  2>&1 | tee "$REVIEW_FILE"
+
+EXIT_CODE=${PIPESTATUS[0]:-0}
+echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+echo "::endgroup::"
+
+# ── Capture output ───────────────────────────────────────────────
+# GitHub outputs have a 1MB limit; truncate if needed
+REVIEW_TEXT=$(head -c 65000 "$REVIEW_FILE")
+
+# Use heredoc delimiter for multi-line output
+{
+  echo "review<<CODETETHER_EOF"
+  echo "$REVIEW_TEXT"
+  echo "CODETETHER_EOF"
+} >> "$GITHUB_OUTPUT"
+
+# ── Post PR comment ──────────────────────────────────────────────
+if [ "${INPUT_AUTO_COMMENT}" = "true" ] && [ -n "${PR_NUMBER:-}" ]; then
+  echo "::group::Posting review comment"
+
+  COMMENT_BODY="## 🔍 CodeTether Review
+
+<details>
+<summary>PR #${PR_NUMBER}: ${PR_TITLE}</summary>
+
+Model: \`${CODETETHER_DEFAULT_MODEL:-default}\` · Steps: ${INPUT_MAX_STEPS}
+
+</details>
+
+${REVIEW_TEXT}"
+
+  # Truncate to GitHub's 65536-char comment limit
+  if [ ${#COMMENT_BODY} -gt 65000 ]; then
+    COMMENT_BODY="${COMMENT_BODY:0:64900}
+
+..._truncated (review exceeded comment size limit)_"
+  fi
+
+  curl -fsSL \
+    -X POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/comments" \
+    -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')" \
+    > /dev/null
+
+  echo "Review posted to PR #${PR_NUMBER}"
+  echo "::endgroup::"
+fi
+
+# Clean up
+rm -f "$DIFF_FILE" "$REVIEW_FILE"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -133,12 +133,11 @@ if [ "$INPUT_MODE" = "server" ]; then
   done
 
   if [ "$TASK_STATUS" = "completed" ]; then
-    # Extract result from the A2A task
-    RESULT_TEXT=$(curl -fsSL \
-      -X POST "${CODETETHER_SERVER}/" \
-      -H "Content-Type: application/json" \
-      -d "$(jq -n --arg id "$TASK_ID" '{"jsonrpc":"2.0","id":"poll","method":"tasks/get","params":{"id":$id}}')" \
-      2>/dev/null | jq -r '.result.task.messages[-1].parts[0].text // "No review text returned."')
+    # Fetch completed task with result from dispatch API
+    RESULT_RESPONSE=$(curl -fsSL \
+      -H "Authorization: Bearer ${CODETETHER_TOKEN}" \
+      "${CODETETHER_SERVER}/v1/tasks/dispatch/${TASK_ID}")
+    RESULT_TEXT=$(echo "$RESULT_RESPONSE" | jq -r '.result // "No review text returned."')
 
     REVIEW_TEXT=$(echo "$RESULT_TEXT" | head -c 65000)
   elif [ "$TASK_STATUS" = "failed" ]; then

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -5,6 +5,12 @@
 #   server — dispatches a review task to an A2A server
 set -euo pipefail
 
+# ── Clear empty credential env vars to avoid panic ───────────────
+# vaultrs panics on empty VAULT_ADDR; codetether should fall back to env providers
+[ -z "${VAULT_ADDR:-}" ] && unset VAULT_ADDR
+[ -z "${VAULT_TOKEN:-}" ] && unset VAULT_TOKEN
+[ -z "${GITHUB_COPILOT_TOKEN:-}" ] && unset GITHUB_COPILOT_TOKEN
+
 # ── Gather PR diff ───────────────────────────────────────────────
 echo "::group::Fetching PR diff"
 DIFF_FILE="$(mktemp)"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -24,15 +24,96 @@ if [ -n "${CODETETHER_API_KEY:-}" ]; then
   unset CODETETHER_API_KEY
 fi
 
+post_github_comment() {
+  local target_number="$1"
+  local body="$2"
+  curl -fsSL \
+    -X POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/${REPO_FULL_NAME}/issues/${target_number}/comments" \
+    -d "$(jq -n --arg body "$body" '{body: $body}')" \
+    > /dev/null
+}
+
+write_review_output() {
+  local text="$1"
+  local code="${2:-0}"
+  echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+  {
+    echo "review<<CODETETHER_EOF"
+    echo "$text"
+    echo "CODETETHER_EOF"
+  } >> "$GITHUB_OUTPUT"
+}
+
+github_api_get() {
+  local path="$1"
+  curl -fsSL \
+    -H "Authorization: token ${GH_ACTIONS_TOKEN:-${GITHUB_TOKEN}}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com${path}"
+}
+
+fetch_pr_metadata() {
+  local response
+  response="$(github_api_get "/repos/${REPO_FULL_NAME}/pulls/${PR_NUMBER}")"
+  PR_BASE="$(echo "$response" | jq -r '.base.ref')"
+  PR_HEAD="$(echo "$response" | jq -r '.head.ref')"
+  PR_HEAD_REPO="$(echo "$response" | jq -r '.head.repo.full_name')"
+}
+
+run_local_codetether() {
+  local prompt="$1"
+  local output_file="$2"
+  local run_args=()
+  if codetether run --help 2>&1 | grep -q -- '--max-steps'; then
+    run_args+=(--max-steps "${INPUT_MAX_STEPS}")
+  fi
+  codetether run "${run_args[@]}" "$prompt" 2>&1 | tee "$output_file"
+  return "${PIPESTATUS[0]:-0}"
+}
+
+COMMENT_BODY=""
+COMMENT_PATH=""
+COMMENT_DIFF_HUNK=""
+IS_PR_COMMENT="false"
+FIX_REQUEST="false"
+if [ -n "${GITHUB_EVENT_PATH:-}" ] && [ -f "${GITHUB_EVENT_PATH}" ]; then
+  COMMENT_BODY="$(jq -r '.comment.body // ""' "${GITHUB_EVENT_PATH}")"
+  COMMENT_PATH="$(jq -r '.comment.path // ""' "${GITHUB_EVENT_PATH}")"
+  COMMENT_DIFF_HUNK="$(jq -r '.comment.diff_hunk // ""' "${GITHUB_EVENT_PATH}")"
+  if [ "${GITHUB_EVENT_NAME:-}" = "pull_request_review_comment" ]; then
+    IS_PR_COMMENT="true"
+  elif [ "${GITHUB_EVENT_NAME:-}" = "issue_comment" ] && jq -e '.issue.pull_request' "${GITHUB_EVENT_PATH}" >/dev/null 2>&1; then
+    IS_PR_COMMENT="true"
+  fi
+fi
+
+COMMENT_BODY_LOWER="$(printf '%s' "${COMMENT_BODY}" | tr '\r\n' '  ' | tr '[:upper:]' '[:lower:]')"
+if printf '%s' "${COMMENT_BODY_LOWER}" | grep -Eq '(@codetether([^[:alnum:]_-]|$).*(fix|apply|address|implement|patch))|((fix|apply|address|implement|patch).+@codetether([^[:alnum:]_-]|$))'; then
+  FIX_REQUEST="true"
+fi
+
 # ── Issue mode: use issue body directly as prompt ────────────────
-if [ "${GITHUB_EVENT_NAME:-}" = "issues" ]; then
+if [ "${GITHUB_EVENT_NAME:-}" = "issues" ] || { [ "${GITHUB_EVENT_NAME:-}" = "issue_comment" ] && [ "${IS_PR_COMMENT}" != "true" ]; }; then
   echo "::group::Processing issue #${PR_NUMBER}"
+
+  COMMENT_INSTRUCTIONS=""
+  if [ "${GITHUB_EVENT_NAME:-}" = "issue_comment" ] && [ -n "${COMMENT_BODY}" ]; then
+    COMMENT_INSTRUCTIONS="A new issue comment mentioned @codetether:
+${COMMENT_BODY}
+
+Respond directly to that comment while considering the full issue context.
+"
+  fi
 
   PROMPT="You are responding to GitHub Issue #${PR_NUMBER}: \"${PR_TITLE}\" in ${REPO_FULL_NAME}.
 
 Analyze the issue and provide a thorough response. If it's a bug report, suggest a fix. If it's a feature request, discuss implementation approach.
 
 ${INPUT_EXTRA_PROMPT:+Additional instructions: ${INPUT_EXTRA_PROMPT}}
+${COMMENT_INSTRUCTIONS}
 
 Issue body:
 ${PR_BODY:-No description provided.}"
@@ -124,26 +205,111 @@ ${REVIEW_TEXT}"
 ..._truncated (response exceeded comment size limit)_"
     fi
 
-    curl -fsSL \
-      -X POST \
-      -H "Authorization: token ${GITHUB_TOKEN}" \
-      -H "Accept: application/vnd.github.v3+json" \
-      "https://api.github.com/repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/comments" \
-      -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')" \
-      > /dev/null
+    post_github_comment "${PR_NUMBER}" "${COMMENT_BODY}"
 
     echo "Response posted to Issue #${PR_NUMBER}"
   fi
 
-  echo "exit_code=0" >> "$GITHUB_OUTPUT"
-  {
-    echo "review<<CODETETHER_EOF"
-    echo "$REVIEW_TEXT"
-    echo "CODETETHER_EOF"
-  } >> "$GITHUB_OUTPUT"
+  write_review_output "$REVIEW_TEXT"
 
   echo "::endgroup::"
   exit 0
+fi
+
+if [ "${IS_PR_COMMENT}" = "true" ]; then
+  fetch_pr_metadata
+
+  if [ -n "${COMMENT_BODY}" ] && [ "${FIX_REQUEST}" != "true" ]; then
+    INPUT_EXTRA_PROMPT="$(printf '%s\n\nRespond to this PR comment while reviewing the current diff:\n%s' "${INPUT_EXTRA_PROMPT:-}" "${COMMENT_BODY}")"
+    if [ -n "${COMMENT_PATH}" ]; then
+      INPUT_EXTRA_PROMPT="$(printf '%s\n\nThe comment targets file: %s' "${INPUT_EXTRA_PROMPT}" "${COMMENT_PATH}")"
+    fi
+    if [ -n "${COMMENT_DIFF_HUNK}" ]; then
+      INPUT_EXTRA_PROMPT="$(printf '%s\n\nRelevant diff hunk:\n%s' "${INPUT_EXTRA_PROMPT}" "${COMMENT_DIFF_HUNK}")"
+    fi
+  fi
+
+  if [ "${FIX_REQUEST}" = "true" ]; then
+    echo "::group::Applying requested PR fix"
+
+    if [ "${INPUT_MODE}" != "local" ]; then
+      REVIEW_TEXT="Auto-fix requests on pull request comments require local mode with repository write access."
+      [ "${INPUT_AUTO_COMMENT}" = "true" ] && post_github_comment "${PR_NUMBER}" "## 🛠️ CodeTether Fix\n\n${REVIEW_TEXT}"
+      write_review_output "${REVIEW_TEXT}"
+      echo "::endgroup::"
+      exit 0
+    fi
+
+    if [ "${PR_HEAD_REPO}" != "${REPO_FULL_NAME}" ]; then
+      REVIEW_TEXT="Auto-fix is not available for forked pull requests because this workflow cannot safely push to \`${PR_HEAD_REPO}:${PR_HEAD}\`."
+      [ "${INPUT_AUTO_COMMENT}" = "true" ] && post_github_comment "${PR_NUMBER}" "## 🛠️ CodeTether Fix\n\n${REVIEW_TEXT}"
+      write_review_output "${REVIEW_TEXT}"
+      echo "::endgroup::"
+      exit 0
+    fi
+
+    git fetch origin "${PR_HEAD}" --depth=1 || true
+    git checkout -B "${PR_HEAD}" "origin/${PR_HEAD}" 2>/dev/null || git checkout -B "${PR_HEAD}"
+
+    DIFF_FILE="$(mktemp)"
+    git diff "origin/${PR_BASE}...HEAD" -- '*.rs' '*.py' '*.ts' '*.js' '*.go' '*.java' '*.tsx' '*.jsx' '*.yml' '*.yaml' '*.toml' > "$DIFF_FILE" 2>/dev/null || true
+    FIX_DIFF="$(head -n 3000 "$DIFF_FILE")"
+    FIX_FILE="$(mktemp)"
+
+    FIX_PROMPT="You are editing the checked-out PR branch for PR #${PR_NUMBER}: \"${PR_TITLE}\" (${PR_HEAD} → ${PR_BASE}).
+
+Apply the requested changes directly in the working tree. Do not just describe the fix.
+
+Triggering comment:
+${COMMENT_BODY}
+
+${COMMENT_PATH:+Commented file: ${COMMENT_PATH}}
+${COMMENT_DIFF_HUNK:+
+Relevant diff hunk:
+${COMMENT_DIFF_HUNK}}
+
+${INPUT_EXTRA_PROMPT:+Additional instructions: ${INPUT_EXTRA_PROMPT}}
+
+Current diff:
+\`\`\`diff
+${FIX_DIFF}
+\`\`\`
+
+After editing files, run the smallest relevant validation needed to support the change. Do not commit or push; the workflow will handle git."
+
+    if ! run_local_codetether "${FIX_PROMPT}" "${FIX_FILE}"; then
+      REVIEW_TEXT="I couldn't apply the requested changes automatically. Review the workflow logs for details."
+      [ "${INPUT_AUTO_COMMENT}" = "true" ] && post_github_comment "${PR_NUMBER}" "## 🛠️ CodeTether Fix\n\n${REVIEW_TEXT}"
+      write_review_output "${REVIEW_TEXT}" "1"
+      echo "::error::codetether failed to apply the requested PR changes"
+      echo "::endgroup::"
+      exit 1
+    fi
+
+    if [ -z "$(git status --short)" ]; then
+      REVIEW_TEXT="I reviewed the request but did not find any file changes to apply."
+      [ "${INPUT_AUTO_COMMENT}" = "true" ] && post_github_comment "${PR_NUMBER}" "## 🛠️ CodeTether Fix\n\n${REVIEW_TEXT}"
+      write_review_output "${REVIEW_TEXT}"
+      rm -f "${DIFF_FILE}" "${FIX_FILE}"
+      echo "::endgroup::"
+      exit 0
+    fi
+
+    git config user.name "codetether[bot]"
+    git config user.email "codetether[bot]@users.noreply.github.com"
+    git remote set-url origin "https://x-access-token:${GH_ACTIONS_TOKEN}@github.com/${REPO_FULL_NAME}.git"
+    git add -A
+    git commit -m "fix: address @codetether request on PR #${PR_NUMBER}"
+    git push origin "HEAD:${PR_HEAD}"
+
+    COMMIT_SHA="$(git rev-parse --short HEAD)"
+    REVIEW_TEXT="Applied the requested changes in commit \`${COMMIT_SHA}\` and pushed them to \`${PR_HEAD}\`."
+    [ "${INPUT_AUTO_COMMENT}" = "true" ] && post_github_comment "${PR_NUMBER}" "## 🛠️ CodeTether Fix\n\n${REVIEW_TEXT}"
+    write_review_output "${REVIEW_TEXT}"
+    rm -f "${DIFF_FILE}" "${FIX_FILE}"
+    echo "::endgroup::"
+    exit 0
+  fi
 fi
 
 # ── Gather PR diff ───────────────────────────────────────────────

--- a/docs/architecture/self_hosted_github_agent.md
+++ b/docs/architecture/self_hosted_github_agent.md
@@ -1,0 +1,237 @@
+# Self-Hosted GitHub Agent Architecture
+
+## Goal
+
+Run CodeTether as the actual agent runtime for GitHub issues and pull requests.
+GitHub should provide identity, webhooks, repository access, comments, branches,
+pull requests, and status surfaces, but should not host the agent session or bill
+the run as a Copilot premium request.
+
+## Problem With The Current Path
+
+The current `.github/agents/codetether.agent.md` path creates a GitHub Copilot
+custom agent. That keeps GitHub Copilot as the outer runtime, model host, and
+billing boundary. The visible symptoms are:
+
+- session actor is `Copilot`
+- model is selected by GitHub cloud agent
+- usage is counted as a GitHub premium request
+- `codetether` appears only as an inner custom agent profile
+
+That path is useful for integration testing, but it does not satisfy the
+requirement that CodeTether itself be the cloud agent.
+
+## Non-Negotiable Constraints
+
+- CodeTether must execute on our infrastructure
+- GitHub App identity must be the external actor for comments, branches, and PRs
+- GitHub premium requests must not be consumed for CodeTether runs
+- Runs must be resumable and observable outside GitHub
+- GitHub must remain the user-facing source for issue and PR collaboration
+
+## Platform Reality
+
+GitHub's native AI assignee UI for `Copilot`, `Claude`, and `Codex` is a GitHub
+platform capability. A normal GitHub App cannot replace that surface purely with
+repository files or workflows. We can mimic the behavior closely, but not occupy
+the same first-party Copilot slot unless GitHub offers CodeTether a partner-grade
+third-party coding-agent integration.
+
+## Proposed Solution
+
+Build a first-party CodeTether GitHub App workflow with five components:
+
+1. GitHub App
+   - installation auth
+   - webhook source
+   - comment/PR/branch/check-run writer
+2. Webhook ingress
+   - validates GitHub signatures
+   - normalizes issue, PR, review, and comment events into CodeTether tasks
+3. Orchestrator
+   - decides whether work is review, implementation, follow-up, or resume
+   - allocates workspace and model
+   - tracks session state
+4. Runner
+   - runs `codetether run` or Ralph on our infrastructure
+   - owns branch creation, commits, test execution, and patch application
+5. Session reporter
+   - posts issue comments
+   - updates PR description and draft state
+   - creates check runs and progress summaries
+
+## User Experience To Mimic Copilot
+
+From GitHub's point of view:
+
+- user mentions `@codetether` on an issue or PR
+- or labels an issue `codetether`
+- or clicks a GitHub App action entry point
+- CodeTether immediately posts a "session started" comment
+- CodeTether creates a branch and draft PR when implementation starts
+- CodeTether updates a check run named `codetether/agent`
+- CodeTether posts progress checkpoints and a final summary
+- user requests follow-up by commenting on the PR
+
+This preserves the GitHub-native feel without depending on GitHub's cloud agent.
+
+## Webhook Events
+
+The minimum event set is:
+
+- `issues`
+- `issue_comment`
+- `pull_request`
+- `pull_request_review_comment`
+- `pull_request_review`
+- `check_run`
+- `installation`
+- `installation_repositories`
+
+## GitHub App Permissions
+
+The minimum repository permissions are:
+
+- `Contents`: read/write
+- `Pull requests`: read/write
+- `Issues`: read/write
+- `Metadata`: read-only
+- `Checks`: read/write
+- `Commit statuses`: read/write
+
+Optional permissions:
+
+- `Actions`: read-only if we want workflow awareness
+- `Discussions`: read/write if we extend to discussions
+
+## Request Routing
+
+Map GitHub events into CodeTether tasks:
+
+- issue labeled or mentioned:
+  - create `issue.execute`
+- PR opened or synchronized:
+  - create `pr.review`
+- PR comment asking for changes:
+  - create `pr.fix`
+- issue comment on an active session:
+  - create `session.steer`
+- PR merge or issue close:
+  - create `session.archive`
+
+Each task stores:
+
+- installation id
+- repository id and full name
+- issue or PR number
+- head and base refs
+- requested mode (`review`, `fix`, `implement`, `resume`)
+- session id
+
+## Execution Model
+
+Every run should:
+
+1. create or resume a CodeTether session id
+2. clone a clean worktree for the target repository
+3. fetch refs and checkout the correct base/head
+4. run CodeTether with task-specific prompt scaffolding
+5. capture structured progress, tool usage, logs, and artifacts
+6. write code, run validation, and commit changes
+7. push a branch if implementation work was requested
+8. create or update a PR
+9. publish final status back to GitHub
+
+## GitHub Surfaces
+
+Use four GitHub surfaces to approximate Copilot:
+
+- issue comments for conversational updates
+- draft PRs for implementation output
+- check runs for machine-readable progress
+- branch naming convention like `codetether/issue-16-byte-index-crash`
+
+Check run phases:
+
+- `queued`
+- `in_progress`
+- `needs_input`
+- `failed`
+- `completed`
+
+## Session And State Model
+
+The orchestrator should persist:
+
+- GitHub installation and repo metadata
+- CodeTether session id
+- active branch name
+- linked PR number
+- last webhook event id
+- state transition timestamps
+- retry count and failure reason
+
+Recommended states:
+
+- `queued`
+- `planning`
+- `implementing`
+- `validating`
+- `waiting_for_user`
+- `completed`
+- `failed`
+- `canceled`
+
+## Security Model
+
+- validate GitHub webhook HMAC signature
+- exchange installation id for short-lived installation token
+- never persist installation tokens beyond the session
+- scope repository access to the single target installation
+- isolate each run in a fresh worktree or container
+- require explicit policy checks before destructive git actions
+
+## Components In This Ecosystem
+
+Recommended ownership split:
+
+- `a2a_server`
+  - webhook ingestion
+  - task orchestration
+  - session registry
+  - GitHub status publishing
+- `codetether-agent`
+  - task execution
+  - code editing
+  - tests and validation
+  - branch and commit operations
+
+## Immediate Build Plan
+
+Phase 1:
+
+- add GitHub App webhook handler in `a2a_server`
+- translate mention/label/review events into dispatch tasks
+- add check-run publishing
+
+Phase 2:
+
+- add `github app` auth mode to CodeTether runner
+- add `issue.execute` and `pr.fix` runner prompts
+- add branch and PR creation helpers
+
+Phase 3:
+
+- add session dashboard in CodeTether UI
+- add resume, steer, and cancel operations
+- add issue-to-PR closure automation
+
+## Success Criteria
+
+The solution is complete when:
+
+- assigning or invoking CodeTether does not consume GitHub premium requests
+- the active model and logs are controlled by our infrastructure
+- CodeTether can open and update PRs directly as the GitHub App
+- progress is visible from GitHub without using Copilot cloud sessions
+- issue follow-up comments resume the same CodeTether session

--- a/examples/github-actions-review.yml
+++ b/examples/github-actions-review.yml
@@ -3,18 +3,12 @@
 # Add this file to .github/workflows/ in any repo to get
 # AI-powered code review on every pull request.
 #
-# Required secrets (pick ONE auth method):
-#
-#   Option A — GitHub Copilot (easiest):
-#     GITHUB_COPILOT_TOKEN — from `codetether auth copilot`
-#
-#   Option B — Vault (for any provider):
-#     VAULT_ADDR  — HashiCorp Vault URL
-#     VAULT_TOKEN — Vault auth token
-#
-# Optional secrets:
-#   CODETETHER_SERVER — A2A server URL (for server mode / K8s workers)
-#   CODETETHER_TOKEN  — A2A server bearer token
+# Setup (2 minutes):
+#   1. Sign up at https://codetether.run
+#   2. Go to Settings → API Tokens → Create Token
+#   3. Add CODETETHER_TOKEN as a repo secret in GitHub
+#   4. Copy this file to .github/workflows/codetether-review.yml
+#   5. Done — every PR gets an AI review.
 
 name: CodeTether Review
 
@@ -22,14 +16,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# Cancel in-flight reviews when a new commit is pushed
 concurrency:
   group: codetether-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: write  # needed to post review comments
+  pull-requests: write
 
 jobs:
   review:
@@ -38,31 +31,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # full history for accurate diff
+          fetch-depth: 0
 
       - name: CodeTether Review
         uses: rileyseaburg/codetether-agent@main
         with:
-          copilot_token: ${{ secrets.GITHUB_COPILOT_TOKEN }}
-          model: "copilot/gpt-4o"  # or glm-5.1, claude-sonnet-4-20250514, etc.
-          max_steps: "30"
-          auto_comment: "true"
+          token: ${{ secrets.CODETETHER_TOKEN }}
           # extra_prompt: "Focus on security issues"
-          # --- OR use Vault for any provider ---
-          # vault_addr: ${{ secrets.VAULT_ADDR }}
-          # vault_token: ${{ secrets.VAULT_TOKEN }}
 
-  # ── Alternative: dispatch to your K8s-hosted A2A worker ──
-  # review-server:
+  # ── Advanced: self-hosted with your own LLM keys ──
+  # review-byok:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v4
   #       with:
   #         fetch-depth: 0
-  #
-  #     - name: CodeTether Review (Server)
+  #     - name: CodeTether Review (BYOK)
   #       uses: rileyseaburg/codetether-agent@main
   #       with:
-  #         mode: "server"
-  #         server_url: ${{ secrets.CODETETHER_SERVER }}
-  #         server_token: ${{ secrets.CODETETHER_TOKEN }}
+  #         token: ${{ secrets.CODETETHER_TOKEN }}
+  #         mode: "local"
+  #         api_key: ${{ secrets.OPENAI_API_KEY }}
+  #         model: "gpt-4o"

--- a/examples/github-actions-review.yml
+++ b/examples/github-actions-review.yml
@@ -1,0 +1,61 @@
+# CodeTether Code Review — Example Workflow
+#
+# Add this file to .github/workflows/ in any repo to get
+# AI-powered code review on every pull request.
+#
+# Required secrets:
+#   VAULT_ADDR  — HashiCorp Vault URL (where your LLM API keys live)
+#   VAULT_TOKEN — Vault auth token
+#
+# Optional secrets:
+#   CODETETHER_SERVER — A2A server URL (for server mode / K8s workers)
+#   CODETETHER_TOKEN  — A2A server bearer token
+
+name: CodeTether Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Cancel in-flight reviews when a new commit is pushed
+concurrency:
+  group: codetether-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write  # needed to post review comments
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for accurate diff
+
+      - name: CodeTether Review
+        uses: rileyseaburg/codetether-agent@main
+        with:
+          vault_addr: ${{ secrets.VAULT_ADDR }}
+          vault_token: ${{ secrets.VAULT_TOKEN }}
+          model: "glm-5.1"        # or gpt-4o, claude-sonnet-4-20250514, etc.
+          max_steps: "30"
+          auto_comment: "true"
+          # extra_prompt: "Focus on security issues"
+
+  # ── Alternative: dispatch to your K8s-hosted A2A worker ──
+  # review-server:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #
+  #     - name: CodeTether Review (Server)
+  #       uses: rileyseaburg/codetether-agent@main
+  #       with:
+  #         mode: "server"
+  #         server_url: ${{ secrets.CODETETHER_SERVER }}
+  #         server_token: ${{ secrets.CODETETHER_TOKEN }}

--- a/examples/github-actions-review.yml
+++ b/examples/github-actions-review.yml
@@ -3,9 +3,14 @@
 # Add this file to .github/workflows/ in any repo to get
 # AI-powered code review on every pull request.
 #
-# Required secrets:
-#   VAULT_ADDR  — HashiCorp Vault URL (where your LLM API keys live)
-#   VAULT_TOKEN — Vault auth token
+# Required secrets (pick ONE auth method):
+#
+#   Option A — GitHub Copilot (easiest):
+#     GITHUB_COPILOT_TOKEN — from `codetether auth copilot`
+#
+#   Option B — Vault (for any provider):
+#     VAULT_ADDR  — HashiCorp Vault URL
+#     VAULT_TOKEN — Vault auth token
 #
 # Optional secrets:
 #   CODETETHER_SERVER — A2A server URL (for server mode / K8s workers)
@@ -38,12 +43,14 @@ jobs:
       - name: CodeTether Review
         uses: rileyseaburg/codetether-agent@main
         with:
-          vault_addr: ${{ secrets.VAULT_ADDR }}
-          vault_token: ${{ secrets.VAULT_TOKEN }}
-          model: "glm-5.1"        # or gpt-4o, claude-sonnet-4-20250514, etc.
+          copilot_token: ${{ secrets.GITHUB_COPILOT_TOKEN }}
+          model: "copilot/gpt-4o"  # or glm-5.1, claude-sonnet-4-20250514, etc.
           max_steps: "30"
           auto_comment: "true"
           # extra_prompt: "Focus on security issues"
+          # --- OR use Vault for any provider ---
+          # vault_addr: ${{ secrets.VAULT_ADDR }}
+          # vault_token: ${{ secrets.VAULT_TOKEN }}
 
   # ── Alternative: dispatch to your K8s-hosted A2A worker ──
   # review-server:

--- a/src/a2a/worker.rs
+++ b/src/a2a/worker.rs
@@ -1887,6 +1887,7 @@ async fn handle_clone_repo_task(
         install_commit_msg_hook(&repo_path)?;
 
         register_cloned_workspace(client, server, token, worker_id, &workspace, &repo_path).await?;
+        enqueue_post_clone_task(client, server, token, &workspace_id, metadata).await?;
 
         Ok::<String, anyhow::Error>(format!(
             "Repository ready at {} (branch: {})",
@@ -1974,6 +1975,65 @@ async fn register_cloned_workspace(
         );
     }
 
+    Ok(())
+}
+
+async fn enqueue_post_clone_task(
+    client: &Client,
+    server: &str,
+    token: &Option<String>,
+    workspace_id: &str,
+    metadata: &serde_json::Map<String, serde_json::Value>,
+) -> Result<()> {
+    let Some(post_clone_task) = metadata.get("post_clone_task") else {
+        return Ok(());
+    };
+    let Some(task) = post_clone_task.as_object() else {
+        return Ok(());
+    };
+    let title = task
+        .get("title")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("post_clone_task is missing title"))?;
+    let prompt = task
+        .get("prompt")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("post_clone_task is missing prompt"))?;
+    let agent_type = task
+        .get("agent_type")
+        .and_then(|value| value.as_str())
+        .unwrap_or("build");
+    let task_metadata = task
+        .get("metadata")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    let mut req = client.post(format!(
+        "{}/v1/agent/workspaces/{}/tasks",
+        server.trim_end_matches('/'),
+        workspace_id
+    ));
+    if let Some(token) = token {
+        req = req.bearer_auth(token);
+    }
+
+    let response = req
+        .json(&serde_json::json!({
+            "title": title,
+            "prompt": prompt,
+            "agent_type": agent_type,
+            "metadata": task_metadata,
+        }))
+        .send()
+        .await
+        .context("Failed to enqueue post-clone task")?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to enqueue post-clone task ({}): {}", status, body);
+    }
     Ok(())
 }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1042,6 +1042,9 @@ impl ProviderRegistry {
                     zai::DEFAULT_BASE_URL.to_string(),
                 )?))
             }),
+            ("github-copilot", "GITHUB_COPILOT_TOKEN", |token| {
+                Ok(Arc::new(copilot::CopilotProvider::new(token)?))
+            }),
         ];
 
         for (provider_id, env_var, constructor) in fallbacks {


### PR DESCRIPTION
## Summary\n- let workers automatically enqueue a follow-up task after  completes\n- preserve the original mention request so a first  on a new repo can clone then execute\n\n## Validation\n- 