### PR TITLE
fix: restore Z.AI wire-compatible tool arguments

### DIFF
--- a/src/provider/zai.rs
+++ b/src/provider/zai.rs
@@ -163,22 +163,21 @@ impl ZaiProvider {
         models
     }
 
-    fn normalize_tool_arguments(arguments: &str) -> Value {
-        // Z.AI expects assistant.tool_calls[*].function.arguments to be a JSON
-        // object, not an OpenAI-style JSON string. Keep the replay payload
-        // strictly object-shaped even if the model emitted malformed JSON.
+    fn normalize_tool_arguments(arguments: &str) -> String {
+        // The live Z.AI endpoint rejects object-typed historical arguments in
+        // assistant.tool_calls and accepts OpenAI-style JSON strings instead.
         if let Ok(parsed) = serde_json::from_str::<Value>(arguments) {
             if parsed.is_object() {
-                return parsed;
+                return serde_json::to_string(&parsed).unwrap_or_else(|_| "{}".to_string());
             }
-            return json!({"input": parsed});
+            return json!({"input": parsed}).to_string();
         }
 
         if let Some(salvaged) = Self::salvage_json_object(arguments) {
-            return salvaged;
+            return serde_json::to_string(&salvaged).unwrap_or_else(|_| "{}".to_string());
         }
 
-        json!({"input": arguments})
+        json!({"input": arguments}).to_string()
     }
 
     fn salvage_json_object(arguments: &str) -> Option<Value> {
@@ -260,13 +259,13 @@ impl ZaiProvider {
                                     arguments,
                                     ..
                                 } => {
-                                    let args_object = Self::normalize_tool_arguments(arguments);
+                                    let args_string = Self::normalize_tool_arguments(arguments);
                                     Some(json!({
                                         "id": id,
                                         "type": "function",
                                         "function": {
                                             "name": name,
-                                            "arguments": args_object
+                                            "arguments": args_string
                                         }
                                     }))
                                 }
@@ -1072,7 +1071,7 @@ mod tests {
     }
 
     #[test]
-    fn convert_messages_serializes_tool_arguments_as_json_object() {
+    fn convert_messages_serializes_tool_arguments_as_json_string() {
         let messages = vec![Message {
             role: Role::Assistant,
             content: vec![ContentPart::ToolCall {
@@ -1084,15 +1083,17 @@ mod tests {
         }];
 
         let converted = ZaiProvider::convert_messages(&messages, true);
-        let args = &converted[0]["tool_calls"][0]["function"]["arguments"];
+        let args = converted[0]["tool_calls"][0]["function"]["arguments"]
+            .as_str()
+            .expect("arguments must be a string");
+        let parsed: Value =
+            serde_json::from_str(args).expect("arguments string must contain valid JSON");
 
-        // Z.AI expects arguments as a JSON object, not a string
-        assert!(args.is_object(), "arguments must be an object, got: {args}");
-        assert_eq!(args["city"], json!("Beijing"));
+        assert_eq!(parsed, json!({"city":"Beijing"}));
     }
 
     #[test]
-    fn convert_messages_wraps_invalid_tool_arguments_as_json_object() {
+    fn convert_messages_wraps_invalid_tool_arguments_as_json_string() {
         let messages = vec![Message {
             role: Role::Assistant,
             content: vec![ContentPart::ToolCall {
@@ -1104,15 +1105,17 @@ mod tests {
         }];
 
         let converted = ZaiProvider::convert_messages(&messages, true);
-        let args = &converted[0]["tool_calls"][0]["function"]["arguments"];
+        let args = converted[0]["tool_calls"][0]["function"]["arguments"]
+            .as_str()
+            .expect("arguments must be a string");
+        let parsed: Value =
+            serde_json::from_str(args).expect("arguments string must contain valid JSON");
 
-        // Z.AI expects arguments as a JSON object, not a string
-        assert!(args.is_object(), "arguments must be an object, got: {args}");
-        assert_eq!(args["input"], json!("city=Beijing"));
+        assert_eq!(parsed, json!({"input":"city=Beijing"}));
     }
 
     #[test]
-    fn convert_messages_wraps_scalar_tool_arguments_as_json_object() {
+    fn convert_messages_wraps_scalar_tool_arguments_as_json_string() {
         let messages = vec![Message {
             role: Role::Assistant,
             content: vec![ContentPart::ToolCall {
@@ -1124,10 +1127,13 @@ mod tests {
         }];
 
         let converted = ZaiProvider::convert_messages(&messages, true);
-        let args = &converted[0]["tool_calls"][0]["function"]["arguments"];
+        let args = converted[0]["tool_calls"][0]["function"]["arguments"]
+            .as_str()
+            .expect("arguments must be a string");
+        let parsed: Value =
+            serde_json::from_str(args).expect("arguments string must contain valid JSON");
 
-        assert!(args.is_object(), "arguments must be an object, got: {args}");
-        assert_eq!(args["input"], json!("Beijing"));
+        assert_eq!(parsed, json!({"input":"Beijing"}));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- restore Z.AI historical tool-call serialization to use JSON-string `function.arguments`
- keep malformed and scalar historical arguments normalized into valid JSON before stringifying
- update the Z.AI tests to assert the live-compatible wire format

## Validation
- cargo fmt --all
- cargo test zai:: --lib
- live Node.js check against Z.AI `chat/completions`

## Node.js Findings
- object `tool_calls[*].function.arguments`: HTTP 400
- string `tool_calls[*].function.arguments`: HTTP 200
- empty assistant content with string arguments: HTTP 200

This hotfix follows the live endpoint behavior rather than the stricter schema interpretation that caused the repeated 400s.