### PR TITLE
fix: restore session context retention wiring

### DIFF
--- a/src/rlm/mod.rs
+++ b/src/rlm/mod.rs
@@ -174,7 +174,7 @@ fn default_runtime() -> String {
 /// Default number of stored messages that triggers RLM compaction
 /// independently of the token-budget check.
 fn default_history_trigger_messages() -> usize {
-    60
+    0
 }
 
 impl Default for RlmConfig {
@@ -189,5 +189,15 @@ impl Default for RlmConfig {
             subcall_model: None,
             history_trigger_messages: default_history_trigger_messages(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RlmConfig;
+
+    #[test]
+    fn default_history_trigger_is_disabled() {
+        assert_eq!(RlmConfig::default().history_trigger_messages, 0);
     }
 }

--- a/src/session/codex_import/parse.rs
+++ b/src/session/codex_import/parse.rs
@@ -87,6 +87,7 @@ pub(crate) fn parse_codex_session_from_path(
         created_at: meta.timestamp,
         updated_at: updated_at.unwrap_or(meta.timestamp),
         messages,
+        pages: Vec::new(),
         tool_uses: Vec::new(),
         usage,
         agent: "build".to_string(),

--- a/src/session/context/derive.rs
+++ b/src/session/context/derive.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use tokio::sync::mpsc;
 
 use crate::provider::ToolDefinition;
+use crate::session::ResidencyLevel;
 use crate::session::Session;
 use crate::session::SessionEvent;
 use crate::session::helper::compression::{CompressContext, compress_last_message_if_oversized};
@@ -71,7 +72,20 @@ pub async fn derive_context(
     experimental::pairing::repair_orphans(&mut messages);
 
     let compressed = step0 || step1 || messages_len_changed(before, &messages);
+    let mut provenance = vec!["legacy".to_string()];
+    if step0 {
+        provenance.push("oversized_last_message".to_string());
+    }
+    if step1 {
+        provenance.push("context_window".to_string());
+    }
+    if compressed && provenance.len() == 1 {
+        provenance.push("experimental".to_string());
+    }
     Ok(DerivedContext {
+        resolutions: vec![ResidencyLevel::Full; messages.len()],
+        dropped_ranges: Vec::new(),
+        provenance,
         messages,
         origin_len,
         compressed,

--- a/src/session/context/helpers.rs
+++ b/src/session/context/helpers.rs
@@ -1,6 +1,7 @@
 //! Shared types and tiny helpers used across the context derivation modules.
 
 use crate::provider::Message;
+use crate::session::ResidencyLevel;
 
 /// The per-step LLM context, derived from an append-only chat history.
 ///
@@ -12,6 +13,9 @@ use crate::provider::Message;
 /// * `messages` — The message list to include in the completion request.
 /// * `origin_len` — Length of the source history at the moment of derivation.
 /// * `compressed` — Whether compression fired during this derivation.
+/// * `dropped_ranges` — Best-effort ranges elided from the working context.
+/// * `provenance` — Pipeline steps that produced this context.
+/// * `resolutions` — Per-message residency levels in the derived context.
 ///
 /// # Examples
 ///
@@ -22,6 +26,9 @@ use crate::provider::Message;
 ///     messages: Vec::new(),
 ///     origin_len: 0,
 ///     compressed: false,
+///     dropped_ranges: Vec::new(),
+///     provenance: Vec::new(),
+///     resolutions: Vec::new(),
 /// };
 /// assert_eq!(derived.origin_len, 0);
 /// assert!(!derived.compressed);
@@ -34,6 +41,12 @@ pub struct DerivedContext {
     pub origin_len: usize,
     /// `true` when any compression / truncation pass rewrote the clone.
     pub compressed: bool,
+    /// Best-effort elided ranges from the source history.
+    pub dropped_ranges: Vec<(usize, usize)>,
+    /// Names of the pipeline stages that shaped this context.
+    pub provenance: Vec<String>,
+    /// Per-message residency level in the derived context.
+    pub resolutions: Vec<ResidencyLevel>,
 }
 
 /// Compare two message counts and return whether compression fired.
@@ -61,11 +74,15 @@ mod tests {
             }],
             origin_len: 1,
             compressed: false,
+            dropped_ranges: Vec::new(),
+            provenance: Vec::new(),
+            resolutions: vec![ResidencyLevel::Full],
         };
         let cloned = ctx.clone();
         assert_eq!(ctx.origin_len, cloned.origin_len);
         assert_eq!(ctx.compressed, cloned.compressed);
         assert_eq!(ctx.messages.len(), cloned.messages.len());
+        assert_eq!(ctx.resolutions, cloned.resolutions);
     }
 
     #[test]

--- a/src/session/context/mod.rs
+++ b/src/session/context/mod.rs
@@ -13,4 +13,4 @@ mod reset_summary;
 
 pub use self::derive::derive_context;
 pub use self::helpers::DerivedContext;
-pub use self::policy::derive_with_policy;
+pub use self::policy::{derive_with_policy, effective_policy};

--- a/src/session/context/policy.rs
+++ b/src/session/context/policy.rs
@@ -1,5 +1,6 @@
 //! Policy dispatcher — routes to the chosen [`DerivePolicy`] implementation.
 
+use std::env;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -13,6 +14,59 @@ use crate::session::derive_policy::DerivePolicy;
 use super::derive::derive_context;
 use super::helpers::DerivedContext;
 use super::reset::derive_reset;
+use super::reset_helpers::latest_reset_marker_index;
+
+const DEFAULT_RESET_THRESHOLD_TOKENS: usize = 32_000;
+
+/// Resolve the effective derivation policy for `session`.
+///
+/// The persisted session policy is the baseline. Operators can override it
+/// process-wide via:
+///
+/// - `CODETETHER_CONTEXT_POLICY=legacy`
+/// - `CODETETHER_CONTEXT_POLICY=reset`
+/// - `CODETETHER_CONTEXT_RESET_THRESHOLD_TOKENS=<usize>`
+///
+/// When there is no explicit override and the persisted policy is still
+/// legacy, a recorded `[CONTEXT RESET]` marker auto-promotes the effective
+/// policy to [`DerivePolicy::Reset`] so `context_reset` markers become live
+/// immediately on the next turn.
+pub fn effective_policy(session: &Session) -> DerivePolicy {
+    let persisted = session.metadata.context_policy;
+    let Ok(raw) = env::var("CODETETHER_CONTEXT_POLICY") else {
+        if matches!(persisted, DerivePolicy::Legacy)
+            && latest_reset_marker_index(&session.messages).is_some()
+        {
+            return DerivePolicy::Reset {
+                threshold_tokens: resolve_reset_threshold(persisted),
+            };
+        }
+        return persisted;
+    };
+    let normalized = raw.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "" => persisted,
+        "legacy" => DerivePolicy::Legacy,
+        "reset" => DerivePolicy::Reset {
+            threshold_tokens: resolve_reset_threshold(persisted),
+        },
+        _ => {
+            tracing::warn!(raw = %raw, "Unknown CODETETHER_CONTEXT_POLICY override; using persisted session policy");
+            persisted
+        }
+    }
+}
+
+fn resolve_reset_threshold(persisted: DerivePolicy) -> usize {
+    let default_threshold = match persisted {
+        DerivePolicy::Reset { threshold_tokens } => threshold_tokens,
+        DerivePolicy::Legacy => DEFAULT_RESET_THRESHOLD_TOKENS,
+    };
+    env::var("CODETETHER_CONTEXT_RESET_THRESHOLD_TOKENS")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(default_threshold)
+}
 
 /// Derive an ephemeral [`DerivedContext`] under a chosen [`DerivePolicy`].
 ///
@@ -25,6 +79,9 @@ use super::reset::derive_reset;
 /// Same as [`derive_context`], plus:
 ///
 /// * `policy` — Which derivation strategy to run. See [`DerivePolicy`].
+/// * `force_keep_last` — When `Some(n)`, bypass policy selection and fall
+///   back to the legacy keep-last derivation used for prompt-too-long
+///   recovery.
 ///
 /// # Errors
 ///
@@ -37,7 +94,20 @@ pub async fn derive_with_policy(
     tools: &[ToolDefinition],
     event_tx: Option<&mpsc::Sender<SessionEvent>>,
     policy: DerivePolicy,
+    force_keep_last: Option<usize>,
 ) -> Result<DerivedContext> {
+    if force_keep_last.is_some() {
+        return derive_context(
+            session,
+            provider,
+            model,
+            system_prompt,
+            tools,
+            event_tx,
+            force_keep_last,
+        )
+        .await;
+    }
     match policy {
         DerivePolicy::Legacy => {
             derive_context(
@@ -47,7 +117,7 @@ pub async fn derive_with_policy(
                 system_prompt,
                 tools,
                 event_tx,
-                None,
+                force_keep_last,
             )
             .await
         }

--- a/src/session/context/reset.rs
+++ b/src/session/context/reset.rs
@@ -5,13 +5,14 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use crate::provider::ToolDefinition;
+use crate::session::ResidencyLevel;
 use crate::session::Session;
 use crate::session::helper::experimental;
 use crate::session::helper::token::estimate_request_tokens;
 
 use super::derive::derive_context;
 use super::helpers::DerivedContext;
-use super::reset_helpers::last_user_index;
+use super::reset_helpers::{last_user_index, latest_reset_marker_index};
 use super::reset_rebuild::rebuild_with_summary;
 
 /// [`DerivePolicy::Reset`](crate::session::derive_policy::DerivePolicy::Reset) implementation.
@@ -30,18 +31,55 @@ pub(super) async fn derive_reset(
 ) -> Result<DerivedContext> {
     let origin_len = session.messages.len();
     let mut messages = session.messages.clone();
+    let mut dropped_ranges = Vec::new();
+    let mut provenance = Vec::new();
+    let mut base_index = 0usize;
 
     let est = estimate_request_tokens(system_prompt, &messages, tools);
     if est <= threshold_tokens {
         experimental::pairing::repair_orphans(&mut messages);
         return Ok(DerivedContext {
+            resolutions: vec![ResidencyLevel::Full; messages.len()],
+            dropped_ranges: Vec::new(),
+            provenance: vec!["reset_below_threshold".to_string()],
             messages,
             origin_len,
             compressed: false,
         });
     }
 
+    if let Some(reset_idx) = latest_reset_marker_index(&messages).filter(|idx| *idx > 0) {
+        messages = messages.split_off(reset_idx);
+        base_index = reset_idx;
+        dropped_ranges.push((0, reset_idx));
+        provenance.push("reset_marker".to_string());
+
+        let anchored_est = estimate_request_tokens(system_prompt, &messages, tools);
+        if anchored_est <= threshold_tokens {
+            experimental::pairing::repair_orphans(&mut messages);
+            return Ok(DerivedContext {
+                resolutions: vec![ResidencyLevel::Full; messages.len()],
+                dropped_ranges,
+                provenance,
+                messages,
+                origin_len,
+                compressed: true,
+            });
+        }
+    }
+
     let Some(split_idx) = last_user_index(&messages) else {
+        if !provenance.is_empty() {
+            experimental::pairing::repair_orphans(&mut messages);
+            return Ok(DerivedContext {
+                resolutions: vec![ResidencyLevel::Full; messages.len()],
+                dropped_ranges,
+                provenance,
+                messages,
+                origin_len,
+                compressed: true,
+            });
+        }
         return derive_context(session, provider, model, system_prompt, tools, None, None).await;
     };
 
@@ -51,11 +89,27 @@ pub(super) async fn derive_reset(
         messages = tail;
         experimental::pairing::repair_orphans(&mut messages);
         return Ok(DerivedContext {
+            resolutions: vec![ResidencyLevel::Full; messages.len()],
+            dropped_ranges,
+            provenance: if provenance.is_empty() {
+                vec!["reset_without_prefix".to_string()]
+            } else {
+                provenance
+            },
             messages,
             origin_len,
-            compressed: false,
+            compressed: base_index > 0,
         });
     }
 
-    rebuild_with_summary(session, &prefix, &tail, provider, model, origin_len).await
+    let prefix_len = prefix.len();
+    let mut derived =
+        rebuild_with_summary(session, &prefix, &tail, provider, model, origin_len).await?;
+    dropped_ranges.push((base_index, base_index + prefix_len));
+    if !provenance.is_empty() {
+        provenance.extend(derived.provenance);
+        derived.provenance = provenance;
+    }
+    derived.dropped_ranges = dropped_ranges;
+    Ok(derived)
 }

--- a/src/session/context/reset_helpers/mod.rs
+++ b/src/session/context/reset_helpers/mod.rs
@@ -2,6 +2,8 @@
 
 use crate::provider::{ContentPart, Message, Role};
 
+const RESET_MARKER_PREFIX: &str = "[CONTEXT RESET]";
+
 /// Index of the last [`Role::User`] message in `messages`, if any.
 ///
 /// Used by [`derive_reset`](super::reset::derive_reset) to preserve
@@ -25,13 +27,31 @@ pub(super) fn build_reset_summary_message(summary: &str) -> Message {
         role: Role::Assistant,
         content: vec![ContentPart::Text {
             text: format!(
-                "[CONTEXT RESET]\nEverything older than the current user turn was \
+                "{RESET_MARKER_PREFIX}\nEverything older than the current user turn was \
                  compressed into the summary below. Recent turns were \
                  intentionally discarded — call `session_recall` if you need \
                  a specific dropped detail.\n\n{summary}"
             ),
         }],
     }
+}
+
+/// Index of the most-recent reset marker in `messages`, if any.
+pub(super) fn latest_reset_marker_index(messages: &[Message]) -> Option<usize> {
+    messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, msg)| message_has_reset_marker(msg))
+        .map(|(idx, _)| idx)
+}
+
+fn message_has_reset_marker(msg: &Message) -> bool {
+    msg.content.iter().any(|part| match part {
+        ContentPart::Text { text } => text.starts_with(RESET_MARKER_PREFIX),
+        ContentPart::ToolResult { content, .. } => content.starts_with(RESET_MARKER_PREFIX),
+        _ => false,
+    })
 }
 
 #[cfg(test)]

--- a/src/session/context/reset_helpers/tests.rs
+++ b/src/session/context/reset_helpers/tests.rs
@@ -2,7 +2,7 @@
 
 use crate::provider::{ContentPart, Message, Role};
 
-use super::{build_reset_summary_message, last_user_index};
+use super::{build_reset_summary_message, last_user_index, latest_reset_marker_index};
 
 fn text(role: Role, s: &str) -> Message {
     Message {
@@ -42,4 +42,26 @@ fn reset_summary_message_carries_expected_markers() {
     } else {
         panic!("expected text content");
     }
+}
+
+#[test]
+fn latest_reset_marker_index_finds_text_markers() {
+    let msgs = vec![
+        text(Role::User, "before"),
+        build_reset_summary_message("summary"),
+        text(Role::Assistant, "after"),
+    ];
+    assert_eq!(latest_reset_marker_index(&msgs), Some(1));
+}
+
+#[test]
+fn latest_reset_marker_index_finds_tool_result_markers() {
+    let msgs = vec![Message {
+        role: Role::Tool,
+        content: vec![ContentPart::ToolResult {
+            tool_call_id: "call-1".to_string(),
+            content: "[CONTEXT RESET]\nsummary".to_string(),
+        }],
+    }];
+    assert_eq!(latest_reset_marker_index(&msgs), Some(0));
 }

--- a/src/session/context/reset_rebuild.rs
+++ b/src/session/context/reset_rebuild.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use crate::provider::Message;
+use crate::session::ResidencyLevel;
 use crate::session::Session;
 use crate::session::helper::experimental;
 
@@ -41,6 +42,9 @@ pub(super) async fn rebuild_with_summary(
     experimental::pairing::repair_orphans(&mut reset_messages);
 
     Ok(DerivedContext {
+        resolutions: vec![ResidencyLevel::Full; reset_messages.len()],
+        dropped_ranges: Vec::new(),
+        provenance: vec!["reset".to_string(), "rlm_summary".to_string()],
         messages: reset_messages,
         origin_len,
         compressed: true,

--- a/src/session/delegation.rs
+++ b/src/session/delegation.rs
@@ -50,6 +50,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::env;
 
 use super::relevance::Bucket;
 
@@ -224,6 +225,14 @@ impl DelegationState {
             beliefs: BTreeMap::new(),
             config,
         }
+    }
+
+    /// Whether CADMAS-CTX routing is enabled for this session.
+    ///
+    /// `CODETETHER_DELEGATION_ENABLED` overrides the persisted config when
+    /// present so operators can toggle the feature process-wide.
+    pub fn enabled(&self) -> bool {
+        env_enabled_override().unwrap_or(self.config.enabled)
     }
 
     /// Serialise a `(agent, skill, bucket)` triple into the flat string
@@ -410,6 +419,15 @@ impl DelegationState {
             .or_insert_with(|| BetaPosterior::from_self_confidence(0.5, kappa));
         post.alpha += avg_alpha * m_z;
         post.beta += avg_beta * m_z;
+    }
+}
+
+fn env_enabled_override() -> Option<bool> {
+    let raw = env::var("CODETETHER_DELEGATION_ENABLED").ok()?;
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
     }
 }
 

--- a/src/session/helper/compression.rs
+++ b/src/session/helper/compression.rs
@@ -134,7 +134,7 @@ const RLM_MODEL_CANDIDATES: &[&str] = &[
 
 /// CADMAS-CTX-aware variant of [`resolve_rlm_model`] (Phase C step 30).
 ///
-/// When `state.config.enabled` is `true`, ranks [`RLM_MODEL_CANDIDATES`]
+/// When delegation is enabled on `state`, ranks [`RLM_MODEL_CANDIDATES`]
 /// by the LCB score `μ − γ·√u` under the supplied `bucket` (skill
 /// key: `"rlm_compact"`) and returns the highest-scoring candidate.
 /// When delegation is disabled, this is exactly [`resolve_rlm_model`].
@@ -162,7 +162,7 @@ pub(crate) fn resolve_rlm_model_bandit(
     state: &crate::session::delegation::DelegationState,
     bucket: crate::session::relevance::Bucket,
 ) -> Option<String> {
-    if !state.config.enabled {
+    if !state.enabled() {
         return resolve_rlm_model(rlm_config);
     }
     // Explicit configuration still wins — the bandit only disambiguates
@@ -921,6 +921,7 @@ mod tests {
             metadata: Default::default(),
             agent: "test".to_string(),
             messages: Vec::new(),
+            pages: Vec::new(),
             tool_uses: Vec::new(),
             usage: Default::default(),
             max_steps: None,

--- a/src/session/helper/experimental/apply_all_tests.rs
+++ b/src/session/helper/experimental/apply_all_tests.rs
@@ -1,0 +1,42 @@
+use super::apply_all;
+use crate::provider::{ContentPart, Message, Role};
+
+fn user(text: &str) -> Message {
+    Message {
+        role: Role::User,
+        content: vec![ContentPart::Text { text: text.into() }],
+    }
+}
+
+fn assistant(text: &str) -> Message {
+    Message {
+        role: Role::Assistant,
+        content: vec![ContentPart::Text { text: text.into() }],
+    }
+}
+
+#[test]
+fn apply_all_keeps_moderate_plaintext_history_intact() {
+    let mut messages = vec![
+        user("scan lm studio"),
+        assistant("confirmed endpoint 192.168.50.251:8080"),
+    ];
+    for i in 0..24 {
+        messages.push(user(&format!("follow-up {i}")));
+        messages.push(assistant(&format!("answer {i}")));
+    }
+
+    let before_len = messages.len();
+    let stats = apply_all(&mut messages);
+
+    assert_eq!(messages.len(), before_len);
+    assert_eq!(stats.dedup_hits, 0);
+    assert!(messages.iter().any(|message| {
+        message.content.iter().any(|part| {
+            matches!(
+                part,
+                ContentPart::Text { text } if text.contains("192.168.50.251:8080")
+            )
+        })
+    }));
+}

--- a/src/session/helper/experimental/apply_all_tool_history_tests.rs
+++ b/src/session/helper/experimental/apply_all_tool_history_tests.rs
@@ -1,0 +1,47 @@
+use super::apply_all;
+use crate::provider::{ContentPart, Message, Role};
+
+fn user(text: &str) -> Message {
+    Message {
+        role: Role::User,
+        content: vec![ContentPart::Text { text: text.into() }],
+    }
+}
+
+#[test]
+fn apply_all_keeps_unique_tool_history_details() {
+    let args = r#"{"path":"src/provider/openai.rs","start_line":1,"end_line":200}"#;
+    let output = "endpoint=192.168.50.251:8080\n".repeat(400);
+    let mut messages = vec![
+        Message {
+            role: Role::Assistant,
+            content: vec![ContentPart::ToolCall {
+                id: "call_1".into(),
+                name: "read_file".into(),
+                arguments: args.into(),
+                thought_signature: None,
+            }],
+        },
+        Message {
+            role: Role::Tool,
+            content: vec![ContentPart::ToolResult {
+                tool_call_id: "call_1".into(),
+                content: output.clone(),
+            }],
+        },
+    ];
+    for i in 0..12 {
+        messages.push(user(&format!("filler {i}")));
+    }
+
+    let _ = apply_all(&mut messages);
+
+    assert!(matches!(
+        &messages[0].content[0],
+        ContentPart::ToolCall { arguments, .. } if arguments == args
+    ));
+    assert!(matches!(
+        &messages[1].content[0],
+        ContentPart::ToolResult { content, .. } if content == &output
+    ));
+}

--- a/src/session/helper/experimental/dedup.rs
+++ b/src/session/helper/experimental/dedup.rs
@@ -35,6 +35,14 @@ use crate::provider::{ContentPart, Message};
 /// content it replaces.
 pub const MIN_DEDUP_BYTES: usize = 256;
 
+/// Never deduplicate tool results in this many trailing messages. When
+/// a user asks the agent to re-run an identical call (e.g. "try that
+/// again"), the freshly-produced output would otherwise be replaced
+/// with a back-reference to the previous sighting, making the retry
+/// appear to produce no new information. Keeping the tail verbatim
+/// lets the model see that the retry actually happened.
+pub const KEEP_LAST_MESSAGES: usize = 8;
+
 /// Replace duplicate tool-result contents with a back-reference marker.
 ///
 /// Walks `messages` in order. The first tool result for a given content
@@ -49,7 +57,9 @@ pub const MIN_DEDUP_BYTES: usize = 256;
 ///
 /// ```rust
 /// use codetether_agent::provider::{ContentPart, Message, Role};
-/// use codetether_agent::session::helper::experimental::dedup::dedup_tool_outputs;
+/// use codetether_agent::session::helper::experimental::dedup::{
+///     dedup_tool_outputs, KEEP_LAST_MESSAGES,
+/// };
 ///
 /// let big = "x".repeat(1024);
 /// let mut msgs = vec![
@@ -68,6 +78,14 @@ pub const MIN_DEDUP_BYTES: usize = 256;
 ///         }],
 ///     },
 /// ];
+/// // Push enough padding so both tool results fall outside the
+/// // trailing keep-window and are eligible for dedup.
+/// for _ in 0..KEEP_LAST_MESSAGES {
+///     msgs.push(Message {
+///         role: Role::User,
+///         content: vec![ContentPart::Text { text: "...".into() }],
+///     });
+/// }
 ///
 /// let stats = dedup_tool_outputs(&mut msgs);
 /// assert_eq!(stats.dedup_hits, 1);
@@ -92,7 +110,13 @@ pub fn dedup_tool_outputs(messages: &mut [Message]) -> ExperimentalStats {
     let mut seen: HashMap<[u8; 32], String> = HashMap::new();
     let mut stats = ExperimentalStats::default();
 
-    for msg in messages.iter_mut() {
+    let total = messages.len();
+    let eligible = total.saturating_sub(KEEP_LAST_MESSAGES);
+    if eligible == 0 {
+        return stats;
+    }
+
+    for msg in messages[..eligible].iter_mut() {
         for part in msg.content.iter_mut() {
             let ContentPart::ToolResult {
                 tool_call_id,
@@ -140,9 +164,19 @@ mod tests {
         }
     }
 
+    fn padding_msg() -> Message {
+        Message {
+            role: crate::provider::Role::User,
+            content: vec![ContentPart::Text { text: "...".into() }],
+        }
+    }
+
     #[test]
     fn short_outputs_are_not_deduplicated() {
         let mut msgs = vec![tool_msg("a", "ok"), tool_msg("b", "ok")];
+        for _ in 0..KEEP_LAST_MESSAGES {
+            msgs.push(padding_msg());
+        }
         let stats = dedup_tool_outputs(&mut msgs);
         assert_eq!(stats.dedup_hits, 0);
     }
@@ -153,6 +187,9 @@ mod tests {
             tool_msg("a", &"x".repeat(1024)),
             tool_msg("b", &"y".repeat(1024)),
         ];
+        for _ in 0..KEEP_LAST_MESSAGES {
+            msgs.push(padding_msg());
+        }
         let stats = dedup_tool_outputs(&mut msgs);
         assert_eq!(stats.dedup_hits, 0);
         assert_eq!(stats.total_bytes_saved, 0);
@@ -166,6 +203,9 @@ mod tests {
             tool_msg("second", &big),
             tool_msg("third", &big),
         ];
+        for _ in 0..KEEP_LAST_MESSAGES {
+            msgs.push(padding_msg());
+        }
         let stats = dedup_tool_outputs(&mut msgs);
         assert_eq!(stats.dedup_hits, 2);
 
@@ -175,5 +215,21 @@ mod tests {
             };
             assert!(content.contains("tool_call_id=first"));
         }
+    }
+
+    #[test]
+    fn recent_identical_tool_result_is_not_deduplicated() {
+        // Regression: when the user asks the agent to re-run a call,
+        // the fresh output must remain verbatim. Previously this
+        // replaced the retry's content with a back-reference, making
+        // the retry appear to produce no new information.
+        let big = "r".repeat(1024);
+        let mut msgs = vec![tool_msg("old", &big), tool_msg("retry", &big)];
+        let stats = dedup_tool_outputs(&mut msgs);
+        assert_eq!(stats.dedup_hits, 0);
+        let ContentPart::ToolResult { content, .. } = &msgs[1].content[0] else {
+            panic!("expected tool result");
+        };
+        assert_eq!(content.len(), 1024);
     }
 }

--- a/src/session/helper/experimental/mod.rs
+++ b/src/session/helper/experimental/mod.rs
@@ -27,10 +27,10 @@
 //!
 //! # Default-on, no config
 //!
-//! These strategies are always active — there is intentionally no env
-//! flag to disable them. If a future regression requires an escape
-//! hatch, add a field to [`crate::config::Config`] rather than a magic
-//! env var so the setting is discoverable.
+//! The conservative strategies in [`apply_all`] are always active —
+//! there is intentionally no env flag to disable them. More aggressive
+//! transforms should stay opt-in until they prove they do not erase
+//! still-relevant chat state.
 //!
 //! # Examples
 //!
@@ -60,9 +60,12 @@
 pub mod dedup;
 pub mod lingua;
 pub mod pairing;
+#[allow(dead_code)]
 pub mod snippet;
+#[allow(dead_code)]
 pub mod streaming_llm;
 pub mod thinking_prune;
+#[allow(dead_code)]
 pub mod tool_call_dedup;
 
 use crate::provider::Message;
@@ -86,15 +89,16 @@ impl ExperimentalStats {
     }
 }
 
-/// Apply every experimental strategy in order, mutating `messages` in
-/// place. Returns aggregate statistics suitable for logging.
+/// Apply the default-safe experimental strategies in order, mutating
+/// `messages` in place. Returns aggregate statistics suitable for
+/// logging.
 ///
 /// Order matters:
 ///
-/// 1. [`dedup::dedup_tool_outputs`] runs first because it can eliminate
-///    a duplicate in full before [`snippet`] has to think about it.
-/// 2. [`snippet::snippet_stale_tool_outputs`] runs second, snipping any
-///    remaining oversized tool outputs older than the recency window.
+/// 1. [`dedup::dedup_tool_outputs`] runs before text cleanup so repeated
+///    tool outputs collapse against the original bytes.
+/// 2. [`lingua::prune_low_entropy`] runs after that to strip formatting
+///    noise from older assistant text without touching semantics.
 ///
 /// # Examples
 ///
@@ -109,11 +113,8 @@ impl ExperimentalStats {
 pub fn apply_all(messages: &mut Vec<Message>) -> ExperimentalStats {
     let mut stats = ExperimentalStats::default();
     stats.merge(thinking_prune::prune_thinking(messages));
-    stats.merge(tool_call_dedup::collapse_duplicate_calls(messages));
     stats.merge(dedup::dedup_tool_outputs(messages));
-    stats.merge(snippet::snippet_stale_tool_outputs(messages));
     stats.merge(lingua::prune_low_entropy(messages));
-    stats.merge(streaming_llm::trim_middle(messages));
     // Correctness pass: repair any orphaned tool_call/tool_result
     // pairs broken by the strategies above. Must run LAST.
     stats.merge(pairing::repair_orphans(messages));
@@ -127,3 +128,8 @@ pub fn apply_all(messages: &mut Vec<Message>) -> ExperimentalStats {
     }
     stats
 }
+
+#[cfg(test)]
+mod apply_all_tests;
+#[cfg(test)]
+mod apply_all_tool_history_tests;

--- a/src/session/helper/experimental/snippet.rs
+++ b/src/session/helper/experimental/snippet.rs
@@ -17,11 +17,12 @@
 //! windows are generous enough (1 KB each by default) to surface error
 //! messages, file headers, or the last lines of a log.
 //!
-//! # Runs *after* [`super::dedup`]
+//! # Rollout
 //!
-//! Dedup replaces exact duplicates with a single line; this pass only
-//! touches what dedup could not collapse. Running in the reverse order
-//! would snippet-then-hash, weakening dedup.
+//! This strategy is intentionally kept out of the default-safe
+//! [`super::apply_all`] path. It is useful under real token pressure,
+//! but it is still lossy because it removes unique bytes from old tool
+//! outputs.
 
 use super::ExperimentalStats;
 use crate::provider::{ContentPart, Message};

--- a/src/session/helper/experimental/streaming_llm.rs
+++ b/src/session/helper/experimental/streaming_llm.rs
@@ -25,11 +25,12 @@
 //! unresolved tool call. This preserves the tool-call ⇄ tool-result
 //! pairing required by every provider's chat API.
 //!
-//! # Always-on
+//! # Rollout
 //!
-//! No config flag. If history is short, this is a no-op. If history is
-//! long, the trim is beneficial regardless of model — the bytes saved
-//! go straight to input-token cost.
+//! This strategy is intentionally kept separate from the default-safe
+//! [`super::apply_all`] path. It is materially lossier than the other
+//! transforms because it can remove semantically relevant turns even
+//! when the request is still well within the model's context budget.
 
 use super::ExperimentalStats;
 use crate::provider::{ContentPart, Message, Role};

--- a/src/session/helper/experimental/tool_call_dedup.rs
+++ b/src/session/helper/experimental/tool_call_dedup.rs
@@ -23,9 +23,11 @@
 //! * Only triggers when arguments exceed [`MIN_COLLAPSE_BYTES`] so
 //!   micro-arguments like `{}` stay readable.
 //!
-//! # Always-on
+//! # Rollout
 //!
-//! No config flag.
+//! This strategy is intentionally kept out of the default-safe
+//! [`super::apply_all`] path because replacing historical arguments
+//! with back-references can erase still-relevant call details.
 
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;

--- a/src/session/helper/mod.rs
+++ b/src/session/helper/mod.rs
@@ -21,6 +21,7 @@ pub mod markup;
 pub mod prompt;
 pub mod prompt_events;
 pub mod provider;
+pub mod request_state;
 pub mod router;
 pub mod runtime;
 pub mod stream;

--- a/src/session/helper/prompt.rs
+++ b/src/session/helper/prompt.rs
@@ -30,9 +30,7 @@ use crate::rlm::{RlmConfig, RlmRouter, RoutingContext};
 use crate::tool::ToolRegistry;
 
 use super::super::{DEFAULT_MAX_STEPS, Session, SessionResult};
-use super::bootstrap::{
-    inject_tool_prompt, list_tools_bootstrap_definition, list_tools_bootstrap_output,
-};
+use super::bootstrap::list_tools_bootstrap_output;
 use super::build::{
     build_request_requires_tool, is_build_agent, should_force_build_tool_first_retry,
 };
@@ -51,13 +49,12 @@ use super::loop_constants::{
 };
 use super::markup::normalize_textual_tool_calls;
 use super::provider::{
-    prefers_temperature_one, resolve_provider_for_session_request,
-    should_retry_missing_native_tool_call, temperature_is_deprecated,
+    resolve_provider_for_session_request, should_retry_missing_native_tool_call,
 };
+use super::request_state::build_provider_step_state;
 use super::router::{build_proactive_lsp_context_message, choose_router_target_bandit};
 use super::runtime::{
     enrich_tool_input_with_runtime_context, is_codesearch_no_match_output, is_interactive_tool,
-    is_local_cuda_provider, local_cuda_light_system_prompt,
 };
 use super::text::extract_text_content;
 use super::token::{
@@ -111,54 +108,26 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
         default_model_for_provider(&selected_provider)
     };
 
-    // Phase A: oversized-user-message compression now happens inside
-    // `derive_context` on a clone. Keeping the original text in
-    // `session.messages` means `session_recall` and the MinIO history
-    // sink can still see what the user actually typed.
-
-    let tool_registry = ToolRegistry::with_provider_arc(Arc::clone(&provider), model.clone());
-    let tool_definitions: Vec<_> = tool_registry
-        .definitions()
-        .into_iter()
-        .filter(|tool| !is_interactive_tool(&tool.name))
-        .collect();
-
-    let mut temperature = if temperature_is_deprecated(&model) {
-        None
-    } else if prefers_temperature_one(&model) {
-        Some(1.0)
-    } else {
-        Some(0.7)
-    };
-
-    tracing::info!("Using model: {} via provider: {}", model, selected_provider);
-    tracing::info!("Available tools: {}", tool_definitions.len());
-
-    let mut model_supports_tools = !matches!(
-        selected_provider.as_str(),
-        "gemini-web" | "local-cuda" | "local_cuda" | "localcuda"
-    );
-    let mut advertised_tool_definitions = if model_supports_tools {
-        tool_definitions.clone()
-    } else {
-        vec![list_tools_bootstrap_definition()]
-    };
-
     let cwd = session
         .metadata
         .directory
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-    let system_prompt = if is_local_cuda_provider(&selected_provider) {
-        local_cuda_light_system_prompt()
-    } else {
-        crate::agent::builtin::build_system_prompt(&cwd)
-    };
-    let system_prompt = if !model_supports_tools && !advertised_tool_definitions.is_empty() {
-        inject_tool_prompt(&system_prompt, &advertised_tool_definitions)
-    } else {
-        system_prompt
-    };
+    // Phase A: oversized-user-message compression now happens inside
+    // `derive_context` on a clone. Keeping the original text in
+    // `session.messages` means `session_recall` and the MinIO history
+    // sink can still see what the user actually typed.
+    let mut provider_state =
+        build_provider_step_state(Arc::clone(&provider), &selected_provider, &model, &cwd);
+    let mut tool_registry = provider_state.tool_registry.clone();
+    let mut tool_definitions = provider_state.tool_definitions.clone();
+    let mut temperature = provider_state.temperature;
+    let mut model_supports_tools = provider_state.model_supports_tools;
+    let mut advertised_tool_definitions = provider_state.advertised_tool_definitions.clone();
+    let mut system_prompt = provider_state.system_prompt.clone();
+
+    tracing::info!("Using model: {} via provider: {}", model, selected_provider);
+    tracing::info!("Available tools: {}", tool_definitions.len());
 
     let max_steps = session.max_steps.unwrap_or(DEFAULT_MAX_STEPS);
     let mut final_output = String::new();
@@ -207,7 +176,7 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
         )
         .await?;
 
-        let proactive_lsp_message = build_proactive_lsp_context_message(
+        let mut proactive_lsp_message = build_proactive_lsp_context_message(
             selected_provider.as_str(),
             step,
             &tool_registry,
@@ -306,22 +275,38 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
                                 anyhow::anyhow!("Provider {} not found", selected_provider.clone())
                             })?;
                             model = retry_model;
-                            temperature = if temperature_is_deprecated(&model) {
-                                None
-                            } else if prefers_temperature_one(&model) {
-                                Some(1.0)
-                            } else {
-                                Some(0.7)
-                            };
-                            model_supports_tools = !matches!(
-                                selected_provider.as_str(),
-                                "gemini-web" | "local-cuda" | "local_cuda" | "localcuda"
+                            provider_state = build_provider_step_state(
+                                Arc::clone(&provider),
+                                &selected_provider,
+                                &model,
+                                &cwd,
                             );
-                            advertised_tool_definitions = if model_supports_tools {
-                                tool_definitions.clone()
-                            } else {
-                                vec![list_tools_bootstrap_definition()]
-                            };
+                            tool_registry = provider_state.tool_registry.clone();
+                            tool_definitions = provider_state.tool_definitions.clone();
+                            temperature = provider_state.temperature;
+                            model_supports_tools = provider_state.model_supports_tools;
+                            advertised_tool_definitions =
+                                provider_state.advertised_tool_definitions.clone();
+                            system_prompt = provider_state.system_prompt.clone();
+                            derived = derive_with_policy(
+                                session,
+                                Arc::clone(&provider),
+                                &model,
+                                &system_prompt,
+                                &advertised_tool_definitions,
+                                None,
+                                policy,
+                                None,
+                            )
+                            .await?;
+                            proactive_lsp_message = build_proactive_lsp_context_message(
+                                selected_provider.as_str(),
+                                step,
+                                &tool_registry,
+                                &session.messages,
+                                &cwd,
+                            )
+                            .await;
                             session.metadata.model = Some(format!("{selected_provider}/{model}"));
                             attempt = 0;
                         }

--- a/src/session/helper/prompt.rs
+++ b/src/session/helper/prompt.rs
@@ -54,7 +54,7 @@ use super::provider::{
     prefers_temperature_one, resolve_provider_for_session_request,
     should_retry_missing_native_tool_call, temperature_is_deprecated,
 };
-use super::router::{build_proactive_lsp_context_message, choose_router_target};
+use super::router::{build_proactive_lsp_context_message, choose_router_target_bandit};
 use super::runtime::{
     enrich_tool_input_with_runtime_context, is_codesearch_no_match_output, is_interactive_tool,
     is_local_cuda_provider, local_cuda_light_system_prompt,
@@ -64,7 +64,9 @@ use super::token::{
     context_window_for_model, estimate_tokens_for_messages, session_completion_max_tokens,
 };
 use super::validation::{build_validation_report, capture_git_dirty_files, track_touched_files};
-use crate::session::context::derive_context;
+use crate::session::{
+    bucket_for_messages, delegation_skills, derive_with_policy, effective_policy,
+};
 
 /// Execute a prompt against the session and return a [`SessionResult`].
 ///
@@ -84,12 +86,13 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
 
     let (provider_name, model_id) = parse_session_model_selector(session, &providers);
 
-    let selected_provider =
-        resolve_provider_for_session_request(providers.as_slice(), provider_name.as_deref())?;
+    let mut selected_provider =
+        resolve_provider_for_session_request(providers.as_slice(), provider_name.as_deref())?
+            .to_string();
 
-    let provider = registry
-        .get(selected_provider)
-        .ok_or_else(|| anyhow::anyhow!("Provider {} not found", selected_provider))?;
+    let mut provider = registry
+        .get(&selected_provider)
+        .ok_or_else(|| anyhow::anyhow!("Provider {} not found", selected_provider.clone()))?;
 
     session.add_message(Message {
         role: Role::User,
@@ -102,10 +105,10 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
         session.generate_title().await?;
     }
 
-    let model = if !model_id.is_empty() {
+    let mut model = if !model_id.is_empty() {
         model_id
     } else {
-        default_model_for_provider(selected_provider)
+        default_model_for_provider(&selected_provider)
     };
 
     // Phase A: oversized-user-message compression now happens inside
@@ -120,7 +123,7 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
         .filter(|tool| !is_interactive_tool(&tool.name))
         .collect();
 
-    let temperature = if temperature_is_deprecated(&model) {
+    let mut temperature = if temperature_is_deprecated(&model) {
         None
     } else if prefers_temperature_one(&model) {
         Some(1.0)
@@ -131,11 +134,11 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
     tracing::info!("Using model: {} via provider: {}", model, selected_provider);
     tracing::info!("Available tools: {}", tool_definitions.len());
 
-    let model_supports_tools = !matches!(
-        selected_provider,
+    let mut model_supports_tools = !matches!(
+        selected_provider.as_str(),
         "gemini-web" | "local-cuda" | "local_cuda" | "localcuda"
     );
-    let advertised_tool_definitions = if model_supports_tools {
+    let mut advertised_tool_definitions = if model_supports_tools {
         tool_definitions.clone()
     } else {
         vec![list_tools_bootstrap_definition()]
@@ -146,7 +149,7 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
         .directory
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-    let system_prompt = if is_local_cuda_provider(selected_provider) {
+    let system_prompt = if is_local_cuda_provider(&selected_provider) {
         local_cuda_light_system_prompt()
     } else {
         crate::agent::builtin::build_system_prompt(&cwd)
@@ -191,25 +194,28 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
         // experimental strategies, RLM-powered context-window
         // enforcement, and orphan-pair repair all run against the
         // clone; the canonical transcript stays append-only.
-        let mut derived = derive_context(
+        let policy = effective_policy(session);
+        let mut derived = derive_with_policy(
             session,
             Arc::clone(&provider),
             &model,
             &system_prompt,
             &advertised_tool_definitions,
             None,
+            policy,
             None,
         )
         .await?;
 
         let proactive_lsp_message = build_proactive_lsp_context_message(
-            selected_provider,
+            selected_provider.as_str(),
             step,
             &tool_registry,
             &session.messages,
             &cwd,
         )
         .await;
+        let bucket = bucket_for_messages(session.history());
 
         let mut attempt = 0;
         let mut upstream_retry_count: u8 = 0;
@@ -239,17 +245,26 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
             };
 
             match provider.complete(request).await {
-                Ok(r) => break r,
+                Ok(r) => {
+                    session.metadata.delegation.update(
+                        &selected_provider,
+                        delegation_skills::MODEL_CALL,
+                        bucket,
+                        true,
+                    );
+                    break r;
+                }
                 Err(e) => {
                     if attempt == 1 && is_prompt_too_long_error(&e) {
                         tracing::warn!(error = %e, "Provider rejected prompt as too long; re-deriving with force_keep_last=6 and retrying");
-                        derived = derive_context(
+                        derived = derive_with_policy(
                             session,
                             Arc::clone(&provider),
                             &model,
                             &system_prompt,
                             &advertised_tool_definitions,
                             None,
+                            policy,
                             Some(6),
                         )
                         .await?;
@@ -258,6 +273,12 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
                     if upstream_retry_count < MAX_UPSTREAM_RETRIES
                         && is_retryable_upstream_error(&e)
                     {
+                        session.metadata.delegation.update(
+                            &selected_provider,
+                            delegation_skills::MODEL_CALL,
+                            bucket,
+                            false,
+                        );
                         upstream_retry_count += 1;
                         let backoff_secs = 1u64 << (upstream_retry_count - 1).min(2);
                         tracing::warn!(
@@ -268,16 +289,40 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
                             "Retryable upstream provider error; sleeping and retrying"
                         );
                         tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
-                        if let Some((retry_provider, retry_model)) =
-                            choose_router_target(&registry, selected_provider, &model)
-                        {
+                        if let Some((retry_provider, retry_model)) = choose_router_target_bandit(
+                            &registry,
+                            &session.metadata.delegation,
+                            bucket,
+                            &selected_provider,
+                            &model,
+                        ) {
                             tracing::info!(
                                 to_provider = %retry_provider,
                                 to_model = %retry_model,
                                 "Failing over to alternate provider/model"
                             );
-                            session.metadata.model =
-                                Some(format!("{retry_provider}/{retry_model}"));
+                            selected_provider = retry_provider;
+                            provider = registry.get(&selected_provider).ok_or_else(|| {
+                                anyhow::anyhow!("Provider {} not found", selected_provider.clone())
+                            })?;
+                            model = retry_model;
+                            temperature = if temperature_is_deprecated(&model) {
+                                None
+                            } else if prefers_temperature_one(&model) {
+                                Some(1.0)
+                            } else {
+                                Some(0.7)
+                            };
+                            model_supports_tools = !matches!(
+                                selected_provider.as_str(),
+                                "gemini-web" | "local-cuda" | "local_cuda" | "localcuda"
+                            );
+                            advertised_tool_definitions = if model_supports_tools {
+                                tool_definitions.clone()
+                            } else {
+                                vec![list_tools_bootstrap_definition()]
+                            };
+                            session.metadata.model = Some(format!("{selected_provider}/{model}"));
                             attempt = 0;
                         }
                         continue;
@@ -364,7 +409,7 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
             continue;
         }
         if should_retry_missing_native_tool_call(
-            selected_provider,
+            selected_provider.as_str(),
             &model,
             native_tool_promise_retry_count,
             &tool_definitions,

--- a/src/session/helper/prompt_events.rs
+++ b/src/session/helper/prompt_events.rs
@@ -41,7 +41,7 @@ use super::confirmation::{
 };
 use super::defaults::default_model_for_provider;
 use super::edit::{detect_stub_in_tool_input, normalize_tool_call_for_execution};
-use super::error::is_prompt_too_long_error;
+use super::error::{is_prompt_too_long_error, is_retryable_upstream_error};
 use super::loop_constants::{
     BUILD_MODE_TOOL_FIRST_MAX_RETRIES, BUILD_MODE_TOOL_FIRST_NUDGE, CODESEARCH_THRASH_NUDGE,
     FORCE_FINAL_ANSWER_NUDGE, MAX_CONSECUTIVE_CODESEARCH_NO_MATCHES, MAX_CONSECUTIVE_SAME_TOOL,
@@ -53,7 +53,7 @@ use super::provider::{
     prefers_temperature_one, resolve_provider_for_session_request,
     should_retry_missing_native_tool_call, temperature_is_deprecated,
 };
-use super::router::build_proactive_lsp_context_message;
+use super::router::{build_proactive_lsp_context_message, choose_router_target_bandit};
 use super::runtime::{
     enrich_tool_input_with_runtime_context, is_codesearch_no_match_output, is_interactive_tool,
     is_local_cuda_provider, local_cuda_light_system_prompt,
@@ -64,7 +64,9 @@ use super::token::{
     context_window_for_model, estimate_tokens_for_messages, session_completion_max_tokens,
 };
 use super::validation::{build_validation_report, capture_git_dirty_files, track_touched_files};
-use crate::session::context::derive_context;
+use crate::session::{
+    bucket_for_messages, delegation_skills, derive_with_policy, effective_policy,
+};
 
 /// Execute a prompt with optional image attachments and stream events to the
 /// provided channel.
@@ -91,12 +93,13 @@ pub(crate) async fn run_prompt_with_events(
 
     let (provider_name, model_id) = parse_session_model_selector(session, &providers);
 
-    let selected_provider =
-        resolve_provider_for_session_request(providers.as_slice(), provider_name.as_deref())?;
+    let mut selected_provider =
+        resolve_provider_for_session_request(providers.as_slice(), provider_name.as_deref())?
+            .to_string();
 
-    let provider = registry
-        .get(selected_provider)
-        .ok_or_else(|| anyhow::anyhow!("Provider {} not found", selected_provider))?;
+    let mut provider = registry
+        .get(&selected_provider)
+        .ok_or_else(|| anyhow::anyhow!("Provider {} not found", selected_provider.clone()))?;
 
     let mut content_parts = vec![ContentPart::Text {
         text: message.to_string(),
@@ -124,10 +127,10 @@ pub(crate) async fn run_prompt_with_events(
         session.generate_title().await?;
     }
 
-    let model = if !model_id.is_empty() {
+    let mut model = if !model_id.is_empty() {
         model_id
     } else {
-        default_model_for_provider(selected_provider)
+        default_model_for_provider(&selected_provider)
     };
 
     // Phase A: oversized-user-message compression now happens inside
@@ -142,7 +145,7 @@ pub(crate) async fn run_prompt_with_events(
         .filter(|tool| !is_interactive_tool(&tool.name))
         .collect();
 
-    let temperature = if temperature_is_deprecated(&model) {
+    let mut temperature = if temperature_is_deprecated(&model) {
         None
     } else if prefers_temperature_one(&model) {
         Some(1.0)
@@ -153,20 +156,22 @@ pub(crate) async fn run_prompt_with_events(
     tracing::info!("Using model: {} via provider: {}", model, selected_provider);
     tracing::info!("Available tools: {}", tool_definitions.len());
 
-    let model_supports_tools = !matches!(
-        selected_provider,
+    let mut model_supports_tools = !matches!(
+        selected_provider.as_str(),
         "gemini-web" | "local-cuda" | "local_cuda" | "localcuda"
     );
-    let advertised_tool_definitions = if model_supports_tools {
+    let mut advertised_tool_definitions = if model_supports_tools {
         tool_definitions.clone()
     } else {
         vec![list_tools_bootstrap_definition()]
     };
 
-    let cwd = std::env::var("PWD")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
-    let system_prompt = if is_local_cuda_provider(selected_provider) {
+    let cwd = session
+        .metadata
+        .directory
+        .clone()
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    let system_prompt = if is_local_cuda_provider(&selected_provider) {
         local_cuda_light_system_prompt()
     } else {
         crate::agent::builtin::build_system_prompt(&cwd)
@@ -212,52 +217,55 @@ pub(crate) async fn run_prompt_with_events(
         // Experimental strategies, RLM-powered context-window
         // enforcement, and the orphan-pair safety net all run against
         // the clone; the canonical transcript stays append-only.
-        let mut derived = derive_context(
+        let policy = effective_policy(session);
+        let mut derived = derive_with_policy(
             session,
             Arc::clone(&provider),
             &model,
             &system_prompt,
             &advertised_tool_definitions,
             Some(&event_tx),
+            policy,
             None,
         )
         .await?;
 
         let proactive_lsp_message = build_proactive_lsp_context_message(
-            selected_provider,
+            selected_provider.as_str(),
             step,
             &tool_registry,
             &session.messages,
             &cwd,
         )
         .await;
-
-        let mut messages = vec![Message {
-            role: Role::System,
-            content: vec![ContentPart::Text {
-                text: system_prompt.clone(),
-            }],
-        }];
-        if let Some(msg) = &proactive_lsp_message {
-            messages.push(msg.clone());
-        }
-        messages.extend(derived.messages.clone());
-
-        let request = CompletionRequest {
-            messages,
-            tools: advertised_tool_definitions.clone(),
-            model: model.clone(),
-            temperature,
-            top_p: None,
-            max_tokens: Some(session_completion_max_tokens()),
-            stop: Vec::new(),
-        };
+        let bucket = bucket_for_messages(session.history());
 
         let llm_start = std::time::Instant::now();
         let mut attempt = 0;
+        let mut upstream_retry_count: u8 = 0;
+        const MAX_UPSTREAM_RETRIES: u8 = 3;
         #[allow(clippy::never_loop)]
         let response = loop {
             attempt += 1;
+            let mut messages = vec![Message {
+                role: Role::System,
+                content: vec![ContentPart::Text {
+                    text: system_prompt.clone(),
+                }],
+            }];
+            if let Some(msg) = &proactive_lsp_message {
+                messages.push(msg.clone());
+            }
+            messages.extend(derived.messages.clone());
+            let request = CompletionRequest {
+                messages,
+                tools: advertised_tool_definitions.clone(),
+                model: model.clone(),
+                temperature,
+                top_p: None,
+                max_tokens: Some(session_completion_max_tokens()),
+                stop: Vec::new(),
+            };
             let completion_result = if model_supports_tools {
                 let stream = provider.complete_stream(request.clone()).await?;
                 collect_stream_completion_with_events(stream, Some(&event_tx)).await
@@ -266,49 +274,87 @@ pub(crate) async fn run_prompt_with_events(
             };
 
             match completion_result {
-                Ok(r) => break r,
+                Ok(r) => {
+                    session.metadata.delegation.update(
+                        &selected_provider,
+                        delegation_skills::MODEL_CALL,
+                        bucket,
+                        true,
+                    );
+                    break r;
+                }
                 Err(e) => {
                     if attempt == 1 && is_prompt_too_long_error(&e) {
                         tracing::warn!(error = %e, "Provider rejected prompt as too long; re-deriving with force_keep_last=6 and retrying");
-                        derived = derive_context(
+                        derived = derive_with_policy(
                             session,
                             Arc::clone(&provider),
                             &model,
                             &system_prompt,
                             &advertised_tool_definitions,
                             Some(&event_tx),
+                            policy,
                             Some(6),
                         )
                         .await?;
-                        let mut messages = vec![Message {
-                            role: Role::System,
-                            content: vec![ContentPart::Text {
-                                text: system_prompt.clone(),
-                            }],
-                        }];
-                        if let Some(msg) = &proactive_lsp_message {
-                            messages.push(msg.clone());
+                        continue;
+                    }
+                    if upstream_retry_count < MAX_UPSTREAM_RETRIES
+                        && is_retryable_upstream_error(&e)
+                    {
+                        session.metadata.delegation.update(
+                            &selected_provider,
+                            delegation_skills::MODEL_CALL,
+                            bucket,
+                            false,
+                        );
+                        upstream_retry_count += 1;
+                        let backoff_secs = 1u64 << (upstream_retry_count - 1).min(2);
+                        tracing::warn!(
+                            error = %e,
+                            retry = upstream_retry_count,
+                            max = MAX_UPSTREAM_RETRIES,
+                            backoff_secs,
+                            "Retryable upstream provider error; sleeping and retrying"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
+                        if let Some((retry_provider, retry_model)) = choose_router_target_bandit(
+                            &registry,
+                            &session.metadata.delegation,
+                            bucket,
+                            &selected_provider,
+                            &model,
+                        ) {
+                            tracing::info!(
+                                to_provider = %retry_provider,
+                                to_model = %retry_model,
+                                "Failing over to alternate provider/model"
+                            );
+                            selected_provider = retry_provider;
+                            provider = registry.get(&selected_provider).ok_or_else(|| {
+                                anyhow::anyhow!("Provider {} not found", selected_provider.clone())
+                            })?;
+                            model = retry_model;
+                            temperature = if temperature_is_deprecated(&model) {
+                                None
+                            } else if prefers_temperature_one(&model) {
+                                Some(1.0)
+                            } else {
+                                Some(0.7)
+                            };
+                            model_supports_tools = !matches!(
+                                selected_provider.as_str(),
+                                "gemini-web" | "local-cuda" | "local_cuda" | "localcuda"
+                            );
+                            advertised_tool_definitions = if model_supports_tools {
+                                tool_definitions.clone()
+                            } else {
+                                vec![list_tools_bootstrap_definition()]
+                            };
+                            session.metadata.model = Some(format!("{selected_provider}/{model}"));
+                            attempt = 0;
                         }
-                        messages.extend(derived.messages.clone());
-                        let new_request = CompletionRequest {
-                            messages,
-                            tools: advertised_tool_definitions.clone(),
-                            model: model.clone(),
-                            temperature,
-                            top_p: None,
-                            max_tokens: Some(session_completion_max_tokens()),
-                            stop: Vec::new(),
-                        };
-                        let retry_result = if model_supports_tools {
-                            let stream = provider.complete_stream(new_request).await?;
-                            collect_stream_completion_with_events(stream, Some(&event_tx)).await
-                        } else {
-                            provider.complete(new_request).await
-                        };
-                        match retry_result {
-                            Ok(r2) => break r2,
-                            Err(e2) => return Err(e2),
-                        }
+                        continue;
                     }
                     return Err(e);
                 }
@@ -402,7 +448,7 @@ pub(crate) async fn run_prompt_with_events(
             continue;
         }
         if should_retry_missing_native_tool_call(
-            selected_provider,
+            selected_provider.as_str(),
             &model,
             native_tool_promise_retry_count,
             &tool_definitions,

--- a/src/session/helper/prompt_events.rs
+++ b/src/session/helper/prompt_events.rs
@@ -29,9 +29,7 @@ use crate::rlm::{RlmConfig, RlmRouter, RoutingContext};
 use crate::tool::ToolRegistry;
 
 use super::super::{DEFAULT_MAX_STEPS, ImageAttachment, Session, SessionEvent, SessionResult};
-use super::bootstrap::{
-    inject_tool_prompt, list_tools_bootstrap_definition, list_tools_bootstrap_output,
-};
+use super::bootstrap::list_tools_bootstrap_output;
 use super::build::{
     build_request_requires_tool, is_build_agent, should_force_build_tool_first_retry,
 };
@@ -50,13 +48,12 @@ use super::loop_constants::{
 };
 use super::markup::normalize_textual_tool_calls;
 use super::provider::{
-    prefers_temperature_one, resolve_provider_for_session_request,
-    should_retry_missing_native_tool_call, temperature_is_deprecated,
+    resolve_provider_for_session_request, should_retry_missing_native_tool_call,
 };
+use super::request_state::build_provider_step_state;
 use super::router::{build_proactive_lsp_context_message, choose_router_target_bandit};
 use super::runtime::{
     enrich_tool_input_with_runtime_context, is_codesearch_no_match_output, is_interactive_tool,
-    is_local_cuda_provider, local_cuda_light_system_prompt,
 };
 use super::stream::collect_stream_completion_with_events;
 use super::text::extract_text_content;
@@ -133,54 +130,26 @@ pub(crate) async fn run_prompt_with_events(
         default_model_for_provider(&selected_provider)
     };
 
-    // Phase A: oversized-user-message compression now happens inside
-    // `derive_context` on a clone. Keeping the original text in
-    // `session.messages` means `session_recall` and the MinIO history
-    // sink can still see what the user actually typed.
-
-    let tool_registry = ToolRegistry::with_provider_arc(Arc::clone(&provider), model.clone());
-    let tool_definitions: Vec<_> = tool_registry
-        .definitions()
-        .into_iter()
-        .filter(|tool| !is_interactive_tool(&tool.name))
-        .collect();
-
-    let mut temperature = if temperature_is_deprecated(&model) {
-        None
-    } else if prefers_temperature_one(&model) {
-        Some(1.0)
-    } else {
-        Some(0.7)
-    };
-
-    tracing::info!("Using model: {} via provider: {}", model, selected_provider);
-    tracing::info!("Available tools: {}", tool_definitions.len());
-
-    let mut model_supports_tools = !matches!(
-        selected_provider.as_str(),
-        "gemini-web" | "local-cuda" | "local_cuda" | "localcuda"
-    );
-    let mut advertised_tool_definitions = if model_supports_tools {
-        tool_definitions.clone()
-    } else {
-        vec![list_tools_bootstrap_definition()]
-    };
-
     let cwd = session
         .metadata
         .directory
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-    let system_prompt = if is_local_cuda_provider(&selected_provider) {
-        local_cuda_light_system_prompt()
-    } else {
-        crate::agent::builtin::build_system_prompt(&cwd)
-    };
-    let system_prompt = if !model_supports_tools && !advertised_tool_definitions.is_empty() {
-        inject_tool_prompt(&system_prompt, &advertised_tool_definitions)
-    } else {
-        system_prompt
-    };
+    // Phase A: oversized-user-message compression now happens inside
+    // `derive_context` on a clone. Keeping the original text in
+    // `session.messages` means `session_recall` and the MinIO history
+    // sink can still see what the user actually typed.
+    let mut provider_state =
+        build_provider_step_state(Arc::clone(&provider), &selected_provider, &model, &cwd);
+    let mut tool_registry = provider_state.tool_registry.clone();
+    let mut tool_definitions = provider_state.tool_definitions.clone();
+    let mut temperature = provider_state.temperature;
+    let mut model_supports_tools = provider_state.model_supports_tools;
+    let mut advertised_tool_definitions = provider_state.advertised_tool_definitions.clone();
+    let mut system_prompt = provider_state.system_prompt.clone();
+
+    tracing::info!("Using model: {} via provider: {}", model, selected_provider);
+    tracing::info!("Available tools: {}", tool_definitions.len());
 
     let mut final_output = String::new();
     let max_steps = session.max_steps.unwrap_or(DEFAULT_MAX_STEPS);
@@ -230,7 +199,7 @@ pub(crate) async fn run_prompt_with_events(
         )
         .await?;
 
-        let proactive_lsp_message = build_proactive_lsp_context_message(
+        let mut proactive_lsp_message = build_proactive_lsp_context_message(
             selected_provider.as_str(),
             step,
             &tool_registry,
@@ -335,22 +304,38 @@ pub(crate) async fn run_prompt_with_events(
                                 anyhow::anyhow!("Provider {} not found", selected_provider.clone())
                             })?;
                             model = retry_model;
-                            temperature = if temperature_is_deprecated(&model) {
-                                None
-                            } else if prefers_temperature_one(&model) {
-                                Some(1.0)
-                            } else {
-                                Some(0.7)
-                            };
-                            model_supports_tools = !matches!(
-                                selected_provider.as_str(),
-                                "gemini-web" | "local-cuda" | "local_cuda" | "localcuda"
+                            provider_state = build_provider_step_state(
+                                Arc::clone(&provider),
+                                &selected_provider,
+                                &model,
+                                &cwd,
                             );
-                            advertised_tool_definitions = if model_supports_tools {
-                                tool_definitions.clone()
-                            } else {
-                                vec![list_tools_bootstrap_definition()]
-                            };
+                            tool_registry = provider_state.tool_registry.clone();
+                            tool_definitions = provider_state.tool_definitions.clone();
+                            temperature = provider_state.temperature;
+                            model_supports_tools = provider_state.model_supports_tools;
+                            advertised_tool_definitions =
+                                provider_state.advertised_tool_definitions.clone();
+                            system_prompt = provider_state.system_prompt.clone();
+                            derived = derive_with_policy(
+                                session,
+                                Arc::clone(&provider),
+                                &model,
+                                &system_prompt,
+                                &advertised_tool_definitions,
+                                Some(&event_tx),
+                                policy,
+                                None,
+                            )
+                            .await?;
+                            proactive_lsp_message = build_proactive_lsp_context_message(
+                                selected_provider.as_str(),
+                                step,
+                                &tool_registry,
+                                &session.messages,
+                                &cwd,
+                            )
+                            .await;
                             session.metadata.model = Some(format!("{selected_provider}/{model}"));
                             attempt = 0;
                         }

--- a/src/session/helper/request_state.rs
+++ b/src/session/helper/request_state.rs
@@ -1,0 +1,70 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::provider::{Provider, ToolDefinition};
+use crate::tool::ToolRegistry;
+
+use super::bootstrap::{inject_tool_prompt, list_tools_bootstrap_definition};
+use super::provider::{prefers_temperature_one, temperature_is_deprecated};
+use super::runtime::{is_interactive_tool, is_local_cuda_provider, local_cuda_light_system_prompt};
+
+pub(crate) struct ProviderStepState {
+    pub tool_registry: Arc<ToolRegistry>,
+    pub tool_definitions: Vec<ToolDefinition>,
+    pub advertised_tool_definitions: Vec<ToolDefinition>,
+    pub temperature: Option<f32>,
+    pub model_supports_tools: bool,
+    pub system_prompt: String,
+}
+
+pub(crate) fn build_provider_step_state(
+    provider: Arc<dyn Provider>,
+    selected_provider: &str,
+    model: &str,
+    cwd: &Path,
+) -> ProviderStepState {
+    let tool_registry = ToolRegistry::with_provider_arc(provider, model.to_string());
+    let tool_definitions: Vec<_> = tool_registry
+        .definitions()
+        .into_iter()
+        .filter(|tool| !is_interactive_tool(&tool.name))
+        .collect();
+
+    let temperature = if temperature_is_deprecated(model) {
+        None
+    } else if prefers_temperature_one(model) {
+        Some(1.0)
+    } else {
+        Some(0.7)
+    };
+
+    let model_supports_tools = !matches!(
+        selected_provider,
+        "gemini-web" | "local-cuda" | "local_cuda" | "localcuda"
+    );
+    let advertised_tool_definitions = if model_supports_tools {
+        tool_definitions.clone()
+    } else {
+        vec![list_tools_bootstrap_definition()]
+    };
+
+    let system_prompt = if is_local_cuda_provider(selected_provider) {
+        local_cuda_light_system_prompt()
+    } else {
+        crate::agent::builtin::build_system_prompt(cwd)
+    };
+    let system_prompt = if !model_supports_tools && !advertised_tool_definitions.is_empty() {
+        inject_tool_prompt(&system_prompt, &advertised_tool_definitions)
+    } else {
+        system_prompt
+    };
+
+    ProviderStepState {
+        tool_registry,
+        tool_definitions,
+        advertised_tool_definitions,
+        temperature,
+        model_supports_tools,
+        system_prompt,
+    }
+}

--- a/src/session/helper/router.rs
+++ b/src/session/helper/router.rs
@@ -178,11 +178,11 @@ pub fn choose_router_target(
 
 /// CADMAS-CTX-aware variant of [`choose_router_target`] (Phase C step 17).
 ///
-/// When `state.config.enabled` is `true`, the rule-based candidate list
+/// When delegation is enabled on `state`, the rule-based candidate list
 /// from [`known_good_router_candidates`] is re-ordered by the LCB score
 /// `μ − γ·√u` under the supplied `bucket`. Candidates with no
 /// observations yet keep their original rule order (cold-start
-/// conservatism). When `state.config.enabled` is `false`, this function
+/// conservatism). When delegation is disabled, this function
 /// is exactly [`choose_router_target`].
 ///
 /// The actual outcome update — `state.update(provider, "model_call",
@@ -225,7 +225,7 @@ pub fn choose_router_target_bandit(
     selected_provider: &str,
     current_model: &str,
 ) -> Option<(String, String)> {
-    if !state.config.enabled {
+    if !state.enabled() {
         return choose_router_target(registry, selected_provider, current_model);
     }
 

--- a/src/session/history.rs
+++ b/src/session/history.rs
@@ -46,6 +46,7 @@
 //! ```
 
 use crate::provider::Message;
+use crate::session::pages::{PageKind, classify, classify_all};
 
 /// Append-only handle to a chat-history buffer.
 ///
@@ -76,6 +77,7 @@ use crate::provider::Message;
 /// ```
 pub struct History<'a> {
     buf: &'a mut Vec<Message>,
+    pages: Option<&'a mut Vec<PageKind>>,
 }
 
 impl<'a> History<'a> {
@@ -98,7 +100,15 @@ impl<'a> History<'a> {
     /// assert!(history.view().is_empty());
     /// ```
     pub fn new(buf: &'a mut Vec<Message>) -> Self {
-        Self { buf }
+        Self { buf, pages: None }
+    }
+
+    /// Wrap a history buffer plus its parallel page sidecar.
+    pub(crate) fn with_pages(buf: &'a mut Vec<Message>, pages: &'a mut Vec<PageKind>) -> Self {
+        Self {
+            buf,
+            pages: Some(pages),
+        }
     }
 
     /// Append a single message to the end of the history.
@@ -106,6 +116,12 @@ impl<'a> History<'a> {
     /// The only mutating operation on [`History`] — every other mutation
     /// must be routed through a dedicated API on the owning type.
     pub fn append(&mut self, msg: Message) {
+        if let Some(pages) = self.pages.as_deref_mut() {
+            if pages.len() != self.buf.len() {
+                *pages = classify_all(self.buf);
+            }
+            pages.push(classify(&msg));
+        }
         self.buf.push(msg);
     }
 

--- a/src/session/history_files.rs
+++ b/src/session/history_files.rs
@@ -1,0 +1,98 @@
+//! Materialized turn files for filesystem-style history browsing.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tokio::fs;
+
+use crate::provider::{ContentPart, Message, Role};
+
+use super::Session;
+
+pub(crate) fn role_label(role: &Role) -> &'static str {
+    match role {
+        Role::System => "system",
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Tool => "tool",
+    }
+}
+
+pub(crate) fn render_turn(msg: &Message) -> String {
+    let mut buf = String::new();
+    for part in &msg.content {
+        if !buf.is_empty() {
+            buf.push_str("\n\n");
+        }
+        match part {
+            ContentPart::Text { text } => buf.push_str(text),
+            ContentPart::ToolResult {
+                tool_call_id,
+                content,
+            } => {
+                buf.push_str(&format!("[tool_result tool_call_id={tool_call_id}]\n"));
+                buf.push_str(content);
+            }
+            ContentPart::ToolCall {
+                name, arguments, ..
+            } => buf.push_str(&format!("[tool_call {name}]\n{arguments}")),
+            ContentPart::Image { url, .. } => buf.push_str(&format!("[image {url}]")),
+            ContentPart::File { path, .. } => buf.push_str(&format!("[file {path}]")),
+            ContentPart::Thinking { text } => buf.push_str(&format!("[thinking]\n{text}")),
+        }
+    }
+    buf
+}
+
+pub(crate) fn format_turn_path(session_dir: &Path, turn: usize, role: &str) -> PathBuf {
+    session_dir.join(format!("turn-{turn:04}-{role}.md"))
+}
+
+pub(crate) fn history_dir_for_session(session: &Session) -> Result<PathBuf> {
+    let data_dir = if let Ok(explicit) = std::env::var("CODETETHER_DATA_DIR") {
+        let explicit = explicit.trim();
+        if !explicit.is_empty() {
+            PathBuf::from(explicit)
+        } else {
+            workspace_data_dir(session.metadata.directory.as_deref())
+        }
+    } else {
+        workspace_data_dir(session.metadata.directory.as_deref())
+    };
+    Ok(data_dir.join("history").join(&session.id))
+}
+
+pub(crate) async fn materialize_session_history(session: &Session) -> Result<Vec<PathBuf>> {
+    let dir = history_dir_for_session(session)?;
+    match fs::remove_dir_all(&dir).await {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err).with_context(|| format!("remove {}", dir.display())),
+    }
+    fs::create_dir_all(&dir)
+        .await
+        .with_context(|| format!("create {}", dir.display()))?;
+
+    let mut paths = Vec::with_capacity(session.history().len());
+    for (idx, msg) in session.history().iter().enumerate() {
+        let path = format_turn_path(&dir, idx, role_label(&msg.role));
+        fs::write(&path, render_turn(msg))
+            .await
+            .with_context(|| format!("write {}", path.display()))?;
+        paths.push(path);
+    }
+    Ok(paths)
+}
+
+fn workspace_data_dir(workspace: Option<&Path>) -> PathBuf {
+    workspace
+        .map(|start| {
+            start
+                .ancestors()
+                .find(|path| path.join(".git").exists())
+                .unwrap_or(start)
+                .join(".codetether-agent")
+        })
+        .or_else(crate::config::Config::data_dir)
+        .unwrap_or_else(|| PathBuf::from(".codetether-agent"))
+}

--- a/src/session/history_files.rs
+++ b/src/session/history_files.rs
@@ -1,5 +1,7 @@
 //! Materialized turn files for filesystem-style history browsing.
 
+use std::collections::HashSet;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -64,24 +66,58 @@ pub(crate) fn history_dir_for_session(session: &Session) -> Result<PathBuf> {
 
 pub(crate) async fn materialize_session_history(session: &Session) -> Result<Vec<PathBuf>> {
     let dir = history_dir_for_session(session)?;
-    match fs::remove_dir_all(&dir).await {
-        Ok(()) => {}
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => return Err(err).with_context(|| format!("remove {}", dir.display())),
-    }
     fs::create_dir_all(&dir)
         .await
         .with_context(|| format!("create {}", dir.display()))?;
 
     let mut paths = Vec::with_capacity(session.history().len());
+    let mut expected = HashSet::with_capacity(session.history().len());
     for (idx, msg) in session.history().iter().enumerate() {
         let path = format_turn_path(&dir, idx, role_label(&msg.role));
-        fs::write(&path, render_turn(msg))
-            .await
-            .with_context(|| format!("write {}", path.display()))?;
+        let body = render_turn(msg);
+        write_turn_if_changed(&path, &body).await?;
+        expected.insert(file_name(&path)?);
         paths.push(path);
     }
+    prune_stale_turn_files(&dir, &expected).await?;
     Ok(paths)
+}
+
+async fn write_turn_if_changed(path: &Path, body: &str) -> Result<()> {
+    match fs::read_to_string(path).await {
+        Ok(existing) if existing == body => return Ok(()),
+        Ok(_) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err).with_context(|| format!("read {}", path.display())),
+    }
+    fs::write(path, body)
+        .await
+        .with_context(|| format!("write {}", path.display()))
+}
+
+async fn prune_stale_turn_files(dir: &Path, expected: &HashSet<OsString>) -> Result<()> {
+    let mut entries = fs::read_dir(dir)
+        .await
+        .with_context(|| format!("read_dir {}", dir.display()))?;
+    while let Some(entry) = entries.next_entry().await? {
+        let file_type = entry.file_type().await?;
+        if !file_type.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        if !expected.contains(&name) {
+            fs::remove_file(entry.path())
+                .await
+                .with_context(|| format!("remove {}", entry.path().display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn file_name(path: &Path) -> Result<OsString> {
+    path.file_name()
+        .map(|name| name.to_os_string())
+        .context("materialized history path missing file name")
 }
 
 fn workspace_data_dir(workspace: Option<&Path>) -> PathBuf {

--- a/src/session/journal.rs
+++ b/src/session/journal.rs
@@ -234,10 +234,14 @@ pub async fn append_entries(session_id: &str, entries: &[JournalEntry]) -> anyho
         .append(true)
         .open(&path)
         .await?;
+    let mut batch = Vec::new();
     for entry in entries {
         let line = serde_json::to_string(entry)?;
-        file.write_all(line.as_bytes()).await?;
-        file.write_all(b"\n").await?;
+        batch.extend_from_slice(line.as_bytes());
+        batch.push(b'\n');
+    }
+    if !batch.is_empty() {
+        file.write_all(&batch).await?;
     }
     file.flush().await?;
     Ok(())

--- a/src/session/journal.rs
+++ b/src/session/journal.rs
@@ -51,6 +51,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use tokio::io::AsyncWriteExt;
 
 /// Opaque handle returned from [`WritebackJournal::stage`] and required
 /// by [`WritebackJournal::validate`] / [`WritebackJournal::commit`].
@@ -216,6 +217,30 @@ impl WritebackJournal {
     pub fn pending_count(&self) -> usize {
         self.pending.len()
     }
+}
+
+/// Append journal entries to `<session-id>.journal.jsonl`.
+///
+/// Best-effort durability helper used by lifecycle call sites such as
+/// `Session::save`. The journal remains append-only: callers hand us a
+/// pre-built ordered slice and we stream it as JSONL.
+pub async fn append_entries(session_id: &str, entries: &[JournalEntry]) -> anyhow::Result<()> {
+    let path = crate::session::Session::sessions_dir()?.join(format!("{session_id}.journal.jsonl"));
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await?;
+    for entry in entries {
+        let line = serde_json::to_string(entry)?;
+        file.write_all(line.as_bytes()).await?;
+        file.write_all(b"\n").await?;
+    }
+    file.flush().await?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/session/lifecycle.rs
+++ b/src/session/lifecycle.rs
@@ -10,6 +10,7 @@ use crate::agent::ToolUse;
 use crate::provenance::{ClaimProvenance, ExecutionProvenance};
 use crate::provider::{Message, Usage};
 
+use super::pages::{PageKind, classify, classify_all};
 use super::types::{Session, SessionMetadata};
 
 impl Session {
@@ -35,6 +36,9 @@ impl Session {
         let id = Uuid::new_v4().to_string();
         let now = Utc::now();
         let provenance = Some(ExecutionProvenance::for_session(&id, "build"));
+        let history_sink = crate::session::history_sink::HistorySinkConfig::from_env()
+            .ok()
+            .flatten();
 
         Ok(Self {
             id,
@@ -42,12 +46,14 @@ impl Session {
             created_at: now,
             updated_at: now,
             messages: Vec::new(),
+            pages: Vec::new(),
             tool_uses: Vec::<ToolUse>::new(),
             usage: Usage::default(),
             agent: "build".to_string(),
             metadata: SessionMetadata {
                 directory: Some(std::env::current_dir()?),
                 provenance,
+                history_sink,
                 ..Default::default()
             },
             max_steps: None,
@@ -65,6 +71,21 @@ impl Session {
     pub(crate) fn attach_global_bus_if_missing(&mut self) {
         if self.bus.is_none() {
             self.bus = crate::bus::global();
+        }
+    }
+
+    /// Rebuild / hydrate runtime sidecars that legacy sessions do not
+    /// carry on disk.
+    pub(crate) fn normalize_sidecars(&mut self) {
+        self.attach_global_bus_if_missing();
+        if self.pages.len() != self.messages.len() {
+            self.pages = classify_all(&self.messages);
+        }
+        if self.metadata.history_sink.is_none() {
+            self.metadata.history_sink =
+                crate::session::history_sink::HistorySinkConfig::from_env()
+                    .ok()
+                    .flatten();
         }
     }
 
@@ -192,6 +213,10 @@ impl Session {
 
     /// Append a message to the transcript and bump `updated_at`.
     pub fn add_message(&mut self, message: Message) {
+        if self.pages.len() != self.messages.len() {
+            self.pages = classify_all(&self.messages);
+        }
+        self.pages.push(classify(&message));
         self.messages.push(message);
         self.updated_at = Utc::now();
     }
@@ -218,6 +243,11 @@ impl Session {
         &self.messages
     }
 
+    /// Borrow the per-message page sidecar.
+    pub fn pages(&self) -> &[PageKind] {
+        &self.pages
+    }
+
     /// Borrow the chat-history transcript as an append-only
     /// [`History`](super::history::History) handle.
     ///
@@ -226,6 +256,6 @@ impl Session {
     /// that would violate the Phase A invariant (destructive in-place
     /// rewrite) is not reachable through this API surface.
     pub fn history_mut(&mut self) -> super::history::History<'_> {
-        super::history::History::new(&mut self.messages)
+        super::history::History::with_pages(&mut self.messages, &mut self.pages)
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -49,6 +49,7 @@ mod event_rlm;
 mod event_token;
 mod events;
 mod header;
+pub(crate) mod history_files;
 mod lifecycle;
 mod persistence;
 mod prompt_api;
@@ -81,7 +82,7 @@ pub use self::bus::{DurableSink, NoopSink, SessionBus};
 pub use self::codex_import::{
     import_codex_session_by_id, import_codex_sessions_for_directory, load_or_import_session,
 };
-pub use self::context::{DerivedContext, derive_context, derive_with_policy};
+pub use self::context::{DerivedContext, derive_context, derive_with_policy, effective_policy};
 pub use self::delegation::{BetaPosterior, DelegationConfig, DelegationState};
 pub use self::derive_policy::DerivePolicy;
 pub use self::eval::{PolicyRunResult, pareto_frontier, reuse_rate};
@@ -99,7 +100,9 @@ pub use self::listing::{SessionSummary, list_sessions};
 pub use self::listing_all::list_all_sessions_for_directory;
 pub use self::oracle::{OracleReport, replay_oracle};
 pub use self::pages::{PageKind, ResidencyLevel};
-pub use self::relevance::{Bucket, Dependency, Difficulty, RelevanceMeta, ToolUse};
+pub use self::relevance::{
+    Bucket, Dependency, Difficulty, RelevanceMeta, ToolUse, bucket_for_messages,
+};
 pub use self::tail_load::TailLoad;
 pub use self::tasks::{TaskEvent, TaskLog, TaskState, TaskStatus};
 pub use self::types::{DEFAULT_MAX_STEPS, ImageAttachment, Session, SessionMetadata};

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -20,7 +20,8 @@ impl Session {
     pub async fn load(id: &str) -> Result<Self> {
         let path = Self::session_path(id)?;
         let content = fs::read_to_string(&path).await?;
-        let session: Session = serde_json::from_str(&content)?;
+        let mut session: Session = serde_json::from_str(&content)?;
+        session.normalize_sidecars();
         Ok(session)
     }
 
@@ -93,7 +94,14 @@ impl Session {
         // Clone-and-serialize off the reactor. The clone is a Vec-copy
         // (~memcpy speed) which is always cheaper than the JSON
         // formatting we are about to avoid blocking the reactor on.
-        let snapshot = self.clone();
+        let mut snapshot = self.clone();
+        snapshot.normalize_sidecars();
+        let sink_config = snapshot.metadata.history_sink.clone().or_else(|| {
+            super::history_sink::HistorySinkConfig::from_env()
+                .ok()
+                .flatten()
+        });
+        let session_id_for_journal = snapshot.id.clone();
         let content = tokio::task::spawn_blocking(move || serde_json::to_vec(&snapshot))
             .await
             .map_err(|e| anyhow::anyhow!("session serialize task panicked: {e}"))??;
@@ -108,6 +116,20 @@ impl Session {
                     "session rename failed: {primary} (retry: {retry})"
                 ));
             }
+        }
+        let mut journal = super::journal::WritebackJournal::new(&session_id_for_journal);
+        let tx = journal.stage(super::journal::Op::Save);
+        if let Err(reason) = journal.commit(tx) {
+            journal.reject(tx, reason);
+        }
+        if let Err(err) =
+            super::journal::append_entries(&session_id_for_journal, journal.entries()).await
+        {
+            tracing::warn!(
+                %err,
+                session_id = %session_id_for_journal,
+                "save journal append failed (non-fatal)"
+            );
         }
         // Update the workspace index so the next resume is O(1). Best
         // effort — a failed index write must not fail the session save.
@@ -129,7 +151,7 @@ impl Session {
         // save will pick up the latest history. This prevents bursty
         // save loops (e.g. during long tool chains) from queueing
         // unbounded background uploads.
-        if let Ok(Some(sink_config)) = super::history_sink::HistorySinkConfig::from_env() {
+        if let Some(sink_config) = sink_config {
             use std::collections::HashSet;
             use std::sync::{Mutex, OnceLock};
             static IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
@@ -257,8 +279,10 @@ fn tail_load_sync(path: &Path, window: usize) -> Result<TailLoad> {
     let file = fs::File::open(path)?;
     let reader = BufReader::with_capacity(64 * 1024, file);
     let (parsed, dropped) = with_tail_cap(window, || serde_json::from_reader::<_, Session>(reader));
+    let mut session = parsed?;
+    session.normalize_sidecars();
     Ok(TailLoad {
-        session: parsed?,
+        session,
         dropped,
         file_bytes,
     })

--- a/src/session/relevance.rs
+++ b/src/session/relevance.rs
@@ -242,6 +242,27 @@ pub fn extract(msg: &Message) -> RelevanceMeta {
     meta
 }
 
+/// Project a coarse CADMAS-CTX bucket from a recent message window.
+///
+/// Merges the last few entries into a single synthetic
+/// [`RelevanceMeta`] so routing decisions can key off the active task
+/// rather than a single arbitrary turn.
+pub fn bucket_for_messages(messages: &[Message]) -> Bucket {
+    let start = messages.len().saturating_sub(8);
+    let mut merged = RelevanceMeta::default();
+    for msg in &messages[start..] {
+        let next = extract(msg);
+        merged.files.extend(next.files);
+        merged.tools.extend(next.tools);
+        merged.error_classes.extend(next.error_classes);
+        merged.explicit_refs.extend(next.explicit_refs);
+    }
+    dedupe_preserving_order(&mut merged.files);
+    dedupe_preserving_order(&mut merged.tools);
+    dedupe_preserving_order(&mut merged.error_classes);
+    merged.project_bucket()
+}
+
 /// Extract path-like tokens from `text` and append unique ones to `out`.
 ///
 /// Heuristic: tokens that look like filesystem paths (contain `/` but
@@ -380,5 +401,17 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(meta.project_bucket().difficulty, Difficulty::Hard);
+    }
+
+    #[test]
+    fn bucket_for_messages_merges_recent_window() {
+        let bucket = bucket_for_messages(&[
+            text("edited src/lib.rs"),
+            tool_call("Shell"),
+            tool_result("Error: broken"),
+        ]);
+        assert_eq!(bucket.tool_use, ToolUse::Yes);
+        assert_eq!(bucket.dependency, Dependency::Chained);
+        assert_eq!(bucket.difficulty, Difficulty::Medium);
     }
 }

--- a/src/session/tail_load.rs
+++ b/src/session/tail_load.rs
@@ -53,8 +53,10 @@ fn parse_tail(path: &Path, window: usize) -> Result<TailLoad> {
         serde_json::from_reader::<_, Session>(reader)
             .with_context(|| format!("parse session file {}", path.display()))
     });
+    let mut session = parsed?;
+    session.normalize_sidecars();
     Ok(TailLoad {
-        session: parsed?,
+        session,
         dropped,
         file_bytes,
     })

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -11,6 +11,10 @@ use serde::{Deserialize, Serialize};
 use crate::agent::ToolUse;
 use crate::provenance::ExecutionProvenance;
 use crate::provider::{Message, Usage};
+use crate::session::delegation::DelegationState;
+use crate::session::derive_policy::DerivePolicy;
+use crate::session::history_sink::HistorySinkConfig;
+use crate::session::pages::PageKind;
 
 /// Default maximum agentic loop iterations when [`Session::max_steps`] is
 /// `None`.
@@ -64,6 +68,12 @@ pub struct Session {
     /// Ordered conversation transcript.
     #[serde(deserialize_with = "crate::session::tail_seed::deserialize_tail_vec")]
     pub messages: Vec<Message>,
+    /// Per-message page classification sidecar.
+    ///
+    /// Backfilled on load for legacy sessions that predate the
+    /// history/context split.
+    #[serde(default)]
+    pub pages: Vec<PageKind>,
     /// Per-tool-call audit records.
     #[serde(deserialize_with = "crate::session::tail_seed::deserialize_tail_vec")]
     pub tool_uses: Vec<ToolUse>,
@@ -114,6 +124,21 @@ pub struct SessionMetadata {
     /// [`crate::rlm::RlmConfig::default`].
     #[serde(default)]
     pub rlm: crate::rlm::RlmConfig,
+    /// Per-session context derivation policy.
+    ///
+    /// Defaults to [`DerivePolicy::Legacy`]. The prompt loop can still
+    /// override this at runtime via `CODETETHER_CONTEXT_POLICY`.
+    #[serde(default)]
+    pub context_policy: DerivePolicy,
+    /// CADMAS-CTX routing posteriors for this session.
+    #[serde(default)]
+    pub delegation: DelegationState,
+    /// Runtime MinIO / S3 history sink configuration.
+    ///
+    /// Intentionally not serialized: carrying live access keys inside the
+    /// session JSON would persist secrets to disk.
+    #[serde(skip)]
+    pub history_sink: Option<HistorySinkConfig>,
     /// Pre-resolved subcall provider from
     /// [`RlmConfig::subcall_model`](crate::rlm::RlmConfig::subcall_model).
     ///
@@ -142,6 +167,15 @@ impl std::fmt::Debug for SessionMetadata {
             .field("shared", &self.shared)
             .field("share_url", &self.share_url)
             .field("rlm", &self.rlm)
+            .field("context_policy", &self.context_policy)
+            .field("delegation", &self.delegation)
+            .field(
+                "history_sink",
+                &self
+                    .history_sink
+                    .as_ref()
+                    .map(|cfg| (&cfg.endpoint, &cfg.bucket, &cfg.prefix)),
+            )
             .field(
                 "subcall_provider",
                 &self.subcall_provider.as_ref().map(|_| "<provider>"),

--- a/src/tool/context_browse.rs
+++ b/src/tool/context_browse.rs
@@ -1,4 +1,4 @@
-//! `context_browse`: expose the session transcript as virtual files.
+//! `context_browse`: expose the session transcript as real turn files.
 //!
 //! ## Meta-Harness filesystem-as-history (Phase B step 21)
 //!
@@ -11,16 +11,16 @@
 //! "may even hurt by compressing away diagnostically useful details".
 //!
 //! This tool gives the agent the same primitive over *its own past
-//! turns*. Every entry in [`Session::messages`] is exposed as a path
-//! of the form:
+//! turns*. Every entry in [`Session::messages`] is materialized as a file
+//! under the workspace data dir:
 //!
 //! ```text
-//! session://<session-id>/turn-NNNN-<role>.md
+//! .codetether-agent/history/<session-id>/turn-NNNN-<role>.md
 //! ```
 //!
-//! The agent's existing Shell / Read / Grep tools can already browse
-//! these paths once Phase A's history-sink backing store is populated;
-//! this tool is the *list + locate* layer on top of it.
+//! The agent's existing Shell / Read / Grep tools can browse those files
+//! directly after this tool materializes them; this tool is the *list +
+//! locate* layer on top of that directory.
 //!
 //! ## What it does
 //!
@@ -42,14 +42,14 @@
 //! ## Examples
 //!
 //! ```rust
-//! use codetether_agent::tool::context_browse::{
-//!     ContextBrowseAction, format_turn_path, parse_browse_action,
-//! };
+//! use std::path::Path;
+//!
+//! use codetether_agent::tool::context_browse::{ContextBrowseAction, format_turn_path, parse_browse_action};
 //! use serde_json::json;
 //!
 //! assert_eq!(
-//!     format_turn_path("abc-123", 7, "user"),
-//!     "session://abc-123/turn-0007-user.md",
+//!     format_turn_path(Path::new("/tmp/history/abc-123"), 7, "user"),
+//!     Path::new("/tmp/history/abc-123/turn-0007-user.md"),
 //! );
 //!
 //! let action = parse_browse_action(&json!({})).unwrap();
@@ -60,11 +60,13 @@
 //! ```
 
 use super::{Tool, ToolResult};
-use crate::provider::{ContentPart, Message, Role};
+use crate::session::Fault;
 use crate::session::Session;
+use crate::session::history_files::{materialize_session_history, render_turn};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
 
 /// Parsed form of the JSON `args` payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,67 +97,18 @@ pub fn parse_browse_action(args: &Value) -> Result<ContextBrowseAction, String> 
     }
 }
 
-/// Produce the canonical virtual path for a turn.
-pub fn format_turn_path(session_id: &str, turn: usize, role: &str) -> String {
-    format!("session://{session_id}/turn-{turn:04}-{role}.md")
+/// Produce the canonical materialized filesystem path for a turn.
+pub fn format_turn_path(session_dir: &Path, turn: usize, role: &str) -> PathBuf {
+    crate::session::history_files::format_turn_path(session_dir, turn, role)
 }
 
-/// Lower-case role label used in the path.
-fn role_label(role: &Role) -> &'static str {
-    match role {
-        Role::System => "system",
-        Role::User => "user",
-        Role::Assistant => "assistant",
-        Role::Tool => "tool",
-    }
-}
-
-/// Render a message body as the text the agent would see if it opened
-/// the virtual file. Text and tool-result parts are concatenated in
-/// order; non-textual parts are replaced by a short placeholder so the
-/// path stays readable.
-fn render_turn(msg: &Message) -> String {
-    let mut buf = String::new();
-    for part in &msg.content {
-        if !buf.is_empty() {
-            buf.push_str("\n\n");
-        }
-        match part {
-            ContentPart::Text { text } => buf.push_str(text),
-            ContentPart::ToolResult {
-                tool_call_id,
-                content,
-            } => {
-                buf.push_str(&format!("[tool_result tool_call_id={tool_call_id}]\n"));
-                buf.push_str(content);
-            }
-            ContentPart::ToolCall {
-                name, arguments, ..
-            } => {
-                buf.push_str(&format!("[tool_call {name}]\n{arguments}"));
-            }
-            ContentPart::Image { url, .. } => {
-                buf.push_str(&format!("[image {url}]"));
-            }
-            ContentPart::File { path, .. } => {
-                buf.push_str(&format!("[file {path}]"));
-            }
-            ContentPart::Thinking { text } => {
-                buf.push_str(&format!("[thinking]\n{text}"));
-            }
-        }
-    }
-    buf
-}
-
-/// Render a listing of virtual paths, one per line.
-fn render_listing(session_id: &str, messages: &[Message]) -> String {
-    let mut out = String::new();
-    for (idx, msg) in messages.iter().enumerate() {
-        out.push_str(&format_turn_path(session_id, idx, role_label(&msg.role)));
-        out.push('\n');
-    }
-    out
+/// Render a listing of materialized paths, one per line.
+fn render_listing(paths: &[PathBuf]) -> String {
+    paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Meta-Harness filesystem-as-history tool.
@@ -173,11 +126,11 @@ impl Tool for ContextBrowseTool {
 
     fn description(&self) -> &str {
         "BROWSE YOUR OWN HISTORY AS A FILESYSTEM (Meta-Harness, \
-         arXiv:2603.28052). Lists virtual paths like \
-         `session://<id>/turn-NNNN-<role>.md` — one per turn in the \
-         canonical transcript — and returns the body of any specific \
-         turn on request. Use this when the active context doesn't \
-         have what you need but you suspect it was said earlier. \
+         arXiv:2603.28052). Materializes real files under \
+         `.codetether-agent/history/<session-id>/turn-NNNN-<role>.md` \
+         — one per turn in the canonical transcript — and returns the \
+         body of any specific turn on request. Use this when the active \
+         context doesn't have what you need but you suspect it was said earlier. \
          Distinct from `session_recall` (RLM-summarised archive) and \
          `memory` (curated notes). Actions: `list` (default) or \
          `show_turn` with an integer `turn`."
@@ -212,30 +165,63 @@ impl Tool for ContextBrowseTool {
         let session = match latest_session_for_cwd().await {
             Ok(Some(s)) => s,
             Ok(None) => {
-                return Ok(ToolResult::error(
+                return Ok(fault_result(
+                    Fault::NoMatch,
                     "No session found for the current workspace.",
                 ));
             }
-            Err(e) => return Ok(ToolResult::error(format!("failed to load session: {e}"))),
+            Err(e) => {
+                return Ok(fault_result(
+                    Fault::BackendError {
+                        reason: e.to_string(),
+                    },
+                    format!("failed to load session: {e}"),
+                ));
+            }
+        };
+        let paths = match materialize_session_history(&session).await {
+            Ok(paths) => paths,
+            Err(err) => {
+                return Ok(fault_result(
+                    Fault::BackendError {
+                        reason: err.to_string(),
+                    },
+                    format!("failed to materialize history files: {err}"),
+                ));
+            }
         };
         let messages = session.history();
         match action {
-            ContextBrowseAction::ListTurns => {
-                Ok(ToolResult::success(render_listing(&session.id, messages))
-                    .truncate_to(super::tool_output_budget()))
-            }
-            ContextBrowseAction::ShowTurn { turn } => {
-                match messages.get(turn) {
-                    Some(msg) => Ok(ToolResult::success(render_turn(msg))
-                        .truncate_to(super::tool_output_budget())),
-                    None => Ok(ToolResult::error(format!(
-                        "turn {turn} out of range (have {} entries)",
-                        messages.len()
-                    ))),
-                }
-            }
+            ContextBrowseAction::ListTurns => Ok(ToolResult::success(render_listing(&paths))
+                .with_metadata("session_id", json!(session.id))
+                .truncate_to(super::tool_output_budget())),
+            ContextBrowseAction::ShowTurn { turn } => match messages.get(turn) {
+                Some(msg) => Ok(ToolResult::success(render_turn(msg))
+                    .with_metadata(
+                        "path",
+                        json!(
+                            paths
+                                .get(turn)
+                                .map(|path| path.display().to_string())
+                                .unwrap_or_else(String::new)
+                        ),
+                    )
+                    .truncate_to(super::tool_output_budget())),
+                None => Ok(ToolResult::error(format!(
+                    "turn {turn} out of range (have {} entries)",
+                    messages.len()
+                ))),
+            },
         }
     }
+}
+
+fn fault_result(fault: Fault, output: impl Into<String>) -> ToolResult {
+    let code = fault.code();
+    let detail = fault.to_string();
+    ToolResult::error(output)
+        .with_metadata("fault_code", json!(code))
+        .with_metadata("fault_detail", json!(detail))
 }
 
 /// Resolve the session this tool should browse.
@@ -277,6 +263,7 @@ async fn latest_session_for_cwd() -> Result<Option<Session>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn parse_browse_action_defaults_to_list() {
@@ -297,43 +284,24 @@ mod tests {
     }
 
     #[test]
-    fn format_turn_path_pads_index_to_four_digits() {
+    fn format_turn_path_uses_real_filesystem_paths() {
+        let path0 = format_turn_path(Path::new("/tmp/history/sid"), 0, "user");
+        let path = format_turn_path(Path::new("/tmp/history/sid"), 7, "assistant");
+        assert_eq!(path0, PathBuf::from("/tmp/history/sid/turn-0000-user.md"));
         assert_eq!(
-            format_turn_path("abc-123", 0, "user"),
-            "session://abc-123/turn-0000-user.md"
+            path,
+            PathBuf::from("/tmp/history/sid/turn-0007-assistant.md")
         );
-        assert_eq!(
-            format_turn_path("abc-123", 9999, "assistant"),
-            "session://abc-123/turn-9999-assistant.md"
-        );
-    }
-
-    fn text(role: Role, s: &str) -> Message {
-        Message {
-            role,
-            content: vec![ContentPart::Text {
-                text: s.to_string(),
-            }],
-        }
     }
 
     #[test]
     fn render_listing_emits_one_path_per_turn() {
-        let msgs = vec![
-            text(Role::User, "hi"),
-            text(Role::Assistant, "hello"),
-            text(Role::User, "more"),
-        ];
-        let listing = render_listing("sid", &msgs);
-        assert_eq!(listing.lines().count(), 3);
-        assert!(listing.contains("session://sid/turn-0000-user.md"));
-        assert!(listing.contains("session://sid/turn-0001-assistant.md"));
-        assert!(listing.contains("session://sid/turn-0002-user.md"));
-    }
-
-    #[test]
-    fn render_turn_preserves_text_body() {
-        let body = render_turn(&text(Role::User, "quick brown fox"));
-        assert_eq!(body, "quick brown fox");
+        let listing = render_listing(&[
+            PathBuf::from("/tmp/history/sid/turn-0000-user.md"),
+            PathBuf::from("/tmp/history/sid/turn-0001-assistant.md"),
+        ]);
+        assert_eq!(listing.lines().count(), 2);
+        assert!(listing.contains("/tmp/history/sid/turn-0000-user.md"));
+        assert!(listing.contains("/tmp/history/sid/turn-0001-assistant.md"));
     }
 }

--- a/src/tool/session_recall.rs
+++ b/src/tool/session_recall.rs
@@ -19,6 +19,7 @@ use super::{Tool, ToolResult};
 use crate::provider::Provider;
 use crate::rlm::router::AutoProcessContext;
 use crate::rlm::{RlmConfig, RlmRouter};
+use crate::session::Fault;
 use crate::session::Session;
 use crate::session::helper::error::messages_to_rlm_context;
 use anyhow::Result;
@@ -115,12 +116,16 @@ impl Tool for SessionRecallTool {
 
         let (context, sources) = match build_recall_context(session_id, limit).await {
             Ok(ok) => ok,
-            Err(e) => return Ok(ToolResult::error(format!("recall load failed: {e}"))),
+            Err(e) => {
+                let fault = fault_from_error(&e);
+                return Ok(fault_result(fault, format!("recall load failed: {e}")));
+            }
         };
 
         if context.trim().is_empty() {
-            return Ok(ToolResult::success(
-                "No prior session history found for this workspace.".to_string(),
+            return Ok(fault_result(
+                Fault::NoMatch,
+                "No prior session history found for this workspace.",
             ));
         }
 
@@ -134,6 +139,27 @@ impl Tool for SessionRecallTool {
         )
         .await
     }
+}
+
+fn fault_from_error(err: &anyhow::Error) -> Fault {
+    let message = err.to_string();
+    let lowered = message.to_ascii_lowercase();
+    if lowered.contains("no session")
+        || lowered.contains("not found")
+        || lowered.contains("no such file")
+    {
+        Fault::NoMatch
+    } else {
+        Fault::BackendError { reason: message }
+    }
+}
+
+fn fault_result(fault: Fault, output: impl Into<String>) -> ToolResult {
+    let code = fault.code();
+    let detail = fault.to_string();
+    ToolResult::error(output)
+        .with_metadata("fault_code", json!(code))
+        .with_metadata("fault_detail", json!(detail))
 }
 
 /// Load session transcripts and flatten them into an RLM-ready string.
@@ -227,6 +253,11 @@ async fn run_recall(
             result.stats.iterations,
             result.processed
         ))),
-        Err(e) => Ok(ToolResult::error(format!("RLM recall failed: {e}"))),
+        Err(e) => Ok(fault_result(
+            Fault::BackendError {
+                reason: e.to_string(),
+            },
+            format!("RLM recall failed: {e}"),
+        )),
     }
 }

--- a/src/tui/app/commands.rs
+++ b/src/tui/app/commands.rs
@@ -348,6 +348,7 @@ async fn handle_undo_command(app: &mut App, session: &mut Session, rest: &str) {
     let t_cut = tui_user_idxs[available - undo_count];
 
     session.messages.truncate(s_cut);
+    session.pages.truncate(s_cut);
     app.state.messages.truncate(t_cut);
     session.updated_at = chrono::Utc::now();
     app.state.streaming_text.clear();
@@ -442,12 +443,20 @@ async fn handle_fork_command(app: &mut App, _cwd: &Path, session: &mut Session, 
     };
 
     child.messages = session.messages[..session_cut].to_vec();
+    child.pages = if session.pages.len() >= session_cut {
+        session.pages[..session_cut].to_vec()
+    } else {
+        crate::session::pages::classify_all(&child.messages)
+    };
     child.metadata.auto_apply_edits = session.metadata.auto_apply_edits;
     child.metadata.allow_network = session.metadata.allow_network;
     child.metadata.slash_autocomplete = session.metadata.slash_autocomplete;
     child.metadata.use_worktree = session.metadata.use_worktree;
     child.metadata.model = session.metadata.model.clone();
     child.metadata.rlm = session.metadata.rlm.clone();
+    child.metadata.context_policy = session.metadata.context_policy;
+    child.metadata.delegation = session.metadata.delegation.clone();
+    child.metadata.history_sink = session.metadata.history_sink.clone();
     child.title = session
         .title
         .as_ref()

--- a/src/tui/app/message_text.rs
+++ b/src/tui/app/message_text.rs
@@ -47,6 +47,9 @@ fn session_messages_to_chat_messages(session: &Session) -> Vec<ChatMessage> {
     let mut tool_call_names = HashMap::new();
 
     for message in session.history() {
+        if is_hidden_context_marker(message) {
+            continue;
+        }
         chat_messages.extend(chat_messages_from_provider_message(
             message,
             &mut tool_call_names,
@@ -54,6 +57,17 @@ fn session_messages_to_chat_messages(session: &Session) -> Vec<ChatMessage> {
     }
 
     chat_messages
+}
+
+fn is_hidden_context_marker(message: &Message) -> bool {
+    matches!(
+        (&message.role, message.content.as_slice()),
+        (
+            Role::Assistant,
+            [ContentPart::Text { text }]
+        ) if text.starts_with("[AUTO CONTEXT COMPRESSION]")
+            || text.starts_with("[CONTEXT TRUNCATED]")
+    )
 }
 
 fn chat_messages_from_provider_message(

--- a/src/tui/app/run.rs
+++ b/src/tui/app/run.rs
@@ -43,13 +43,25 @@ enum SessionLoadOutcome {
 /// prior session. Older entries are dropped to bound startup memory; the
 /// user is notified in the status line when truncation occurs.
 const DEFAULT_SESSION_RESUME_WINDOW: usize = 1_000;
+const MAX_SESSION_RESUME_WINDOW: usize = 10_000;
 
 fn session_resume_window() -> usize {
-    std::env::var("CODETETHER_SESSION_RESUME_WINDOW")
+    let parsed = std::env::var("CODETETHER_SESSION_RESUME_WINDOW")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_SESSION_RESUME_WINDOW)
+        .filter(|value| *value > 0);
+    match parsed {
+        Some(value) if value > MAX_SESSION_RESUME_WINDOW => {
+            tracing::warn!(
+                requested = value,
+                clamped = MAX_SESSION_RESUME_WINDOW,
+                "session resume window too large; clamping"
+            );
+            MAX_SESSION_RESUME_WINDOW
+        }
+        Some(value) => value,
+        None => DEFAULT_SESSION_RESUME_WINDOW,
+    }
 }
 
 async fn init_tui_secrets_manager() {

--- a/src/tui/app/run.rs
+++ b/src/tui/app/run.rs
@@ -39,10 +39,18 @@ enum SessionLoadOutcome {
     },
 }
 
-/// Number of trailing messages + tool uses kept when resuming a prior
-/// session. Older entries are dropped to bound startup memory; the user
-/// is notified in the status line when truncation occurs.
-const SESSION_RESUME_WINDOW: usize = 200;
+/// Default number of trailing messages + tool uses kept when resuming a
+/// prior session. Older entries are dropped to bound startup memory; the
+/// user is notified in the status line when truncation occurs.
+const DEFAULT_SESSION_RESUME_WINDOW: usize = 1_000;
+
+fn session_resume_window() -> usize {
+    std::env::var("CODETETHER_SESSION_RESUME_WINDOW")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_SESSION_RESUME_WINDOW)
+}
 
 async fn init_tui_secrets_manager() {
     if crate::secrets::secrets_manager().is_some() {
@@ -149,9 +157,10 @@ pub async fn run(project: Option<std::path::PathBuf>, allow_network: bool) -> an
     // the budget we start a fresh session; the scan task is detached and
     // its result (if any) is simply dropped.
     const SESSION_SCAN_BUDGET: std::time::Duration = std::time::Duration::from_secs(3);
+    let resume_window = session_resume_window();
     let session_task = tokio::time::timeout(
         SESSION_SCAN_BUDGET,
-        Session::last_for_directory_tail(Some(&cwd), SESSION_RESUME_WINDOW),
+        Session::last_for_directory_tail(Some(&cwd), resume_window),
     );
     let config_task = crate::config::Config::load();
     let workspace_task = tokio::task::spawn_blocking({


### PR DESCRIPTION
## Summary
- stop default lossy history transforms and disable message-count-only RLM compaction
- wire policy-driven session derivation, live `[CONTEXT RESET]` handling, and persisted session sidecars for pages/delegation/history browsing
- fix in-process provider failover so prompt loops update live provider/model state instead of only mutating session metadata

## Notes
- did not run `cargo build`, `cargo check`, or `cargo test`
- branch intentionally excludes unrelated local edits in `src/search/model.rs` and `src/telemetry/rss_watchdog.rs`