### PR TITLE
fix: close open installer and crash issues

### DIFF
--- a/npm/codetether/lib/darwin_tls.js
+++ b/npm/codetether/lib/darwin_tls.js
@@ -1,0 +1,55 @@
+const https = require('node:https');
+const tls = require('node:tls');
+const { execSync } = require('node:child_process');
+
+const DARWIN_CERT_CMD =
+  'security find-certificate -a -p /Library/Keychains/System.keychain ' +
+  '/System/Library/Keychains/SystemRootCertificates.keychain';
+
+let cachedCa;
+let cachedAgent;
+
+function isDarwin() {
+  return process.platform === 'darwin';
+}
+
+function loadDarwinCaBundle() {
+  if (!isDarwin()) {
+    return null;
+  }
+
+  if (cachedCa !== undefined) {
+    return cachedCa;
+  }
+
+  try {
+    const systemRoots = execSync(DARWIN_CERT_CMD, {
+      encoding: 'utf8',
+      timeout: 10_000,
+      maxBuffer: 8 * 1024 * 1024,
+    }).trim();
+    cachedCa = systemRoots ? [...tls.rootCertificates, systemRoots].join('\n') : null;
+  } catch {
+    cachedCa = null;
+  }
+
+  return cachedCa;
+}
+
+function tlsOptions() {
+  if (!isDarwin()) {
+    return {};
+  }
+
+  if (cachedAgent !== undefined) {
+    return cachedAgent ? { agent: cachedAgent } : {};
+  }
+
+  const ca = loadDarwinCaBundle();
+  cachedAgent = ca ? new https.Agent({ ca }) : null;
+  return cachedAgent ? { agent: cachedAgent } : {};
+}
+
+module.exports = {
+  tlsOptions,
+};

--- a/npm/codetether/lib/http.js
+++ b/npm/codetether/lib/http.js
@@ -1,0 +1,134 @@
+const fs = require('node:fs');
+const https = require('node:https');
+const { tlsOptions: defaultTlsOptions } = require('./darwin_tls');
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function requestOptions(headers, tlsOptionsFn) {
+  return {
+    ...tlsOptionsFn(),
+    headers: {
+      'User-Agent': 'codetether-npx',
+      Accept: '*/*',
+      ...headers,
+    },
+  };
+}
+
+function resolveRedirectUrl(currentUrl, location) {
+  return new URL(location, currentUrl).toString();
+}
+
+function getWithRedirects(url, headers, handleResponse, deps = {}) {
+  const httpsGet = deps.httpsGet || https.get;
+  const tlsOptions = deps.tlsOptions || defaultTlsOptions;
+
+  return new Promise((resolve, reject) => {
+    const doGet = (currentUrl, redirectsLeft) => {
+      httpsGet(currentUrl, requestOptions(headers, tlsOptions), (res) => {
+        if (res.statusCode && REDIRECT_STATUSES.has(res.statusCode)) {
+          const loc = res.headers.location;
+          if (!loc) {
+            reject(new Error(`Redirect without location from ${currentUrl}`));
+            return;
+          }
+          if (redirectsLeft <= 0) {
+            reject(new Error(`Too many redirects downloading ${url}`));
+            return;
+          }
+          res.resume();
+          doGet(resolveRedirectUrl(currentUrl, loc), redirectsLeft - 1);
+          return;
+        }
+
+        Promise.resolve(handleResponse(res, currentUrl)).then(resolve, reject);
+      }).on('error', reject);
+    };
+
+    doGet(url, 8);
+  });
+}
+
+function requestJson(url, headers = {}, deps = {}) {
+  return getWithRedirects(
+    url,
+    {
+      Accept: 'application/vnd.github+json',
+      ...headers,
+    },
+    (res, currentUrl) =>
+      new Promise((resolve, reject) => {
+        const chunks = [];
+        res.on('data', (d) => chunks.push(d));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8');
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            try {
+              resolve(JSON.parse(body));
+            } catch (e) {
+              reject(new Error(`Failed to parse JSON from ${currentUrl}: ${e.message}`));
+            }
+            return;
+          }
+          reject(new Error(`HTTP ${res.statusCode} fetching ${currentUrl}: ${body.slice(0, 400)}`));
+        });
+      }),
+    deps
+  );
+}
+
+function downloadText(url, deps = {}) {
+  return getWithRedirects(
+    url,
+    {},
+    (res, currentUrl) =>
+      new Promise((resolve, reject) => {
+        const chunks = [];
+        res.on('data', (d) => chunks.push(d));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8');
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            resolve(body);
+            return;
+          }
+          const err = new Error(`HTTP ${res.statusCode} downloading ${currentUrl}: ${body.slice(0, 400)}`);
+          err.statusCode = res.statusCode;
+          reject(err);
+        });
+      }),
+    deps
+  );
+}
+
+function downloadFile(url, destPath, deps = {}) {
+  return getWithRedirects(
+    url,
+    {},
+    (res, currentUrl) =>
+      new Promise((resolve, reject) => {
+        if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+          const chunks = [];
+          res.on('data', (d) => chunks.push(d));
+          res.on('end', () => {
+            const body = Buffer.concat(chunks).toString('utf8');
+            const err = new Error(`HTTP ${res.statusCode} downloading ${currentUrl}: ${body.slice(0, 400)}`);
+            err.statusCode = res.statusCode;
+            reject(err);
+          });
+          return;
+        }
+
+        const out = fs.createWriteStream(destPath);
+        res.pipe(out);
+        out.on('finish', () => out.close(resolve));
+        out.on('error', reject);
+      }),
+    deps
+  );
+}
+
+module.exports = {
+  downloadFile,
+  downloadText,
+  requestJson,
+};

--- a/npm/codetether/lib/http.js
+++ b/npm/codetether/lib/http.js
@@ -20,12 +20,14 @@ function resolveRedirectUrl(currentUrl, location) {
 }
 
 function getWithRedirects(url, headers, handleResponse, deps = {}) {
+  const action = deps.action || 'fetching';
   const httpsGet = deps.httpsGet || https.get;
   const tlsOptions = deps.tlsOptions || defaultTlsOptions;
 
   return new Promise((resolve, reject) => {
     const doGet = (currentUrl, redirectsLeft) => {
       httpsGet(currentUrl, requestOptions(headers, tlsOptions), (res) => {
+        res.on('error', reject);
         if (res.statusCode && REDIRECT_STATUSES.has(res.statusCode)) {
           const loc = res.headers.location;
           if (!loc) {
@@ -33,7 +35,7 @@ function getWithRedirects(url, headers, handleResponse, deps = {}) {
             return;
           }
           if (redirectsLeft <= 0) {
-            reject(new Error(`Too many redirects downloading ${url}`));
+            reject(new Error(`Too many redirects ${action} ${url}`));
             return;
           }
           res.resume();
@@ -73,7 +75,7 @@ function requestJson(url, headers = {}, deps = {}) {
           reject(new Error(`HTTP ${res.statusCode} fetching ${currentUrl}: ${body.slice(0, 400)}`));
         });
       }),
-    deps
+    { ...deps, action: 'fetching' }
   );
 }
 
@@ -96,11 +98,13 @@ function downloadText(url, deps = {}) {
           reject(err);
         });
       }),
-    deps
+    { ...deps, action: 'downloading' }
   );
 }
 
 function downloadFile(url, destPath, deps = {}) {
+  const createWriteStream = deps.createWriteStream || fs.createWriteStream;
+
   return getWithRedirects(
     url,
     {},
@@ -118,12 +122,20 @@ function downloadFile(url, destPath, deps = {}) {
           return;
         }
 
-        const out = fs.createWriteStream(destPath);
+        const out = createWriteStream(destPath);
         res.pipe(out);
-        out.on('finish', () => out.close(resolve));
+        out.on('finish', () =>
+          out.close((err) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            resolve();
+          })
+        );
         out.on('error', reject);
       }),
-    deps
+    { ...deps, action: 'downloading' }
   );
 }
 

--- a/npm/codetether/lib/installer.js
+++ b/npm/codetether/lib/installer.js
@@ -2,9 +2,9 @@ const fs = require('node:fs');
 const fsp = require('node:fs/promises');
 const path = require('node:path');
 const os = require('node:os');
-const https = require('node:https');
 const crypto = require('node:crypto');
 const { spawnSync } = require('node:child_process');
+const { downloadFile, downloadText, requestJson } = require('./http');
 
 function repoFromEnv() {
   return process.env.CODETETHER_GITHUB_REPO || 'rileyseaburg/codetether-agent';
@@ -178,39 +178,6 @@ function canExecute(p) {
   }
 }
 
-function requestJson(url, headers = {}) {
-  return new Promise((resolve, reject) => {
-    https
-      .get(
-        url,
-        {
-          headers: {
-            'User-Agent': 'codetether-npx',
-            Accept: 'application/vnd.github+json',
-            ...headers,
-          },
-        },
-        (res) => {
-          const chunks = [];
-          res.on('data', (d) => chunks.push(d));
-          res.on('end', () => {
-            const body = Buffer.concat(chunks).toString('utf8');
-            if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-              try {
-                resolve(JSON.parse(body));
-              } catch (e) {
-                reject(new Error(`Failed to parse JSON from ${url}: ${e.message}`));
-              }
-              return;
-            }
-            reject(new Error(`HTTP ${res.statusCode} fetching ${url}: ${body.slice(0, 400)}`));
-          });
-        }
-      )
-      .on('error', reject);
-  });
-}
-
 async function getLatestReleaseTag(repo) {
   const data = await requestJson(`https://api.github.com/repos/${repo}/releases/latest`);
   if (!data || !data.tag_name) {
@@ -228,109 +195,6 @@ async function getReleaseAssetNames(repo, tag) {
   return data.assets
     .map((asset) => asset && asset.name)
     .filter((name) => typeof name === 'string' && name.length > 0);
-}
-
-function downloadFile(url, destPath) {
-  return new Promise((resolve, reject) => {
-    const doGet = (u, redirectsLeft) => {
-      https
-        .get(
-          u,
-          {
-            headers: {
-              'User-Agent': 'codetether-npx',
-              Accept: '*/*',
-            },
-          },
-          (res) => {
-            // Follow redirects (GitHub assets redirect to S3)
-            if (res.statusCode && [301, 302, 303, 307, 308].includes(res.statusCode)) {
-              const loc = res.headers.location;
-              if (!loc) {
-                reject(new Error(`Redirect without location from ${u}`));
-                return;
-              }
-              if (redirectsLeft <= 0) {
-                reject(new Error(`Too many redirects downloading ${url}`));
-                return;
-              }
-              res.resume();
-              doGet(loc, redirectsLeft - 1);
-              return;
-            }
-
-            if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
-              const chunks = [];
-              res.on('data', (d) => chunks.push(d));
-              res.on('end', () => {
-                const body = Buffer.concat(chunks).toString('utf8');
-                const err = new Error(`HTTP ${res.statusCode} downloading ${u}: ${body.slice(0, 400)}`);
-                err.statusCode = res.statusCode;
-                reject(err);
-              });
-              return;
-            }
-
-            const out = fs.createWriteStream(destPath);
-            res.pipe(out);
-            out.on('finish', () => out.close(resolve));
-            out.on('error', reject);
-          }
-        )
-        .on('error', reject);
-    };
-
-    doGet(url, 8);
-  });
-}
-
-function downloadText(url) {
-  return new Promise((resolve, reject) => {
-    const doGet = (u, redirectsLeft) => {
-      https
-        .get(
-          u,
-          {
-            headers: {
-              'User-Agent': 'codetether-npx',
-              Accept: '*/*',
-            },
-          },
-          (res) => {
-            if (res.statusCode && [301, 302, 303, 307, 308].includes(res.statusCode)) {
-              const loc = res.headers.location;
-              if (!loc) {
-                reject(new Error(`Redirect without location from ${u}`));
-                return;
-              }
-              if (redirectsLeft <= 0) {
-                reject(new Error(`Too many redirects downloading ${url}`));
-                return;
-              }
-              res.resume();
-              doGet(loc, redirectsLeft - 1);
-              return;
-            }
-
-            const chunks = [];
-            res.on('data', (d) => chunks.push(d));
-            res.on('end', () => {
-              const body = Buffer.concat(chunks).toString('utf8');
-              if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-                resolve(body);
-                return;
-              }
-              const err = new Error(`HTTP ${res.statusCode} downloading ${u}: ${body.slice(0, 400)}`);
-              err.statusCode = res.statusCode;
-              reject(err);
-            });
-          }
-        )
-        .on('error', reject);
-    };
-
-    doGet(url, 8);
-  });
 }
 
 function rmdirRecursiveSafe(p) {

--- a/npm/codetether/test/installer.test.js
+++ b/npm/codetether/test/installer.test.js
@@ -6,7 +6,7 @@ const {
   defaultCacheDirFor,
   selectAssetCandidates,
 } = require('../lib/installer');
-const { downloadText } = require('../lib/http');
+const { downloadFile, downloadText, requestJson } = require('../lib/http');
 
 function mockHttpsGet(responses, calls) {
   return (url, options, onResponse) => {
@@ -35,10 +35,22 @@ function mockHttpsGet(responses, calls) {
           return this;
         },
         resume() {},
+        pipe(dest) {
+          process.nextTick(() => {
+            if (typeof dest.emit === 'function') {
+              dest.emit('finish');
+            }
+          });
+          return dest;
+        },
       };
 
       calls.push({ url, options });
       onResponse(res);
+      if (spec.error && listeners.error) {
+        listeners.error(spec.error);
+        return;
+      }
       if (spec.body && listeners.data) {
         listeners.data(Buffer.from(spec.body));
       }
@@ -137,4 +149,56 @@ test('preserves TLS options across redirected installer downloads', async () => 
   assert.equal(calls.length, 2);
   assert.equal(calls[0].options.agent, agent);
   assert.equal(calls[1].options.agent, agent);
+});
+
+test('propagates response stream errors from redirected downloads', async () => {
+  const boom = new Error('socket reset');
+  const responses = new Map([['https://objects.example.com/test.txt', { statusCode: 200, error: boom }]]);
+
+  await assert.rejects(
+    downloadText('https://objects.example.com/test.txt', {
+      httpsGet: mockHttpsGet(responses, []),
+    }),
+    /socket reset/
+  );
+});
+
+test('reports requestJson redirect exhaustion as fetching', async () => {
+  const url = 'https://api.github.com/repos/rileyseaburg/codetether-agent/releases/latest';
+  const responses = new Map([[url, { statusCode: 302, headers: { location: url } }]]);
+
+  await assert.rejects(
+    requestJson(url, {}, { httpsGet: mockHttpsGet(responses, []) }),
+    /Too many redirects fetching/
+  );
+});
+
+test('rejects downloadFile when closing the output stream fails', async () => {
+  const closeError = new Error('close failed');
+  const responses = new Map([['https://objects.example.com/test.bin', { statusCode: 200 }]]);
+  const createWriteStream = () => {
+    const listeners = {};
+    return {
+      on(event, handler) {
+        listeners[event] = handler;
+        return this;
+      },
+      emit(event, value) {
+        if (listeners[event]) {
+          listeners[event](value);
+        }
+      },
+      close(callback) {
+        callback(closeError);
+      },
+    };
+  };
+
+  await assert.rejects(
+    downloadFile('https://objects.example.com/test.bin', '/tmp/test.bin', {
+      httpsGet: mockHttpsGet(responses, []),
+      createWriteStream,
+    }),
+    /close failed/
+  );
 });

--- a/npm/codetether/test/installer.test.js
+++ b/npm/codetether/test/installer.test.js
@@ -6,6 +6,50 @@ const {
   defaultCacheDirFor,
   selectAssetCandidates,
 } = require('../lib/installer');
+const { downloadText } = require('../lib/http');
+
+function mockHttpsGet(responses, calls) {
+  return (url, options, onResponse) => {
+    const spec = responses.get(url);
+    const req = {
+      on(event, handler) {
+        if (event === 'error') {
+          this.onError = handler;
+        }
+        return this;
+      },
+    };
+
+    process.nextTick(() => {
+      if (!spec) {
+        req.onError(new Error(`Unexpected URL: ${url}`));
+        return;
+      }
+
+      const listeners = {};
+      const res = {
+        statusCode: spec.statusCode,
+        headers: spec.headers || {},
+        on(event, handler) {
+          listeners[event] = handler;
+          return this;
+        },
+        resume() {},
+      };
+
+      calls.push({ url, options });
+      onResponse(res);
+      if (spec.body && listeners.data) {
+        listeners.data(Buffer.from(spec.body));
+      }
+      if (listeners.end) {
+        listeners.end();
+      }
+    });
+
+    return req;
+  };
+}
 
 test('prefers explicit release tags over npm package versions', () => {
   assert.equal(
@@ -68,4 +112,29 @@ test('keeps preferred Windows asset order when release assets cannot be enumerat
       'codetether-v4.4.1-x86_64-pc-windows-gnu.tar.gz',
     ]
   );
+});
+
+test('preserves TLS options across redirected installer downloads', async () => {
+  const agent = { name: 'darwin-agent' };
+  const calls = [];
+  const responses = new Map([
+    [
+      'https://github.com/rileyseaburg/codetether-agent/releases/download/v4.6.1/test.txt',
+      { statusCode: 302, headers: { location: 'https://objects.example.com/test.txt' } },
+    ],
+    ['https://objects.example.com/test.txt', { statusCode: 200, body: 'ok' }],
+  ]);
+
+  const body = await downloadText(
+    'https://github.com/rileyseaburg/codetether-agent/releases/download/v4.6.1/test.txt',
+    {
+      httpsGet: mockHttpsGet(responses, calls),
+      tlsOptions: () => ({ agent }),
+    }
+  );
+
+  assert.equal(body, 'ok');
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].options.agent, agent);
+  assert.equal(calls[1].options.agent, agent);
 });

--- a/src/provider/bedrock/tests.rs
+++ b/src/provider/bedrock/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the Bedrock provider module.
 
-use super::{BedrockProvider, CompletionRequest};
+use super::{BedrockProvider, CompletionRequest, parse_converse_response};
 
 #[test]
 fn resolve_opus_46_alias_includes_profile_suffix() {
@@ -114,4 +114,16 @@ fn sigv4_sorts_and_encodes_query_parameters() {
         canonical.canonical_querystring,
         "maxResults=200&typeEquals=SYSTEM_DEFINED"
     );
+}
+
+#[test]
+fn parse_converse_response_handles_multibyte_error_prefix_without_panicking() {
+    let prefix = "a".repeat(299);
+    let body = format!("{prefix}\u{2014}{{");
+
+    let err = parse_converse_response(&body).unwrap_err();
+    let message = err.to_string();
+
+    assert!(message.contains("Failed to parse Bedrock response:"));
+    assert!(!message.contains("byte index 300 is not a char boundary"));
 }


### PR DESCRIPTION
## Summary
- load macOS system root certificates for npm installer HTTPS requests and keep them applied across redirects
- cache macOS CA discovery, merge those certs with Node's root store, and raise the `security` command buffer so the fix does not silently no-op
- add regression coverage for the Bedrock multibyte truncation crash path that originally triggered issue #16

## Testing
- `node --test npm/codetether/test/installer.test.js`
- `cargo test parse_converse_response_handles_multibyte_error_prefix_without_panicking --lib`

Closes #64
Closes #16

Supersedes #65.