### PR TITLE
fix: add SSH image clipboard bridge

### DIFF
--- a/src/cli/clipboard.rs
+++ b/src/cli/clipboard.rs
@@ -1,0 +1,50 @@
+//! Clipboard bridge CLI commands.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Clipboard bridge arguments.
+#[derive(Parser, Debug)]
+pub struct ClipboardArgs {
+    /// Clipboard bridge operation to run.
+    #[command(subcommand)]
+    pub command: ClipboardCommand,
+}
+
+/// Clipboard bridge subcommands.
+#[derive(Subcommand, Debug)]
+pub enum ClipboardCommand {
+    /// Copy the local clipboard image as text for pasting over SSH
+    Image(ClipboardImageArgs),
+}
+
+/// Arguments for copying a clipboard image into pasteable text.
+#[derive(Parser, Debug)]
+pub struct ClipboardImageArgs {
+    /// Print the data URL instead of copying it back to the clipboard
+    #[arg(long)]
+    pub print: bool,
+}
+
+/// Execute a clipboard bridge subcommand.
+///
+/// # Errors
+///
+/// Returns an error when the requested clipboard operation cannot read or
+/// write the system clipboard.
+pub fn execute(args: ClipboardArgs) -> Result<()> {
+    match args.command {
+        ClipboardCommand::Image(args) => image(args.print),
+    }
+}
+
+fn image(print: bool) -> Result<()> {
+    let image = crate::image_clipboard::capture_image()?;
+    if print {
+        println!("{}", image.data_url);
+        return Ok(());
+    }
+    crate::image_clipboard::copy_text(&image.data_url)?;
+    eprintln!("Copied image paste text. Paste it into the remote CodeTether TUI.");
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 //! CLI command definitions and handlers
 
 pub mod auth;
+pub mod clipboard;
 pub mod config;
 pub mod context;
 pub mod go_ralph;
@@ -68,6 +69,9 @@ pub enum Command {
 
     /// Manage configuration
     Config(ConfigArgs),
+
+    /// Convert clipboard images into terminal-pasteable CodeTether input
+    Clipboard(clipboard::ClipboardArgs),
 
     /// Browse or reset the active session context
     Context(ContextArgs),

--- a/src/image_clipboard/capture.rs
+++ b/src/image_clipboard/capture.rs
@@ -1,0 +1,63 @@
+//! Capture and write system clipboard data for the image bridge.
+
+use std::io::Cursor;
+
+use anyhow::{Context, Result};
+use base64::Engine;
+
+use crate::session::ImageAttachment;
+
+/// Read the current system clipboard image as a PNG data URL.
+///
+/// # Errors
+///
+/// Returns an error when the clipboard is unavailable, does not contain an
+/// image, or the image cannot be encoded as PNG.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// let image = codetether_agent::image_clipboard::capture_image()?;
+/// assert!(image.data_url.starts_with("data:image/png;base64,"));
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub fn capture_image() -> Result<ImageAttachment> {
+    let mut clipboard = arboard::Clipboard::new().context("system clipboard is not available")?;
+    let image = clipboard
+        .get_image()
+        .context("clipboard does not contain an image")?;
+    attachment_from_rgba(image.width, image.height, image.bytes.into_owned())
+        .context("clipboard image could not be encoded as PNG")
+}
+
+/// Replace the system clipboard with text.
+///
+/// # Errors
+///
+/// Returns an error when the clipboard cannot be opened or written.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// codetether_agent::image_clipboard::copy_text("hello")?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub fn copy_text(text: &str) -> Result<()> {
+    let mut clipboard = arboard::Clipboard::new().context("system clipboard is not available")?;
+    clipboard
+        .set_text(text.to_string())
+        .context("failed to write image paste text to clipboard")
+}
+
+fn attachment_from_rgba(width: usize, height: usize, bytes: Vec<u8>) -> Option<ImageAttachment> {
+    let buf: image::ImageBuffer<image::Rgba<u8>, Vec<u8>> =
+        image::ImageBuffer::from_raw(width as u32, height as u32, bytes)?;
+    let mut png = Vec::new();
+    buf.write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
+        .ok()?;
+    let data = base64::engine::general_purpose::STANDARD.encode(&png);
+    Some(ImageAttachment {
+        data_url: format!("data:image/png;base64,{data}"),
+        mime_type: Some("image/png".to_string()),
+    })
+}

--- a/src/image_clipboard/data_url.rs
+++ b/src/image_clipboard/data_url.rs
@@ -1,8 +1,12 @@
 //! Parse pasted image data URLs.
 
 use base64::Engine;
+use std::borrow::Cow;
 
 use crate::session::ImageAttachment;
+
+const MAX_IMAGE_DECODED_BYTES: usize = 10 * 1024 * 1024;
+pub(crate) const MAX_BASE64_PAYLOAD_CHARS: usize = (MAX_IMAGE_DECODED_BYTES + 2) / 3 * 4;
 
 const IMAGE_MIME_TYPES: &[&str] = &[
     "image/png",
@@ -35,19 +39,34 @@ const IMAGE_MIME_TYPES: &[&str] = &[
 /// ```
 pub fn attachment_from_data_url(text: &str) -> Option<ImageAttachment> {
     let data = text.trim().strip_prefix("data:")?;
-    let (mime, payload) = data.split_once(";base64,")?;
+    let (mime, raw_payload) = data.split_once(";base64,")?;
     if !IMAGE_MIME_TYPES.contains(&mime) {
         return None;
     }
-    let payload: String = payload.split_ascii_whitespace().collect();
-    if payload.is_empty() {
+    let payload = normalized_payload(raw_payload)?;
+    if payload.len() > MAX_BASE64_PAYLOAD_CHARS {
         return None;
     }
-    base64::engine::general_purpose::STANDARD
-        .decode(&payload)
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(payload.as_ref())
         .ok()?;
+    if decoded.len() > MAX_IMAGE_DECODED_BYTES {
+        return None;
+    }
     Some(ImageAttachment {
         data_url: format!("data:{mime};base64,{payload}"),
         mime_type: Some(mime.to_string()),
     })
+}
+
+fn normalized_payload(payload: &str) -> Option<Cow<'_, str>> {
+    let payload = payload.trim();
+    if payload.is_empty() {
+        return None;
+    }
+    if !payload.as_bytes().iter().any(u8::is_ascii_whitespace) {
+        return Some(Cow::Borrowed(payload));
+    }
+    let payload: String = payload.split_ascii_whitespace().collect();
+    (!payload.is_empty()).then_some(Cow::Owned(payload))
 }

--- a/src/image_clipboard/data_url.rs
+++ b/src/image_clipboard/data_url.rs
@@ -1,0 +1,53 @@
+//! Parse pasted image data URLs.
+
+use base64::Engine;
+
+use crate::session::ImageAttachment;
+
+const IMAGE_MIME_TYPES: &[&str] = &[
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+    "image/svg+xml",
+];
+
+/// Convert pasted image data URL text into an attachment.
+///
+/// # Arguments
+///
+/// * `text` - Candidate pasted data URL text.
+///
+/// # Returns
+///
+/// An [`ImageAttachment`] when `text` is a valid base64 image data URL.
+///
+/// # Examples
+///
+/// ```rust
+/// use base64::Engine;
+/// use codetether_agent::image_clipboard::attachment_from_data_url;
+///
+/// let payload = base64::engine::general_purpose::STANDARD.encode("png bytes");
+/// let image = attachment_from_data_url(&format!("data:image/png;base64,{payload}"));
+/// assert_eq!(image.unwrap().mime_type.as_deref(), Some("image/png"));
+/// ```
+pub fn attachment_from_data_url(text: &str) -> Option<ImageAttachment> {
+    let data = text.trim().strip_prefix("data:")?;
+    let (mime, payload) = data.split_once(";base64,")?;
+    if !IMAGE_MIME_TYPES.contains(&mime) {
+        return None;
+    }
+    let payload: String = payload.split_ascii_whitespace().collect();
+    if payload.is_empty() {
+        return None;
+    }
+    base64::engine::general_purpose::STANDARD
+        .decode(&payload)
+        .ok()?;
+    Some(ImageAttachment {
+        data_url: format!("data:{mime};base64,{payload}"),
+        mime_type: Some(mime.to_string()),
+    })
+}

--- a/src/image_clipboard/mod.rs
+++ b/src/image_clipboard/mod.rs
@@ -1,0 +1,13 @@
+//! Clipboard image bridge helpers.
+//!
+//! These helpers support SSH sessions by converting a local clipboard image
+//! into a text data URL that can be pasted through a terminal.
+
+mod capture;
+mod data_url;
+
+#[cfg(test)]
+mod tests;
+
+pub use capture::{capture_image, copy_text};
+pub use data_url::attachment_from_data_url;

--- a/src/image_clipboard/tests.rs
+++ b/src/image_clipboard/tests.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 
-use super::attachment_from_data_url;
+use super::{attachment_from_data_url, data_url::MAX_BASE64_PAYLOAD_CHARS};
 
 #[test]
 fn accepts_image_data_url() {
@@ -24,4 +24,11 @@ fn normalizes_wrapped_payload() {
     let wrapped = format!("data:image/png;base64,{}\n{}", &payload[..4], &payload[4..]);
     let image = attachment_from_data_url(&wrapped).expect("wrapped image data URL");
     assert_eq!(image.data_url, format!("data:image/png;base64,{payload}"));
+}
+
+#[test]
+fn rejects_oversized_payload_before_decode() {
+    let payload = "A".repeat(MAX_BASE64_PAYLOAD_CHARS + 1);
+    let text = format!("data:image/png;base64,{payload}");
+    assert!(attachment_from_data_url(&text).is_none());
 }

--- a/src/image_clipboard/tests.rs
+++ b/src/image_clipboard/tests.rs
@@ -1,0 +1,27 @@
+use base64::Engine;
+
+use super::attachment_from_data_url;
+
+#[test]
+fn accepts_image_data_url() {
+    let payload = base64::engine::general_purpose::STANDARD.encode("png bytes");
+    let text = format!("data:image/png;base64,{payload}");
+    let image = attachment_from_data_url(&text).expect("image data URL");
+    assert_eq!(image.mime_type.as_deref(), Some("image/png"));
+    assert_eq!(image.data_url, text);
+}
+
+#[test]
+fn rejects_non_image_data_url() {
+    let payload = base64::engine::general_purpose::STANDARD.encode("hello");
+    let text = format!("data:text/plain;base64,{payload}");
+    assert!(attachment_from_data_url(&text).is_none());
+}
+
+#[test]
+fn normalizes_wrapped_payload() {
+    let payload = base64::engine::general_purpose::STANDARD.encode("png bytes");
+    let wrapped = format!("data:image/png;base64,{}\n{}", &payload[..4], &payload[4..]);
+    let image = attachment_from_data_url(&wrapped).expect("wrapped image data URL");
+    assert_eq!(image.data_url, format!("data:image/png;base64,{payload}"));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub mod event_stream;
 pub mod forage;
 pub mod github_pr;
+pub mod image_clipboard;
 pub mod indexer;
 pub mod k8s;
 pub mod lsp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod crash;
 mod event_stream;
 mod forage;
 mod github_pr;
+mod image_clipboard;
 mod indexer;
 mod k8s;
 mod lsp;
@@ -514,7 +515,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Check if we're running TUI - if so, redirect logs to file instead of stderr
     // TUI is the default when no subcommand is given
-    let is_tui = matches!(cli.command, Some(Command::Tui(_)) | None);
+    let is_tui = matches!(&cli.command, Some(Command::Tui(_)) | None);
 
     // Initialize tracing
     if is_tui {
@@ -557,7 +558,9 @@ async fn main() -> anyhow::Result<()> {
     let app_config = crash::maybe_prompt_for_consent(&app_config, allow_crash_prompt).await;
     crash::initialize(&app_config).await;
 
-    if !is_tui {
+    let needs_vault = !is_tui && !matches!(&cli.command, Some(Command::Clipboard(_)));
+
+    if needs_vault {
         // Initialize HashiCorp Vault connection for secrets
         if let Ok(secrets_manager) = secrets::SecretsManager::from_env().await {
             if secrets_manager.is_connected() {
@@ -587,6 +590,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Serve(args)) => server::serve(args).await,
         Some(Command::Run(args)) => cli::run::execute(args).await,
         Some(Command::Pr(args)) => github_pr::run(args).await,
+        Some(Command::Clipboard(args)) => cli::clipboard::execute(args),
         Some(Command::Models(args)) => {
             let registry = provider::ProviderRegistry::from_vault().await?;
             let mut all_models: Vec<provider::ModelInfo> = Vec::new();

--- a/src/tui/app/event_handlers/clipboard.rs
+++ b/src/tui/app/event_handlers/clipboard.rs
@@ -30,6 +30,9 @@ use crate::tui::models::InputMode;
 /// ```
 pub(super) fn handle_clipboard_paste(app: &mut App) {
     if let Some(text) = crate::tui::clipboard::get_clipboard_text() {
+        if crate::tui::app::input::try_attach_data_url(app, &text) {
+            return;
+        }
         insert_clipboard_text(app, &text);
         return;
     }
@@ -45,7 +48,9 @@ pub(super) fn handle_clipboard_paste(app: &mut App) {
             };
         }
         None => {
-            app.state.status = "Clipboard empty — use /image <path> for images".into();
+            app.state.status =
+                "Clipboard unavailable; use /image <path> or `codetether clipboard image` locally."
+                    .into();
         }
     }
 }

--- a/src/tui/app/input/image_data_paste.rs
+++ b/src/tui/app/input/image_data_paste.rs
@@ -1,0 +1,18 @@
+//! Attach pasted image data URLs.
+
+use crate::tui::app::state::App;
+
+/// Attach a pasted image data URL when the text is one.
+pub(crate) fn try_attach_data_url(app: &mut App, text: &str) -> bool {
+    let Some(image) = crate::image_clipboard::attachment_from_data_url(text) else {
+        return false;
+    };
+    app.state.pending_images.push(image);
+    let count = app.state.pending_images.len();
+    app.state.status = if count == 1 {
+        "Attached pasted image. Type a message and press Enter to send.".to_string()
+    } else {
+        format!("Attached {count} pasted images. Press Enter to send them.")
+    };
+    true
+}

--- a/src/tui/app/input/image_data_paste.rs
+++ b/src/tui/app/input/image_data_paste.rs
@@ -10,9 +10,9 @@ pub(crate) fn try_attach_data_url(app: &mut App, text: &str) -> bool {
     app.state.pending_images.push(image);
     let count = app.state.pending_images.len();
     app.state.status = if count == 1 {
-        "Attached pasted image. Type a message and press Enter to send.".to_string()
+        "Attached pasted image. Press Enter to send, or add text first.".to_string()
     } else {
-        format!("Attached {count} pasted images. Press Enter to send them.")
+        format!("Attached {count} pasted images. Press Enter to send, or add text first.")
     };
     true
 }

--- a/src/tui/app/input/mod.rs
+++ b/src/tui/app/input/mod.rs
@@ -17,6 +17,7 @@ mod chat_submit_dispatch;
 // user message as a fresh turn without duplicating the dispatch logic.
 mod enter;
 pub(crate) mod image;
+mod image_data_paste;
 mod merge;
 mod paste;
 mod pr;
@@ -38,5 +39,6 @@ pub use bus::{handle_bus_c, handle_bus_g, handle_bus_slash};
 pub use char_input::handle_char;
 pub use enter::dispatch_enter as handle_enter;
 pub(crate) use image::attach_image_file;
+pub(crate) use image_data_paste::try_attach_data_url;
 pub use paste::handle_paste;
 pub use sessions::handle_sessions_char;

--- a/src/tui/app/input/mod.rs
+++ b/src/tui/app/input/mod.rs
@@ -28,6 +28,7 @@ mod pr_helpers;
 mod pr_title;
 mod sessions;
 mod tests_enter;
+mod tests_image_paste;
 mod tests_paste;
 mod tests_pr;
 mod tests_submit;

--- a/src/tui/app/input/paste.rs
+++ b/src/tui/app/input/paste.rs
@@ -58,6 +58,9 @@ fn paste_chars_no_newlines(text: &str, mut f: impl FnMut(char)) {
 
 /// Insert pasted text into the chat input buffer.
 fn paste_into_chat(app: &mut App, normalized: &str) {
+    if super::try_attach_data_url(app, normalized) {
+        return;
+    }
     app.state.input_mode = if app.state.input.is_empty() && normalized.starts_with('/') {
         InputMode::Command
     } else if app.state.input.starts_with('/') {

--- a/src/tui/app/input/tests_image_paste.rs
+++ b/src/tui/app/input/tests_image_paste.rs
@@ -1,0 +1,34 @@
+//! Tests for pasted image data URLs.
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+
+    use crate::tui::app::input::handle_paste;
+    use crate::tui::app::state::App;
+    use crate::tui::models::ViewMode;
+
+    #[tokio::test]
+    async fn image_data_url_paste_attaches_without_inserting_text() {
+        let mut app = App::default();
+        app.state.view_mode = ViewMode::Chat;
+        app.state.input = "draft".to_string();
+        app.state.input_cursor = app.state.input.len();
+        let payload = base64::engine::general_purpose::STANDARD.encode("png bytes");
+        let text = format!("data:image/png;base64,{payload}");
+
+        handle_paste(&mut app, &text).await;
+
+        assert_eq!(app.state.input, "draft");
+        assert_eq!(app.state.pending_images.len(), 1);
+        assert_eq!(
+            app.state.pending_images[0].mime_type.as_deref(),
+            Some("image/png")
+        );
+        assert_eq!(app.state.pending_images[0].data_url, text);
+        assert_eq!(
+            app.state.status,
+            "Attached pasted image. Press Enter to send, or add text first."
+        );
+    }
+}

--- a/src/tui/clipboard.rs
+++ b/src/tui/clipboard.rs
@@ -3,9 +3,6 @@
 //! Reads image data from the system clipboard and converts it to an
 //! `ImageAttachment` suitable for sending with a chat message.
 
-use base64::Engine;
-use std::io::Cursor;
-
 use crate::session::ImageAttachment;
 
 /// Check if we're in an SSH or headless session without clipboard access.
@@ -25,26 +22,7 @@ pub fn get_clipboard_image() -> Option<ImageAttachment> {
     if is_ssh_or_headless() {
         return None;
     }
-
-    let mut clipboard = arboard::Clipboard::new().ok()?;
-    let img_data = clipboard.get_image().ok()?;
-
-    let width = img_data.width;
-    let height = img_data.height;
-    let raw_bytes = img_data.bytes.into_owned();
-
-    let buf: image::ImageBuffer<image::Rgba<u8>, Vec<u8>> =
-        image::ImageBuffer::from_raw(width as u32, height as u32, raw_bytes)?;
-
-    let mut png_bytes = Vec::new();
-    buf.write_to(&mut Cursor::new(&mut png_bytes), image::ImageFormat::Png)
-        .ok()?;
-
-    let b64 = base64::engine::general_purpose::STANDARD.encode(&png_bytes);
-    Some(ImageAttachment {
-        data_url: format!("data:image/png;base64,{b64}"),
-        mime_type: Some("image/png".to_string()),
-    })
+    crate::image_clipboard::capture_image().ok()
 }
 
 /// Extract plain text from the system clipboard, returning `None` when


### PR DESCRIPTION
## Summary
- add `codetether clipboard image` to convert a local clipboard image into terminal-pasteable data URL text
- teach the TUI paste path to recognize pasted image data URLs and attach them as pending images
- share clipboard image capture/data URL parsing between CLI and TUI code paths

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo test image_clipboard`

Did not run `cargo build` or `cargo check` per project instruction.