### PR TITLE
fix: prevent interactive bash auth prompts

### DIFF
--- a/src/tool/bash.rs
+++ b/src/tool/bash.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use std::ffi::OsString;
 use std::path::PathBuf;
-use std::process::Stdio;
 use std::time::Instant;
 use tokio::process::Command;
 use tokio::time::{Duration, timeout};
@@ -158,7 +157,7 @@ impl Tool for BashTool {
     }
 
     fn description(&self) -> &str {
-        "bash(command: string, cwd?: string, timeout?: int) - Execute a shell command. Commands run in a bash shell with the current working directory."
+        "bash(command: string, cwd?: string, timeout?: int) - Execute a noninteractive shell command. Password prompts are disabled; use noninteractive credentials or flags such as sudo -n."
     }
 
     fn parameters(&self) -> Value {
@@ -317,16 +316,8 @@ impl Tool for BashTool {
 
         let shell = super::bash_shell::resolve();
         let mut cmd = Command::new(&shell.program);
-        cmd.args(&shell.prefix_args)
-            .arg(&wrapped_command)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .env("GCM_INTERACTIVE", "never")
-            .env("DEBIAN_FRONTEND", "noninteractive")
-            .env("SUDO_ASKPASS", "/bin/false")
-            .env("SSH_ASKPASS", "/bin/false");
+        cmd.args(&shell.prefix_args).arg(&wrapped_command);
+        super::bash_noninteractive::configure(&mut cmd);
         if let Some((codetether_bin, path)) = codetether_runtime_env() {
             cmd.env("CODETETHER_BIN", codetether_bin).env("PATH", path);
         }
@@ -398,10 +389,18 @@ impl Tool for BashTool {
                 );
 
                 let success = output.status.success();
+                let auth_prompt_blocked = !success && looks_like_auth_prompt(&combined);
 
-                if !success && looks_like_auth_prompt(&combined) {
+                if auth_prompt_blocked {
                     tracing::warn!("Interactive auth prompt detected in output");
                 }
+                let combined = if auth_prompt_blocked {
+                    format!(
+                        "{combined}\n\n[CodeTether] Interactive password prompts are disabled for agent-run commands. Use non-interactive credentials or commands such as `sudo -n`."
+                    )
+                } else {
+                    combined
+                };
 
                 // Truncate if too long
                 let max_len = 50_000;
@@ -467,6 +466,10 @@ impl Tool for BashTool {
                     metadata: [
                         ("exit_code".to_string(), json!(exit_code)),
                         ("truncated".to_string(), json!(truncated)),
+                        (
+                            "interactive_auth_prompt".to_string(),
+                            json!(auth_prompt_blocked),
+                        ),
                     ]
                     .into_iter()
                     .collect(),

--- a/src/tool/bash_noninteractive.rs
+++ b/src/tool/bash_noninteractive.rs
@@ -1,0 +1,44 @@
+//! Noninteractive subprocess hardening for shell-backed tools.
+
+use std::process::Stdio;
+use tokio::process::Command;
+
+pub(super) fn configure(cmd: &mut Command) {
+    configure_stdio(cmd);
+    configure_auth_env(cmd);
+    detach_controlling_terminal(cmd);
+}
+
+fn configure_stdio(cmd: &mut Command) {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+}
+
+fn configure_auth_env(cmd: &mut Command) {
+    cmd.env("GIT_TERMINAL_PROMPT", "0")
+        .env("GCM_INTERACTIVE", "never")
+        .env("DEBIAN_FRONTEND", "noninteractive")
+        .env("SUDO_ASKPASS", "/bin/false")
+        .env("SSH_ASKPASS", "/bin/false");
+}
+
+#[cfg(unix)]
+fn detach_controlling_terminal(cmd: &mut Command) {
+    // SAFETY: `pre_exec` runs after fork in the child. The closure only calls
+    // `setsid` and converts errno, which keeps it async-signal-safe enough for
+    // this child-process setup hook.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn detach_controlling_terminal(_cmd: &mut Command) {}

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -10,6 +10,7 @@ pub mod bash;
 #[path = "bash_github/mod.rs"]
 mod bash_github;
 mod bash_identity;
+mod bash_noninteractive;
 mod bash_shell;
 pub mod batch;
 pub mod browserctl;
@@ -42,9 +43,9 @@ pub mod readonly;
 pub mod relay_autochat;
 pub mod rlm;
 pub mod sandbox;
-pub mod session_recall;
 pub mod search;
 pub mod search_router;
+pub mod session_recall;
 pub mod session_task;
 pub mod skill;
 pub mod swarm_execute;

--- a/src/tool/sandbox.rs
+++ b/src/tool/sandbox.rs
@@ -294,13 +294,8 @@ pub async fn execute_sandboxed(
         .unwrap_or_else(std::env::temp_dir);
 
     let mut cmd = Command::new(command);
-    cmd.args(args)
-        .current_dir(&work_dir)
-        .env_clear()
-        .envs(&env)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
+    cmd.args(args).current_dir(&work_dir).env_clear().envs(&env);
+    super::bash_noninteractive::configure(&mut cmd);
 
     let timeout = std::time::Duration::from_secs(policy.timeout_secs);
 

--- a/src/tool/sandbox.rs
+++ b/src/tool/sandbox.rs
@@ -271,11 +271,6 @@ pub async fn execute_sandboxed(
     env.insert("PATH".to_string(), "/usr/bin:/bin".to_string());
     env.insert("HOME".to_string(), "/tmp".to_string());
     env.insert("LANG".to_string(), "C.UTF-8".to_string());
-    env.insert("GIT_TERMINAL_PROMPT".to_string(), "0".to_string());
-    env.insert("GCM_INTERACTIVE".to_string(), "never".to_string());
-    env.insert("DEBIAN_FRONTEND".to_string(), "noninteractive".to_string());
-    env.insert("SUDO_ASKPASS".to_string(), "/bin/false".to_string());
-    env.insert("SSH_ASKPASS".to_string(), "/bin/false".to_string());
     inject_codetether_runtime_env(&mut env);
 
     if !policy.allow_network {

--- a/tests/bash_noninteractive.rs
+++ b/tests/bash_noninteractive.rs
@@ -1,0 +1,24 @@
+use codetether_agent::tool::{Tool, bash::BashTool};
+use serde_json::json;
+
+#[tokio::test]
+async fn bash_tool_denies_controlling_tty() {
+    let tool = BashTool::with_timeout(5);
+    let result = tool
+        .execute(json!({
+            "command": r#"err="$(mktemp)"; if printf codetether-test >/dev/tty 2>"$err"; then echo tty-opened; else echo no-controlling-tty; cat "$err"; fi; rm -f "$err""#
+        }))
+        .await
+        .unwrap();
+
+    assert!(
+        !result.output.contains("tty-opened"),
+        "command unexpectedly opened /dev/tty:\n{}",
+        result.output
+    );
+    assert!(
+        result.output.contains("no-controlling-tty"),
+        "command did not report tty isolation:\n{}",
+        result.output
+    );
+}

--- a/tests/bash_noninteractive.rs
+++ b/tests/bash_noninteractive.rs
@@ -1,12 +1,13 @@
 use codetether_agent::tool::{Tool, bash::BashTool};
 use serde_json::json;
 
+#[cfg(unix)]
 #[tokio::test]
 async fn bash_tool_denies_controlling_tty() {
     let tool = BashTool::with_timeout(5);
     let result = tool
         .execute(json!({
-            "command": r#"err="$(mktemp)"; if printf codetether-test >/dev/tty 2>"$err"; then echo tty-opened; else echo no-controlling-tty; cat "$err"; fi; rm -f "$err""#
+            "command": r#"err="$(mktemp)"; if printf codetether-test >/dev/tty 2>"$err"; then echo tty-opened; else echo no-controlling-tty; cat "$err"; fi; rm -f "$err";"#
         }))
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- add shared noninteractive subprocess setup for bash-backed tool execution
- detach bash commands from the controlling TTY on Unix so sudo-style prompts cannot take over the TUI
- add a regression test that verifies BashTool cannot open /dev/tty

## Tests
- cargo test --test bash_noninteractive bash_tool_denies_controlling_tty