### PR TITLE
fix: explain npx TLS certificate failures

### DIFF
--- a/npm/codetether/lib/installer.js
+++ b/npm/codetether/lib/installer.js
@@ -5,6 +5,7 @@ const os = require('node:os');
 const crypto = require('node:crypto');
 const { spawnSync } = require('node:child_process');
 const { downloadFile, downloadText, requestJson } = require('./http');
+const { tlsRemediationFor } = require('./tls_remediation');
 
 function repoFromEnv() {
   return process.env.CODETETHER_GITHUB_REPO || 'rileyseaburg/codetether-agent';
@@ -534,6 +535,7 @@ async function ensureInstalled({ allowLatestFallback = true } = {}) {
     '',
     'Or build from source:',
     '  cargo install codetether-agent',
+    ...tlsRemediationFor(lastErr),
   ].join('\n');
 
   const err = new Error(`${help}\n\nUnderlying error: ${lastErr ? lastErr.message : 'unknown'}`);

--- a/npm/codetether/lib/tls_remediation.js
+++ b/npm/codetether/lib/tls_remediation.js
@@ -1,0 +1,36 @@
+const CERT_ERROR_PATTERNS = [
+  /unable to get local issuer certificate/i,
+  /self[ -]?signed certificate/i,
+  /unable to verify the first certificate/i,
+  /certificate has expired/i,
+  /\bUNABLE_TO_GET_ISSUER_CERT\b/i,
+  /\bSELF_SIGNED_CERT_IN_CHAIN\b/i,
+];
+
+function isTlsCertificateError(err) {
+  const text = err && (err.stack || err.message || String(err));
+  return CERT_ERROR_PATTERNS.some((pattern) => pattern.test(text || ''));
+}
+
+function tlsRemediationFor(err) {
+  if (!isTlsCertificateError(err)) {
+    return [];
+  }
+
+  return [
+    '',
+    'TLS certificate verification failed while downloading from GitHub Releases.',
+    'If you are behind corporate TLS interception or a custom CA, export the',
+    'issuer certificate as PEM and retry with one of:',
+    '  NODE_EXTRA_CA_CERTS=/path/to/issuer.pem npx codetether',
+    '  npm config set cafile /path/to/issuer.pem',
+    '',
+    'Do not disable TLS verification. The installer will keep refusing',
+    'untrusted release downloads until Node can validate the issuer.',
+  ];
+}
+
+module.exports = {
+  isTlsCertificateError,
+  tlsRemediationFor,
+};

--- a/npm/codetether/lib/tls_remediation.js
+++ b/npm/codetether/lib/tls_remediation.js
@@ -3,12 +3,12 @@ const CERT_ERROR_PATTERNS = [
   /self[ -]?signed certificate/i,
   /unable to verify the first certificate/i,
   /certificate has expired/i,
-  /\bUNABLE_TO_GET_ISSUER_CERT\b/i,
+  /\bUNABLE_TO_GET_ISSUER_CERT(?:_LOCALLY)?\b/i,
   /\bSELF_SIGNED_CERT_IN_CHAIN\b/i,
 ];
 
 function isTlsCertificateError(err) {
-  const text = err && (err.stack || err.message || String(err));
+  const text = err && `${err.stack || err.message || String(err)}\n${err.code || ''}`;
   return CERT_ERROR_PATTERNS.some((pattern) => pattern.test(text || ''));
 }
 
@@ -22,8 +22,12 @@ function tlsRemediationFor(err) {
     'TLS certificate verification failed while downloading from GitHub Releases.',
     'If you are behind corporate TLS interception or a custom CA, export the',
     'issuer certificate as PEM and retry with one of:',
+    '  Recommended for this install only:',
     '  NODE_EXTRA_CA_CERTS=/path/to/issuer.pem npx codetether',
+    '  Optional persistent npm setting:',
     '  npm config set cafile /path/to/issuer.pem',
+    '  Undo the persistent npm setting with:',
+    '  npm config delete cafile',
     '',
     'Do not disable TLS verification. The installer will keep refusing',
     'untrusted release downloads until Node can validate the issuer.',

--- a/npm/codetether/test/installer.test.js
+++ b/npm/codetether/test/installer.test.js
@@ -7,7 +7,6 @@ const {
   selectAssetCandidates,
 } = require('../lib/installer');
 const { downloadFile, downloadText, requestJson } = require('../lib/http');
-const { isTlsCertificateError, tlsRemediationFor } = require('../lib/tls_remediation');
 
 function mockHttpsGet(responses, calls) {
   return (url, options, onResponse) => {
@@ -202,14 +201,4 @@ test('rejects downloadFile when closing the output stream fails', async () => {
     }),
     /close failed/
   );
-});
-
-test('detects TLS issuer failures and explains safe remediation', () => {
-  const err = new Error('unable to get local issuer certificate');
-  const help = tlsRemediationFor(err).join('\n');
-
-  assert.equal(isTlsCertificateError(err), true);
-  assert.match(help, /NODE_EXTRA_CA_CERTS/);
-  assert.match(help, /npm config set cafile/);
-  assert.match(help, /Do not disable TLS verification/);
 });

--- a/npm/codetether/test/installer.test.js
+++ b/npm/codetether/test/installer.test.js
@@ -7,6 +7,7 @@ const {
   selectAssetCandidates,
 } = require('../lib/installer');
 const { downloadFile, downloadText, requestJson } = require('../lib/http');
+const { isTlsCertificateError, tlsRemediationFor } = require('../lib/tls_remediation');
 
 function mockHttpsGet(responses, calls) {
   return (url, options, onResponse) => {
@@ -201,4 +202,14 @@ test('rejects downloadFile when closing the output stream fails', async () => {
     }),
     /close failed/
   );
+});
+
+test('detects TLS issuer failures and explains safe remediation', () => {
+  const err = new Error('unable to get local issuer certificate');
+  const help = tlsRemediationFor(err).join('\n');
+
+  assert.equal(isTlsCertificateError(err), true);
+  assert.match(help, /NODE_EXTRA_CA_CERTS/);
+  assert.match(help, /npm config set cafile/);
+  assert.match(help, /Do not disable TLS verification/);
 });

--- a/npm/codetether/test/tls_remediation.test.js
+++ b/npm/codetether/test/tls_remediation.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isTlsCertificateError, tlsRemediationFor } = require('../lib/tls_remediation');
+
+test('detects TLS issuer failures from error code', () => {
+  const err = new Error('certificate download failed');
+  err.code = 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY';
+
+  assert.equal(isTlsCertificateError(err), true);
+});
+
+test('explains safe TLS remediation', () => {
+  const err = new Error('unable to get local issuer certificate');
+  const help = tlsRemediationFor(err).join('\n');
+
+  assert.match(help, /Recommended for this install only/);
+  assert.match(help, /NODE_EXTRA_CA_CERTS/);
+  assert.match(help, /Optional persistent npm setting/);
+  assert.match(help, /npm config delete cafile/);
+  assert.match(help, /Do not disable TLS verification/);
+});


### PR DESCRIPTION
## Summary
- detect Node TLS certificate issuer failures during npx release installation
- add safe remediation guidance for NODE_EXTRA_CA_CERTS and npm cafile without disabling TLS
- cover the remediation helper with a Node test

Fixes #79

## Tests
- node --test npm/codetether/test/installer.test.js