### PR TITLE
docs: align provider secret fallback contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,9 @@ impl Provider for YourProvider {
 
 ## Secrets Management
 
-**CRITICAL**: Never hardcode API keys. All secrets come from HashiCorp Vault.
+**CRITICAL**: Never hardcode API keys. Provider secrets are loaded from
+HashiCorp Vault first. Local development may also use env vars and local AWS
+credentials unless `CODETETHER_DISABLE_ENV_FALLBACK=1` is set.
 
 ```rust
 // Good - load from Vault

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ cargo build --release --no-default-features
 
 ## Quick Start
 
-### 1. Configure Vault
+### 1. Configure Provider Credentials
 
-All API keys live in HashiCorp Vault — never in config files or env vars.
+Provider API keys are loaded from HashiCorp Vault first. For local development,
+CodeTether also detects common env vars and local AWS credentials unless
+`CODETETHER_DISABLE_ENV_FALLBACK=1` is set.
 
 ```bash
 export VAULT_ADDR="https://vault.example.com:8200"
@@ -74,6 +76,9 @@ export VAULT_TOKEN="hvs.your-token"
 
 # Add a provider
 vault kv put secret/codetether/providers/openrouter api_key="sk-or-v1-..."
+
+# Production / hardened mode: require Vault-configured providers only.
+export CODETETHER_DISABLE_ENV_FALLBACK=1
 ```
 
 ### 2. Launch the TUI

--- a/docs/PROJECT_CONSTRAINTS_ANALYSIS.md
+++ b/docs/PROJECT_CONSTRAINTS_ANALYSIS.md
@@ -31,7 +31,7 @@ This document defines the comprehensive constraints framework for the CodeTether
 - **AI/LLM:** async-openai 0.32.4 (OpenAI-compatible APIs only)
 - **TUI:** ratatui 0.30.0, crossterm 0.29.0
 - **LSP:** jsonrpc-core 18, lsp-types 0.97.0
-- **Secrets:** vaultrs 0.7 (HashiCorp Vault only)
+- **Secrets:** vaultrs 0.7 (Vault-first, optional env/AWS fallback)
 
 **Constraint Implications:**
 - Major version upgrades require significant refactoring
@@ -75,8 +75,8 @@ This document defines the comprehensive constraints framework for the CodeTether
 - Streaming support varies by provider
 
 **Vault Requirements:**
-- HashiCorp Vault mandatory for all API keys
-- No environment variable fallback for secrets
+- HashiCorp Vault is the production source for provider API keys
+- Env/AWS fallback is available for local development unless disabled
 - Requires VAULT_ADDR and VAULT_TOKEN environment variables
 
 ---
@@ -343,8 +343,8 @@ Based on historical data (Ralph dogfooding):
 ### 6.3 Security Requirements
 
 **Secrets Management:**
-- All API keys in HashiCorp Vault only
-- No secrets in environment variables
+- Store production API keys in HashiCorp Vault
+- Set `CODETETHER_DISABLE_ENV_FALLBACK=1` to reject env/AWS fallback
 - No secrets in code or config files
 - Vault token rotation required quarterly
 

--- a/docs/assessment_config_main_lib.md
+++ b/docs/assessment_config_main_lib.md
@@ -72,9 +72,9 @@ Add comprehensive crate-level documentation:
 //!
 //! # Security
 //!
-//! All API keys and secrets are loaded exclusively from HashiCorp Vault.
-//! Environment variables are used only for Vault connection bootstrap
-//! (`VAULT_ADDR`, `VAULT_TOKEN`).
+//! Provider credentials are loaded from HashiCorp Vault first.
+//! Local-development env/AWS fallback is available unless
+//! `CODETETHER_DISABLE_ENV_FALLBACK=1` is set.
 //!
 //! # Feature Flags
 //!
@@ -149,8 +149,9 @@ Expand the module documentation:
 //!
 //! # Security
 //!
-//! All API keys and secrets are loaded exclusively from HashiCorp Vault.
-//! Environment variables are NOT used for secrets (only for Vault connection bootstrap).
+//! Provider credentials are loaded from HashiCorp Vault first.
+//! Local-development env/AWS fallback is available unless
+//! `CODETETHER_DISABLE_ENV_FALLBACK=1` is set.
 //!
 //! Required environment variables for Vault:
 //! - `VAULT_ADDR`: Vault server URL (e.g., "https://vault.example.com:8200")

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,9 @@
 //! By default, runs as an A2A worker connecting to the CodeTether platform.
 //! Use the 'tui' subcommand for interactive terminal mode.
 //!
-//! SECURITY: All API keys and secrets are loaded exclusively from HashiCorp Vault.
-//! Environment variables are NOT used for secrets (only for Vault connection bootstrap).
+//! SECURITY: Provider credentials are loaded from HashiCorp Vault first.
+//! Local development may also use env/AWS fallback credentials unless
+//! `CODETETHER_DISABLE_ENV_FALLBACK=1` is set for Vault-only mode.
 
 mod a2a;
 mod agent;

--- a/src/provider/fallback_policy.rs
+++ b/src/provider/fallback_policy.rs
@@ -1,0 +1,42 @@
+//! Provider credential fallback policy.
+
+pub(crate) const DISABLE_ENV_FALLBACK: &str = "CODETETHER_DISABLE_ENV_FALLBACK";
+
+pub(crate) fn env_fallback_disabled() -> bool {
+    let value = std::env::var(DISABLE_ENV_FALLBACK).ok();
+    env_fallback_disabled_from(value.as_deref())
+}
+
+pub(crate) fn env_fallback_disabled_from(value: Option<&str>) -> bool {
+    value
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+pub(crate) fn registry_mode_label(disabled: bool) -> &'static str {
+    if disabled {
+        "Vault only"
+    } else {
+        "Vault + env/AWS fallback"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{env_fallback_disabled_from, registry_mode_label};
+
+    #[test]
+    fn parses_security_hardened_flag() {
+        assert!(env_fallback_disabled_from(Some("1")));
+        assert!(env_fallback_disabled_from(Some("true")));
+        assert!(env_fallback_disabled_from(Some("TRUE")));
+        assert!(!env_fallback_disabled_from(Some("0")));
+        assert!(!env_fallback_disabled_from(None));
+    }
+
+    #[test]
+    fn labels_provider_registry_mode() {
+        assert_eq!(registry_mode_label(true), "Vault only");
+        assert_eq!(registry_mode_label(false), "Vault + env/AWS fallback");
+    }
+}

--- a/src/provider/init_config.rs
+++ b/src/provider/init_config.rs
@@ -24,13 +24,14 @@ impl ProviderRegistry {
     /// ```
     pub async fn from_config(config: &crate::config::Config) -> Result<Self> {
         let mut registry = Self::new();
+        let disable_env = fallback_policy::env_fallback_disabled();
 
         // ---- OpenAI ----
         if let Some(pc) = config.providers.get("openai") {
             if let Some(key) = &pc.api_key {
                 registry.register(Arc::new(openai::OpenAIProvider::new(key.clone())?));
             }
-        } else if let Ok(key) = std::env::var("OPENAI_API_KEY") {
+        } else if !disable_env && let Ok(key) = std::env::var("OPENAI_API_KEY") {
             registry.register(Arc::new(openai::OpenAIProvider::new(key)?));
         }
 
@@ -44,7 +45,7 @@ impl ProviderRegistry {
                 };
                 registry.register(Arc::new(p));
             }
-        } else if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
+        } else if !disable_env && let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
             registry.register(Arc::new(anthropic::AnthropicProvider::new(key)?));
         }
 
@@ -53,7 +54,7 @@ impl ProviderRegistry {
             if let Some(key) = &pc.api_key {
                 registry.register(Arc::new(google::GoogleProvider::new(key.clone())?));
             }
-        } else if let Ok(key) = std::env::var("GOOGLE_API_KEY") {
+        } else if !disable_env && let Ok(key) = std::env::var("GOOGLE_API_KEY") {
             registry.register(Arc::new(google::GoogleProvider::new(key)?));
         }
 
@@ -73,7 +74,7 @@ impl ProviderRegistry {
         }
 
         // ---- Bedrock (auto-detect from env / ~/.aws) ----
-        if let Some(creds) = bedrock::AwsCredentials::from_environment() {
+        if !disable_env && let Some(creds) = bedrock::AwsCredentials::from_environment() {
             let region = bedrock::AwsCredentials::detect_region()
                 .unwrap_or_else(|| bedrock::DEFAULT_REGION.to_string());
             match bedrock::BedrockProvider::with_credentials(creds, region) {
@@ -83,13 +84,12 @@ impl ProviderRegistry {
         }
 
         // ---- Env-var fallback ----
-        let disable = fallback_policy::env_fallback_disabled();
-        if !disable {
+        if !disable_env {
             super::init_env::register_env_fallbacks(&mut registry);
         } else {
             tracing::info!(
                 env = fallback_policy::DISABLE_ENV_FALLBACK,
-                "Environment variable fallback disabled"
+                "Env/AWS fallback disabled"
             );
         }
 

--- a/src/provider/init_config.rs
+++ b/src/provider/init_config.rs
@@ -2,6 +2,7 @@
 
 use super::anthropic;
 use super::bedrock;
+use super::fallback_policy;
 use super::google;
 use super::openai;
 use super::registry::ProviderRegistry;
@@ -82,14 +83,13 @@ impl ProviderRegistry {
         }
 
         // ---- Env-var fallback ----
-        let disable = std::env::var("CODETETHER_DISABLE_ENV_FALLBACK")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        let disable = fallback_policy::env_fallback_disabled();
         if !disable {
             super::init_env::register_env_fallbacks(&mut registry);
         } else {
             tracing::info!(
-                "Environment variable fallback disabled (CODETETHER_DISABLE_ENV_FALLBACK=1)"
+                env = fallback_policy::DISABLE_ENV_FALLBACK,
+                "Environment variable fallback disabled"
             );
         }
 

--- a/src/provider/init_dispatch_impl.rs
+++ b/src/provider/init_dispatch_impl.rs
@@ -36,7 +36,9 @@ pub(super) fn dispatch_bedrock(secrets: &ProviderSecrets) -> Option<Arc<dyn Prov
         bedrock::BedrockProvider::with_credentials(creds, region)
     } else if let Some(ref key) = secrets.api_key {
         bedrock::BedrockProvider::with_region(key.clone(), region)
-    } else if let Some(creds) = bedrock::AwsCredentials::from_environment() {
+    } else if !super::fallback_policy::env_fallback_disabled()
+        && let Some(creds) = bedrock::AwsCredentials::from_environment()
+    {
         bedrock::BedrockProvider::with_credentials(creds, region)
     } else {
         tracing::warn!("No AWS credentials or API key found for Bedrock");

--- a/src/provider/init_vault.rs
+++ b/src/provider/init_vault.rs
@@ -1,10 +1,12 @@
 //! Build a [`ProviderRegistry`](super::ProviderRegistry) from HashiCorp Vault.
 //!
 //! Iterates all providers configured in Vault, delegates each to
-//! [`super::init_dispatch::dispatch`], then falls back to env-var / AWS
-//! auto-detection when `CODETETHER_DISABLE_ENV_FALLBACK` is not set.
+//! [`super::init_dispatch::dispatch`], then adds env-var / AWS auto-detection
+//! unless [`CODETETHER_DISABLE_ENV_FALLBACK`](super::fallback_policy::DISABLE_ENV_FALLBACK)
+//! is set.
 
 use super::bedrock;
+use super::fallback_policy;
 use super::init_dispatch;
 use super::init_env;
 use super::registry::ProviderRegistry;
@@ -12,7 +14,7 @@ use anyhow::Result;
 use std::sync::Arc;
 
 impl ProviderRegistry {
-    /// Initialize providers from HashiCorp Vault with env-var fallback.
+    /// Initialize providers from HashiCorp Vault with optional env/AWS fallback.
     ///
     /// See [module-level docs](super) for the security model and fallback order.
     ///
@@ -26,9 +28,7 @@ impl ProviderRegistry {
     /// ```
     pub async fn from_vault() -> Result<Self> {
         let mut registry = Self::new();
-        let disable_env = std::env::var("CODETETHER_DISABLE_ENV_FALLBACK")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        let disable_env = fallback_policy::env_fallback_disabled();
 
         if let Some(mgr) = crate::secrets::secrets_manager() {
             let providers = mgr.list_configured_providers().await?;
@@ -80,18 +80,15 @@ impl ProviderRegistry {
             init_env::register_env_fallbacks(&mut registry);
         } else {
             tracing::info!(
-                "Environment variable fallback disabled (CODETETHER_DISABLE_ENV_FALLBACK=1)"
+                env = fallback_policy::DISABLE_ENV_FALLBACK,
+                "Environment variable fallback disabled"
             );
         }
 
         tracing::info!(
-            "Registered {} providers{}",
+            mode = fallback_policy::registry_mode_label(disable_env),
+            "Registered {} providers",
             registry.providers.len(),
-            if disable_env {
-                " (Vault only)"
-            } else {
-                " (Vault + env fallback)"
-            }
         );
         Ok(registry)
     }

--- a/src/provider/init_vault.rs
+++ b/src/provider/init_vault.rs
@@ -81,7 +81,7 @@ impl ProviderRegistry {
         } else {
             tracing::info!(
                 env = fallback_policy::DISABLE_ENV_FALLBACK,
-                "Environment variable fallback disabled"
+                "Env/AWS fallback disabled"
             );
         }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -23,6 +23,7 @@ pub mod anthropic;
 pub mod bedrock;
 pub mod body_cap;
 pub mod copilot;
+mod fallback_policy;
 pub mod gemini_web;
 pub mod glm5;
 pub mod google;

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -1,7 +1,8 @@
 //! Secrets management via HashiCorp Vault
 //!
-//! All API keys and secrets are loaded exclusively from HashiCorp Vault.
-//! Environment variables are NOT used for secrets.
+//! This module only reads HashiCorp Vault. Provider initialization may add
+//! local-development env/AWS fallback credentials unless
+//! `CODETETHER_DISABLE_ENV_FALLBACK=1` is set.
 
 use anyhow::{Context, Result};
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary
- document provider loading as Vault-first with optional env/AWS fallback
- centralize and test CODETETHER_DISABLE_ENV_FALLBACK parsing and mode labels
- update runtime logs and top-level security docs to match actual behavior

Fixes #77

## Tests
- cargo test fallback_policy