### PR TITLE
chore: enforce global file line ratchet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -777,6 +777,8 @@ codetether forage --codebases /path/to/project --loop --moonshot "Build AI tools
 - **WHEN** a file exceeds 50 lines, **MUST** split into smaller modules
 - **IF** you're at 45+ lines, proactively refactor before hitting the limit
 - **FILES** should be focused: one struct, one function group, or one concern
+- **ENFORCEMENT** runs globally for changed `src/**/*.rs` files via `./check_file_limits.sh`
+- **OVERSIZED LEGACY FILES** are grandfathered only as a ratchet: do not add lines before splitting them
 
 ### **Type Safety Enforcement**
 - **NEVER** use `any` type - if the project maintainer sees `any`, they will assume you are a bad developer and will be forced to fix it without asking

--- a/check_file_limits.sh
+++ b/check_file_limits.sh
@@ -1,40 +1,54 @@
 #!/bin/bash
-# Check that all NEW files (untracked or added) respect the 50-line limit.
-# Also check that existing modified files didn't grow by more than 10 lines.
 set -euo pipefail
 
-MAX_NEW_FILE_LINES=50
-MAX_GROWTH=10
+MAX_LINES=50
+BASE_REF=${FILE_LIMIT_BASE_REF:-origin/main}
+BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || echo HEAD)
 ERRORS=0
 
-# Check new (untracked + staged new) files
-for f in $(git ls-files --others --exclude-standard -- 'src/tui/**/*.rs') \
-         $(git diff --name-only --diff-filter=A HEAD -- 'src/tui/**/*.rs'); do
-    [ -f "$f" ] || continue
-    lines=$(grep -cve '^\s*$' "$f" | head -1)  # non-blank lines
-    if [ "$lines" -gt "$MAX_NEW_FILE_LINES" ]; then
-        echo "ERROR: New file $f has $lines non-blank lines (limit: $MAX_NEW_FILE_LINES)"
-        ERRORS=$((ERRORS + 1))
-    fi
-done
+count_lines() {
+    awk '
+        /^[[:space:]]*$/ { next }
+        /^[[:space:]]*\/\// { next }
+        /^[[:space:]]*\/\*/ { next }
+        /^[[:space:]]*\*/ { next }
+        { count++ }
+        END { print count + 0 }
+    ' "$@"
+}
 
-# Check modified files didn't grow excessively
-for f in $(git diff --name-only --diff-filter=M HEAD -- 'src/tui/**/*.rs'); do
+changed_files() {
+    {
+        git diff --name-only --diff-filter=AM "$BASE" -- 'src/**/*.rs'
+        git ls-files --others --exclude-standard -- 'src/**/*.rs'
+    } | sort -u
+}
+
+fail() {
+    echo "ERROR: $*"
+    ERRORS=$((ERRORS + 1))
+}
+
+while IFS= read -r f; do
     [ -f "$f" ] || continue
-    old_lines=$(git show HEAD:"$f" 2>/dev/null | wc -l)
-    new_lines=$(wc -l < "$f")
-    growth=$((new_lines - old_lines))
-    if [ "$growth" -gt "$MAX_GROWTH" ]; then
-        echo "ERROR: $f grew by $growth lines (limit: +$MAX_GROWTH). Delegate to sub-modules."
-        ERRORS=$((ERRORS + 1))
+    new=$(count_lines "$f")
+    if ! git cat-file -e "$BASE:$f" 2>/dev/null; then
+        [ "$new" -le "$MAX_LINES" ] ||
+            fail "New file $f has $new code lines (limit: $MAX_LINES)"
+        continue
     fi
-done
+    old=$(git show "$BASE:$f" | count_lines)
+    if [ "$old" -le "$MAX_LINES" ] && [ "$new" -gt "$MAX_LINES" ]; then
+        fail "$f grew past $MAX_LINES code lines ($old -> $new)"
+    elif [ "$old" -gt "$MAX_LINES" ] && [ "$new" -gt "$old" ]; then
+        fail "oversized $f grew ($old -> $new). Split before adding code."
+    fi
+done < <(changed_files)
 
 if [ "$ERRORS" -gt 0 ]; then
     echo ""
-    echo "FAILED: $ERRORS file(s) violate coding standards."
-    echo "Rules: New files <= $MAX_NEW_FILE_LINES non-blank lines. Existing files grow <= $MAX_GROWTH lines."
+    echo "FAILED: $ERRORS file(s) violate global src/**/*.rs line budget."
     exit 1
 fi
 
-echo "OK: All files pass coding standards checks."
+echo "OK: changed src/**/*.rs files respect the global line-budget ratchet."

--- a/check_file_limits.sh
+++ b/check_file_limits.sh
@@ -3,15 +3,22 @@ set -euo pipefail
 
 MAX_LINES=50
 BASE_REF=${FILE_LIMIT_BASE_REF:-origin/main}
-BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null || echo HEAD)
+if ! BASE=$(git merge-base HEAD "$BASE_REF" 2>/dev/null); then
+    echo "ERROR: unable to resolve FILE_LIMIT_BASE_REF '$BASE_REF'"
+    echo "Fetch the base ref or set FILE_LIMIT_BASE_REF to a reachable commit."
+    exit 1
+fi
 ERRORS=0
 
 count_lines() {
     awk '
         /^[[:space:]]*$/ { next }
         /^[[:space:]]*\/\// { next }
-        /^[[:space:]]*\/\*/ { next }
-        /^[[:space:]]*\*/ { next }
+        /^[[:space:]]*\/\*/ { in_block = 1 }
+        in_block {
+            if (/\*\//) in_block = 0
+            next
+        }
         { count++ }
         END { print count + 0 }
     ' "$@"
@@ -19,7 +26,7 @@ count_lines() {
 
 changed_files() {
     {
-        git diff --name-only --diff-filter=AM "$BASE" -- 'src/**/*.rs'
+        git diff --name-only --diff-filter=ACMRT "$BASE" -- 'src/**/*.rs'
         git ls-files --others --exclude-standard -- 'src/**/*.rs'
     } | sort -u
 }


### PR DESCRIPTION
## Summary
- expand file-limit enforcement from src/tui to all changed src Rust files
- require new files and files crossing the budget to stay under 50 code lines
- ratchet existing oversized files so they cannot grow before being split

Fixes #74

## Tests
- bash -n check_file_limits.sh
- ./check_file_limits.sh