### PR TITLE
fix: gate Ralph stories on verification steps

### DIFF
--- a/src/ralph/mod.rs
+++ b/src/ralph/mod.rs
@@ -11,6 +11,7 @@ pub mod state_store;
 pub mod store_http;
 pub mod store_memory;
 mod types;
+mod verification;
 
 pub use ralph_loop::*;
 pub use state_store::{RalphRunState, RalphRunSummary, RalphStateStore, StoryResultEntry};

--- a/src/ralph/ralph_loop.rs
+++ b/src/ralph/ralph_loop.rs
@@ -2,6 +2,7 @@
 
 use super::state_store::{RalphRunState, RalphStateStore, StoryResultEntry};
 use super::types::*;
+use super::verification::run_story_verification;
 use crate::bus::AgentBus;
 use crate::bus::relay::{ProtocolRelayRuntime, RelayAgentProfile};
 use crate::provenance::{
@@ -518,6 +519,31 @@ impl RalphLoop {
                     if self.config.quality_checks_enabled {
                         if self.run_quality_gates_with_events(&story.id).await? {
                             info!("Story {} passed quality checks!", story.id);
+                            if let Err(error) =
+                                run_story_verification(&self.state.working_dir, &story).await
+                            {
+                                let error = format!("Verification steps failed: {error}");
+                                warn!(story_id = %story.id, error = %error);
+                                if let Some(ref store) = self.store {
+                                    let s = store.clone();
+                                    let rid = self.run_id.clone();
+                                    let entry = StoryResultEntry {
+                                        story_id: story.id.clone(),
+                                        title: story.title.clone(),
+                                        passed: false,
+                                        iteration: self.state.current_iteration,
+                                        error: Some(error.clone()),
+                                    };
+                                    self.store_fire_and_forget(async move {
+                                        s.record_story_result(&rid, &entry).await
+                                    });
+                                }
+                                self.try_send_event(RalphEvent::StoryComplete {
+                                    story_id: story.id.clone(),
+                                    passed: false,
+                                });
+                                continue;
+                            }
                             self.state.prd.mark_passed(&story.id);
 
                             // Record story result in store
@@ -591,7 +617,32 @@ impl RalphLoop {
                             });
                         }
                     } else {
-                        // No quality checks, just mark as passed
+                        // No quality checks; verification still gates completion.
+                        if let Err(error) =
+                            run_story_verification(&self.state.working_dir, &story).await
+                        {
+                            let error = format!("Verification steps failed: {error}");
+                            warn!(story_id = %story.id, error = %error);
+                            if let Some(ref store) = self.store {
+                                let s = store.clone();
+                                let rid = self.run_id.clone();
+                                let entry = StoryResultEntry {
+                                    story_id: story.id.clone(),
+                                    title: story.title.clone(),
+                                    passed: false,
+                                    iteration: self.state.current_iteration,
+                                    error: Some(error.clone()),
+                                };
+                                self.store_fire_and_forget(async move {
+                                    s.record_story_result(&rid, &entry).await
+                                });
+                            }
+                            self.try_send_event(RalphEvent::StoryComplete {
+                                story_id: story.id.clone(),
+                                passed: false,
+                            });
+                            continue;
+                        }
                         self.state.prd.mark_passed(&story.id);
                         self.state.prd.save(&self.state.prd_path).await?;
 
@@ -788,6 +839,7 @@ impl RalphLoop {
                     Option<crate::worktree::WorktreeInfo>,
                     Option<std::sync::Arc<crate::worktree::WorktreeManager>>,
                     bool, // quality_passed
+                    Option<String>,
                 )> = tokio::spawn(async move {
                     let _permit = sem.acquire().await.expect("semaphore closed");
 
@@ -929,10 +981,11 @@ impl RalphLoop {
 
                     // Quality-gate retry loop: if agent succeeded but quality gates fail,
                     // feed errors back and let the agent try to fix them.
-                    let (final_result, quality_passed) = match call_result {
+                    let (final_result, quality_passed, failure_reason) = match call_result {
                         Ok(initial_output) => {
                             let mut output = initial_output;
-                            let mut qg_passed = !quality_checks_enabled; // skip if disabled
+                            let mut qg_passed = false;
+                            let mut failure_reason = None;
 
                             if quality_checks_enabled {
                                 for qg_attempt in 0..=max_quality_retries {
@@ -988,16 +1041,31 @@ impl RalphLoop {
                                     }
 
                                     if all_ok {
-                                        qg_passed = true;
-                                        info!(
-                                            story_id = %story.id,
-                                            attempt = qg_attempt + 1,
-                                            "Quality gates passed"
-                                        );
-                                        break;
+                                        match run_story_verification(&story_working_dir, &story)
+                                            .await
+                                        {
+                                            Ok(()) => {
+                                                qg_passed = true;
+                                                failure_reason = None;
+                                                info!(
+                                                    story_id = %story.id,
+                                                    attempt = qg_attempt + 1,
+                                                    "Quality gates and verification passed"
+                                                );
+                                                break;
+                                            }
+                                            Err(e) => {
+                                                error_output =
+                                                    format!("Verification steps failed:\n{e}");
+                                                failure_reason = Some(error_output.clone());
+                                            }
+                                        }
                                     }
 
                                     if qg_attempt < max_quality_retries {
+                                        if !error_output.is_empty() {
+                                            failure_reason = Some(error_output.clone());
+                                        }
                                         // Feed errors back to agent for self-repair
                                         warn!(
                                             story_id = %story.id,
@@ -1053,6 +1121,9 @@ impl RalphLoop {
                                             }
                                         }
                                     } else {
+                                        if !error_output.is_empty() {
+                                            failure_reason = Some(error_output.clone());
+                                        }
                                         warn!(
                                             story_id = %story.id,
                                             "Quality gates still failing after {} retries",
@@ -1060,11 +1131,22 @@ impl RalphLoop {
                                         );
                                     }
                                 }
+                            } else {
+                                match run_story_verification(&story_working_dir, &story).await {
+                                    Ok(()) => {
+                                        qg_passed = true;
+                                        failure_reason = None;
+                                    }
+                                    Err(e) => {
+                                        failure_reason =
+                                            Some(format!("Verification steps failed:\n{e}"));
+                                    }
+                                }
                             }
 
-                            (Ok(output), qg_passed)
+                            (Ok(output), qg_passed, failure_reason)
                         }
-                        Err(e) => (Err(e), false),
+                        Err(e) => (Err(e), false, None),
                     };
 
                     let entry = match &final_result {
@@ -1102,6 +1184,7 @@ impl RalphLoop {
                         worktree_info,
                         worktree_mgr,
                         quality_passed,
+                        failure_reason,
                     )
                 });
 
@@ -1112,7 +1195,15 @@ impl RalphLoop {
             let _stage_passed = 0usize;
             for handle in handles {
                 match handle.await {
-                    Ok((story, success, entry, worktree_info, worktree_mgr, quality_passed)) => {
+                    Ok((
+                        story,
+                        success,
+                        entry,
+                        worktree_info,
+                        worktree_mgr,
+                        quality_passed,
+                        failure_reason,
+                    )) => {
                         self.state.progress_log.push(entry);
 
                         if success && quality_passed {
@@ -1138,6 +1229,38 @@ impl RalphLoop {
                                                     files_changed = merge_result.files_changed,
                                                     "Merged story changes successfully"
                                                 );
+                                                if let Err(error) =
+                                                    run_story_verification(&working_dir, &story)
+                                                        .await
+                                                {
+                                                    let error = format!(
+                                                        "Verification steps failed after merge: {error}"
+                                                    );
+                                                    warn!(story_id = %story.id, error = %error);
+                                                    if let Some(ref store) = self.store {
+                                                        let s = store.clone();
+                                                        let rid = self.run_id.clone();
+                                                        let entry = StoryResultEntry {
+                                                            story_id: story.id.clone(),
+                                                            title: story.title.clone(),
+                                                            passed: false,
+                                                            iteration: self.state.current_iteration,
+                                                            error: Some(error),
+                                                        };
+                                                        self.store_fire_and_forget(async move {
+                                                            s.record_story_result(&rid, &entry)
+                                                                .await
+                                                        });
+                                                    }
+                                                    self.try_send_event(
+                                                        RalphEvent::StoryComplete {
+                                                            story_id: story.id.clone(),
+                                                            passed: false,
+                                                        },
+                                                    );
+                                                    let _ = mgr.cleanup(&wt.name).await;
+                                                    continue;
+                                                }
                                                 self.state.prd.mark_passed(&story.id);
                                                 self.try_send_event(RalphEvent::StoryMerge {
                                                     story_id: story.id.clone(),
@@ -1207,9 +1330,42 @@ impl RalphLoop {
                                                                             story_id = %story.id,
                                                                             "Merge completed after conflict resolution"
                                                                         );
-                                                                        self.state
-                                                                            .prd
-                                                                            .mark_passed(&story.id);
+                                                                        match run_story_verification(
+                                                                            &working_dir,
+                                                                            &story,
+                                                                        )
+                                                                        .await
+                                                                        {
+                                                                            Ok(()) => self
+                                                                                .state
+                                                                                .prd
+                                                                                .mark_passed(
+                                                                                    &story.id,
+                                                                                ),
+                                                                            Err(e) => {
+                                                                                let error = format!(
+                                                                                    "Verification failed after conflict resolution: {e}"
+                                                                                );
+                                                                                warn!(
+                                                                                    story_id = %story.id,
+                                                                                    error = %error
+                                                                                );
+                                                                                if let Some(ref store) = self.store {
+                                                                                    let s = store.clone();
+                                                                                    let rid = self.run_id.clone();
+                                                                                    let entry = StoryResultEntry {
+                                                                                        story_id: story.id.clone(),
+                                                                                        title: story.title.clone(),
+                                                                                        passed: false,
+                                                                                        iteration: self.state.current_iteration,
+                                                                                        error: Some(error),
+                                                                                    };
+                                                                                    self.store_fire_and_forget(async move {
+                                                                                        s.record_story_result(&rid, &entry).await
+                                                                                    });
+                                                                                }
+                                                                            }
+                                                                        }
                                                                     } else {
                                                                         warn!(
                                                                             story_id = %story.id,
@@ -1278,7 +1434,32 @@ impl RalphLoop {
                                         }
                                     }
                                 } else {
-                                    // No worktree, just mark passed
+                                    // No worktree; verification still gates completion.
+                                    if let Err(error) =
+                                        run_story_verification(&working_dir, &story).await
+                                    {
+                                        let error = format!("Verification steps failed: {error}");
+                                        warn!(story_id = %story.id, error = %error);
+                                        if let Some(ref store) = self.store {
+                                            let s = store.clone();
+                                            let rid = self.run_id.clone();
+                                            let entry = StoryResultEntry {
+                                                story_id: story.id.clone(),
+                                                title: story.title.clone(),
+                                                passed: false,
+                                                iteration: self.state.current_iteration,
+                                                error: Some(error),
+                                            };
+                                            self.store_fire_and_forget(async move {
+                                                s.record_story_result(&rid, &entry).await
+                                            });
+                                        }
+                                        self.try_send_event(RalphEvent::StoryComplete {
+                                            story_id: story.id.clone(),
+                                            passed: false,
+                                        });
+                                        continue;
+                                    }
                                     self.state.prd.mark_passed(&story.id);
                                     self.try_send_event(RalphEvent::StoryComplete {
                                         story_id: story.id.clone(),
@@ -1304,10 +1485,31 @@ impl RalphLoop {
                             }
                         } else {
                             // Failed - cleanup worktree without merging (keep for debugging)
+                            let error = failure_reason.unwrap_or_else(|| {
+                                if success {
+                                    "Quality or verification checks failed".to_string()
+                                } else {
+                                    "LLM call failed".to_string()
+                                }
+                            });
                             self.try_send_event(RalphEvent::StoryError {
                                 story_id: story.id.clone(),
-                                error: "LLM call failed".to_string(),
+                                error: error.clone(),
                             });
+                            if let Some(ref store) = self.store {
+                                let s = store.clone();
+                                let rid = self.run_id.clone();
+                                let entry = StoryResultEntry {
+                                    story_id: story.id.clone(),
+                                    title: story.title.clone(),
+                                    passed: false,
+                                    iteration: self.state.current_iteration,
+                                    error: Some(error),
+                                };
+                                self.store_fire_and_forget(async move {
+                                    s.record_story_result(&rid, &entry).await
+                                });
+                            }
                             if let Some(ref wt) = worktree_info {
                                 info!(
                                     story_id = %story.id,
@@ -1384,6 +1586,9 @@ impl RalphLoop {
 ### Acceptance Criteria:
 {}
 
+### Verification Steps:
+{}
+
 ## WORKFLOW (follow this exactly):
 
 1. **EXPLORE** (2-4 tool calls): Use `glob` and `read` to understand existing code
@@ -1429,9 +1634,19 @@ Do NOT keep iterating indefinitely. Stop when done or blocked.
                 .map(|c| format!("- {}", c))
                 .collect::<Vec<_>>()
                 .join("\n"),
+            Self::format_verification_steps(story),
             story.id,
             story.id
         )
+    }
+
+    fn format_verification_steps(story: &UserStory) -> String {
+        if story.verification_steps.is_empty() {
+            "None".to_string()
+        } else {
+            serde_json::to_string_pretty(&story.verification_steps)
+                .unwrap_or_else(|_| "Unable to render verification steps".to_string())
+        }
     }
 
     /// Call LLM with agentic tool loop (static version for parallel execution)
@@ -2088,6 +2303,9 @@ Working directory: {}
 ### Acceptance Criteria:
 {}
 
+### Verification Steps:
+{}
+
 ## Previous Progress:
 {}
 
@@ -2110,6 +2328,7 @@ Respond with the implementation and any shell commands needed.
                 .map(|c| format!("- {}", c))
                 .collect::<Vec<_>>()
                 .join("\n"),
+            Self::format_verification_steps(story),
             if progress.is_empty() {
                 "None yet".to_string()
             } else {

--- a/src/ralph/ralph_loop.rs
+++ b/src/ralph/ralph_loop.rs
@@ -140,6 +140,21 @@ impl RalphLoop {
         }
     }
 
+    fn record_story_result(&self, story: &UserStory, passed: bool, error: Option<String>) {
+        if let Some(ref store) = self.store {
+            let s = store.clone();
+            let rid = self.run_id.clone();
+            let entry = StoryResultEntry {
+                story_id: story.id.clone(),
+                title: story.title.clone(),
+                passed,
+                iteration: self.state.current_iteration,
+                error,
+            };
+            self.store_fire_and_forget(async move { s.record_story_result(&rid, &entry).await });
+        }
+    }
+
     /// Publish story learnings, handoff context, and progress to the bus.
     fn bus_publish_story_result(
         &self,
@@ -524,20 +539,7 @@ impl RalphLoop {
                             {
                                 let error = format!("Verification steps failed: {error}");
                                 warn!(story_id = %story.id, error = %error);
-                                if let Some(ref store) = self.store {
-                                    let s = store.clone();
-                                    let rid = self.run_id.clone();
-                                    let entry = StoryResultEntry {
-                                        story_id: story.id.clone(),
-                                        title: story.title.clone(),
-                                        passed: false,
-                                        iteration: self.state.current_iteration,
-                                        error: Some(error.clone()),
-                                    };
-                                    self.store_fire_and_forget(async move {
-                                        s.record_story_result(&rid, &entry).await
-                                    });
-                                }
+                                self.record_story_result(&story, false, Some(error.clone()));
                                 self.try_send_event(RalphEvent::StoryComplete {
                                     story_id: story.id.clone(),
                                     passed: false,
@@ -547,20 +549,7 @@ impl RalphLoop {
                             self.state.prd.mark_passed(&story.id);
 
                             // Record story result in store
-                            if let Some(ref store) = self.store {
-                                let s = store.clone();
-                                let rid = self.run_id.clone();
-                                let entry = StoryResultEntry {
-                                    story_id: story.id.clone(),
-                                    title: story.title.clone(),
-                                    passed: true,
-                                    iteration: self.state.current_iteration,
-                                    error: None,
-                                };
-                                self.store_fire_and_forget(async move {
-                                    s.record_story_result(&rid, &entry).await
-                                });
-                            }
+                            self.record_story_result(&story, true, None);
 
                             self.try_send_event(RalphEvent::StoryComplete {
                                 story_id: story.id.clone(),
@@ -587,20 +576,11 @@ impl RalphLoop {
                             warn!("Story {} failed quality checks", story.id);
 
                             // Record failed story result in store
-                            if let Some(ref store) = self.store {
-                                let s = store.clone();
-                                let rid = self.run_id.clone();
-                                let entry = StoryResultEntry {
-                                    story_id: story.id.clone(),
-                                    title: story.title.clone(),
-                                    passed: false,
-                                    iteration: self.state.current_iteration,
-                                    error: Some("Quality checks failed".to_string()),
-                                };
-                                self.store_fire_and_forget(async move {
-                                    s.record_story_result(&rid, &entry).await
-                                });
-                            }
+                            self.record_story_result(
+                                &story,
+                                false,
+                                Some("Quality checks failed".to_string()),
+                            );
 
                             // Publish failure learnings to bus
                             let next = self.state.prd.next_story().map(|s| s.id.clone());
@@ -623,20 +603,7 @@ impl RalphLoop {
                         {
                             let error = format!("Verification steps failed: {error}");
                             warn!(story_id = %story.id, error = %error);
-                            if let Some(ref store) = self.store {
-                                let s = store.clone();
-                                let rid = self.run_id.clone();
-                                let entry = StoryResultEntry {
-                                    story_id: story.id.clone(),
-                                    title: story.title.clone(),
-                                    passed: false,
-                                    iteration: self.state.current_iteration,
-                                    error: Some(error.clone()),
-                                };
-                                self.store_fire_and_forget(async move {
-                                    s.record_story_result(&rid, &entry).await
-                                });
-                            }
+                            self.record_story_result(&story, false, Some(error.clone()));
                             self.try_send_event(RalphEvent::StoryComplete {
                                 story_id: story.id.clone(),
                                 passed: false,
@@ -647,20 +614,7 @@ impl RalphLoop {
                         self.state.prd.save(&self.state.prd_path).await?;
 
                         // Record story result in store
-                        if let Some(ref store) = self.store {
-                            let s = store.clone();
-                            let rid = self.run_id.clone();
-                            let entry = StoryResultEntry {
-                                story_id: story.id.clone(),
-                                title: story.title.clone(),
-                                passed: true,
-                                iteration: self.state.current_iteration,
-                                error: None,
-                            };
-                            self.store_fire_and_forget(async move {
-                                s.record_story_result(&rid, &entry).await
-                            });
-                        }
+                        self.record_story_result(&story, true, None);
 
                         self.try_send_event(RalphEvent::StoryComplete {
                             story_id: story.id.clone(),
@@ -1237,21 +1191,11 @@ impl RalphLoop {
                                                         "Verification steps failed after merge: {error}"
                                                     );
                                                     warn!(story_id = %story.id, error = %error);
-                                                    if let Some(ref store) = self.store {
-                                                        let s = store.clone();
-                                                        let rid = self.run_id.clone();
-                                                        let entry = StoryResultEntry {
-                                                            story_id: story.id.clone(),
-                                                            title: story.title.clone(),
-                                                            passed: false,
-                                                            iteration: self.state.current_iteration,
-                                                            error: Some(error),
-                                                        };
-                                                        self.store_fire_and_forget(async move {
-                                                            s.record_story_result(&rid, &entry)
-                                                                .await
-                                                        });
-                                                    }
+                                                    self.record_story_result(
+                                                        &story,
+                                                        false,
+                                                        Some(error),
+                                                    );
                                                     self.try_send_event(
                                                         RalphEvent::StoryComplete {
                                                             story_id: story.id.clone(),
@@ -1273,20 +1217,7 @@ impl RalphLoop {
                                                 });
 
                                                 // Record story result in store
-                                                if let Some(ref store) = self.store {
-                                                    let s = store.clone();
-                                                    let rid = self.run_id.clone();
-                                                    let entry = StoryResultEntry {
-                                                        story_id: story.id.clone(),
-                                                        title: story.title.clone(),
-                                                        passed: true,
-                                                        iteration: self.state.current_iteration,
-                                                        error: None,
-                                                    };
-                                                    self.store_fire_and_forget(async move {
-                                                        s.record_story_result(&rid, &entry).await
-                                                    });
-                                                }
+                                                self.record_story_result(&story, true, None);
 
                                                 // Cleanup worktree
                                                 let _ = mgr.cleanup(&wt.name).await;
@@ -1350,20 +1281,15 @@ impl RalphLoop {
                                                                                     story_id = %story.id,
                                                                                     error = %error
                                                                                 );
-                                                                                if let Some(ref store) = self.store {
-                                                                                    let s = store.clone();
-                                                                                    let rid = self.run_id.clone();
-                                                                                    let entry = StoryResultEntry {
-                                                                                        story_id: story.id.clone(),
-                                                                                        title: story.title.clone(),
-                                                                                        passed: false,
-                                                                                        iteration: self.state.current_iteration,
-                                                                                        error: Some(error),
-                                                                                    };
-                                                                                    self.store_fire_and_forget(async move {
-                                                                                        s.record_story_result(&rid, &entry).await
-                                                                                    });
-                                                                                }
+                                                                                self.record_story_result(
+                                                                                    &story,
+                                                                                    false,
+                                                                                    Some(error),
+                                                                                );
+                                                                                self.try_send_event(RalphEvent::StoryComplete {
+                                                                                    story_id: story.id.clone(),
+                                                                                    passed: false,
+                                                                                });
                                                                             }
                                                                         }
                                                                     } else {
@@ -1440,20 +1366,7 @@ impl RalphLoop {
                                     {
                                         let error = format!("Verification steps failed: {error}");
                                         warn!(story_id = %story.id, error = %error);
-                                        if let Some(ref store) = self.store {
-                                            let s = store.clone();
-                                            let rid = self.run_id.clone();
-                                            let entry = StoryResultEntry {
-                                                story_id: story.id.clone(),
-                                                title: story.title.clone(),
-                                                passed: false,
-                                                iteration: self.state.current_iteration,
-                                                error: Some(error),
-                                            };
-                                            self.store_fire_and_forget(async move {
-                                                s.record_story_result(&rid, &entry).await
-                                            });
-                                        }
+                                        self.record_story_result(&story, false, Some(error));
                                         self.try_send_event(RalphEvent::StoryComplete {
                                             story_id: story.id.clone(),
                                             passed: false,
@@ -1467,20 +1380,7 @@ impl RalphLoop {
                                     });
 
                                     // Record story result in store
-                                    if let Some(ref store) = self.store {
-                                        let s = store.clone();
-                                        let rid = self.run_id.clone();
-                                        let entry = StoryResultEntry {
-                                            story_id: story.id.clone(),
-                                            title: story.title.clone(),
-                                            passed: true,
-                                            iteration: self.state.current_iteration,
-                                            error: None,
-                                        };
-                                        self.store_fire_and_forget(async move {
-                                            s.record_story_result(&rid, &entry).await
-                                        });
-                                    }
+                                    self.record_story_result(&story, true, None);
                                 }
                             }
                         } else {
@@ -1496,20 +1396,7 @@ impl RalphLoop {
                                 story_id: story.id.clone(),
                                 error: error.clone(),
                             });
-                            if let Some(ref store) = self.store {
-                                let s = store.clone();
-                                let rid = self.run_id.clone();
-                                let entry = StoryResultEntry {
-                                    story_id: story.id.clone(),
-                                    title: story.title.clone(),
-                                    passed: false,
-                                    iteration: self.state.current_iteration,
-                                    error: Some(error),
-                                };
-                                self.store_fire_and_forget(async move {
-                                    s.record_story_result(&rid, &entry).await
-                                });
-                            }
+                            self.record_story_result(&story, false, Some(error));
                             if let Some(ref wt) = worktree_info {
                                 info!(
                                     story_id = %story.id,

--- a/src/ralph/verification.rs
+++ b/src/ralph/verification.rs
@@ -11,8 +11,9 @@ use std::path::Path;
 
 pub async fn run_story_verification(root: &Path, story: &UserStory) -> Result<()> {
     let mut failures = Vec::new();
+    let client = reqwest::Client::new();
     for (index, item) in story.verification_steps.iter().enumerate() {
-        if let Err(error) = step::run(root, item).await {
+        if let Err(error) = step::run(root, item, &client).await {
             failures.push(format!("step {}: {error}", index + 1));
         }
     }

--- a/src/ralph/verification.rs
+++ b/src/ralph/verification.rs
@@ -1,0 +1,24 @@
+mod file;
+mod shell;
+mod step;
+#[cfg(test)]
+mod tests;
+mod url;
+
+use super::types::UserStory;
+use anyhow::{Result, anyhow};
+use std::path::Path;
+
+pub async fn run_story_verification(root: &Path, story: &UserStory) -> Result<()> {
+    let mut failures = Vec::new();
+    for (index, item) in story.verification_steps.iter().enumerate() {
+        if let Err(error) = step::run(root, item).await {
+            failures.push(format!("step {}: {error}", index + 1));
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!(failures.join("\n")))
+    }
+}

--- a/src/ralph/verification/file.rs
+++ b/src/ralph/verification/file.rs
@@ -1,0 +1,32 @@
+use anyhow::{Result, bail};
+use std::path::Path;
+
+pub fn exists(root: &Path, path: &str, is_glob: bool) -> Result<()> {
+    if is_glob {
+        if glob_exists(root, path)? {
+            return Ok(());
+        }
+        bail!("no files matched glob `{path}`");
+    }
+
+    let candidate = root.join(path);
+    if candidate.exists() {
+        Ok(())
+    } else {
+        bail!("file `{}` does not exist", candidate.display())
+    }
+}
+
+pub fn glob_exists(root: &Path, pattern: &str) -> Result<bool> {
+    let anchored = if Path::new(pattern).is_absolute() {
+        pattern.to_string()
+    } else {
+        root.join(pattern).to_string_lossy().to_string()
+    };
+    for entry in glob::glob(&anchored)? {
+        if matches!(entry, Ok(path) if path.exists()) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}

--- a/src/ralph/verification/shell.rs
+++ b/src/ralph/verification/shell.rs
@@ -1,0 +1,39 @@
+use super::file::glob_exists;
+use anyhow::{Result, bail};
+use std::path::Path;
+use std::process::Command;
+
+pub fn run(
+    root: &Path,
+    command: &str,
+    cwd: &Option<String>,
+    expect_output_contains: &[String],
+    expect_files_glob: &[String],
+) -> Result<()> {
+    let dir = cwd
+        .as_ref()
+        .map_or_else(|| root.to_path_buf(), |c| root.join(c));
+    let output = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(&dir)
+        .output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+
+    if !output.status.success() {
+        bail!("command `{command}` failed: {combined}");
+    }
+    for expected in expect_output_contains {
+        if !combined.contains(expected) {
+            bail!("command output did not contain `{expected}`");
+        }
+    }
+    for pattern in expect_files_glob {
+        if !glob_exists(&dir, pattern)? {
+            bail!("command did not create files matching `{pattern}`");
+        }
+    }
+    Ok(())
+}

--- a/src/ralph/verification/step.rs
+++ b/src/ralph/verification/step.rs
@@ -1,0 +1,40 @@
+use super::{file, shell, url};
+use crate::ralph::types::VerificationStep;
+use anyhow::Result;
+use std::path::Path;
+
+pub async fn run(root: &Path, step: &VerificationStep) -> Result<()> {
+    match step {
+        VerificationStep::Shell {
+            command,
+            cwd,
+            expect_output_contains,
+            expect_files_glob,
+            ..
+        } => shell::run(
+            root,
+            command,
+            cwd,
+            expect_output_contains,
+            expect_files_glob,
+        ),
+        VerificationStep::FileExists { path, glob, .. } => file::exists(root, path, *glob),
+        VerificationStep::Url {
+            url: target,
+            method,
+            expect_status,
+            expect_body_contains,
+            timeout_secs,
+            ..
+        } => {
+            url::check(
+                target,
+                method,
+                *expect_status,
+                expect_body_contains,
+                *timeout_secs,
+            )
+            .await
+        }
+    }
+}

--- a/src/ralph/verification/step.rs
+++ b/src/ralph/verification/step.rs
@@ -3,7 +3,7 @@ use crate::ralph::types::VerificationStep;
 use anyhow::Result;
 use std::path::Path;
 
-pub async fn run(root: &Path, step: &VerificationStep) -> Result<()> {
+pub async fn run(root: &Path, step: &VerificationStep, client: &reqwest::Client) -> Result<()> {
     match step {
         VerificationStep::Shell {
             command,
@@ -28,6 +28,7 @@ pub async fn run(root: &Path, step: &VerificationStep) -> Result<()> {
             ..
         } => {
             url::check(
+                client,
                 target,
                 method,
                 *expect_status,

--- a/src/ralph/verification/tests.rs
+++ b/src/ralph/verification/tests.rs
@@ -1,0 +1,49 @@
+use super::run_story_verification;
+use crate::ralph::types::{UserStory, VerificationStep};
+use tempfile::tempdir;
+
+fn story(step: VerificationStep) -> UserStory {
+    UserStory {
+        id: "US-1".into(),
+        title: "story".into(),
+        description: "desc".into(),
+        acceptance_criteria: vec![],
+        verification_steps: vec![step],
+        passes: false,
+        priority: 1,
+        depends_on: vec![],
+        complexity: 1,
+    }
+}
+
+#[tokio::test]
+async fn failing_step_blocks_completion_gate() {
+    let dir = tempdir().expect("tempdir");
+    let step = VerificationStep::FileExists {
+        name: None,
+        path: "missing.txt".into(),
+        glob: false,
+    };
+    assert!(
+        run_story_verification(dir.path(), &story(step))
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn shell_step_checks_output_and_artifacts() {
+    let dir = tempdir().expect("tempdir");
+    let step = VerificationStep::Shell {
+        name: None,
+        command: "mkdir -p out && echo ready > out/result.txt && echo ok".into(),
+        cwd: None,
+        expect_output_contains: vec!["ok".into()],
+        expect_files_glob: vec!["out/*.txt".into()],
+    };
+    assert!(
+        run_story_verification(dir.path(), &story(step))
+            .await
+            .is_ok()
+    );
+}

--- a/src/ralph/verification/url.rs
+++ b/src/ralph/verification/url.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result, bail};
 use std::time::Duration;
 
 pub async fn check(
+    client: &reqwest::Client,
     url: &str,
     method: &str,
     expect_status: u16,
@@ -11,10 +12,11 @@ pub async fn check(
     let method = method
         .parse::<reqwest::Method>()
         .with_context(|| format!("invalid HTTP method `{method}`"))?;
-    let client = reqwest::Client::builder()
+    let response = client
+        .request(method, url)
         .timeout(Duration::from_secs(timeout_secs))
-        .build()?;
-    let response = client.request(method, url).send().await?;
+        .send()
+        .await?;
     let status = response.status().as_u16();
     let body = response.text().await?;
 

--- a/src/ralph/verification/url.rs
+++ b/src/ralph/verification/url.rs
@@ -1,0 +1,30 @@
+use anyhow::{Context, Result, bail};
+use std::time::Duration;
+
+pub async fn check(
+    url: &str,
+    method: &str,
+    expect_status: u16,
+    expect_body_contains: &[String],
+    timeout_secs: u64,
+) -> Result<()> {
+    let method = method
+        .parse::<reqwest::Method>()
+        .with_context(|| format!("invalid HTTP method `{method}`"))?;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()?;
+    let response = client.request(method, url).send().await?;
+    let status = response.status().as_u16();
+    let body = response.text().await?;
+
+    if status != expect_status {
+        bail!("URL `{url}` returned {status}, expected {expect_status}");
+    }
+    for expected in expect_body_contains {
+        if !body.contains(expected) {
+            bail!("URL `{url}` body did not contain `{expected}`");
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a Ralph verification runner for shell, file/glob, and URL verification steps
- run story verification before any Ralph story is marked passed
- feed verification failures into repair prompts and failed story store records
- include verification steps in Ralph story prompts

Fixes #73

## Tests
- cargo test verification