### PR TITLE
fix: resolve cargo check warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo::rerun-if-env-changed=PROTOC");
     // If PROTOC isn't set, try common locations
     if std::env::var("PROTOC").is_err() {
         let home = std::env::var("HOME").unwrap_or_default();
@@ -8,7 +9,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             unsafe {
                 std::env::set_var("PROTOC", &local_protoc);
             }
-            println!("cargo::warning=Using protoc from {local_protoc}");
         }
     }
 

--- a/examples/oracle_demo.rs
+++ b/examples/oracle_demo.rs
@@ -4,6 +4,7 @@
 
 use codetether_agent::rlm::context_trace::{ContextEvent, ContextTrace};
 use codetether_agent::rlm::oracle::{GrepOracle, OracleResult, TraceValidator, TreeSitterOracle};
+use codetether_agent::rlm::{RlmAnalysisResult, RlmStats, SubQuery};
 
 fn main() {
     println!("=== RLM Oracle System Demo ===\n");
@@ -139,6 +140,36 @@ enum Status {
 
     println!("Validator can verify pattern-match and structural queries,");
     println!("producing golden traces for training data generation.");
+    let validator = TraceValidator::new();
+    let answer = source_code
+        .lines()
+        .enumerate()
+        .find_map(|(index, line)| {
+            line.contains("pub async fn process")
+                .then(|| format!("{}:{}", index + 1, line))
+        })
+        .expect("sample source contains async function");
+    let analysis = RlmAnalysisResult {
+        answer,
+        iterations: 1,
+        sub_queries: vec![SubQuery {
+            query: "Find all async functions".to_string(),
+            context_slice: None,
+            response: String::new(),
+            tokens_used: 0,
+        }],
+        stats: RlmStats::default(),
+    };
+    let verdict = validator.validate(&analysis, source_code, Some("demo.rs"), None, None);
+    match verdict {
+        OracleResult::Golden(trace) => {
+            println!(
+                "Demo validation: {} via {:?}",
+                trace.verdict, trace.verification_method
+            );
+        }
+        other => println!("Demo validation: {:?}", other),
+    }
     println!();
     println!("Query types supported:");
     println!("  - Pattern-match: grep-based (find, list, count, search)");

--- a/src/github_pr/client.rs
+++ b/src/github_pr/client.rs
@@ -67,11 +67,6 @@ fn build_body(args: &CreatePrArgs, context: &RepoContext) -> Result<String> {
     let base = match (&args.body, &args.body_file) {
         (Some(body), _) => body.clone(),
         (None, Some(path)) => {
-            let path = if path.is_absolute() {
-                path.clone()
-            } else {
-                context.repo_root.join(path)
-            };
             std::fs::read_to_string(path)?
         }
         (None, None) => String::new(),

--- a/src/github_pr/client.rs
+++ b/src/github_pr/client.rs
@@ -66,7 +66,14 @@ fn project_root(project: Option<&PathBuf>) -> Option<&std::path::Path> {
 fn build_body(args: &CreatePrArgs, context: &RepoContext) -> Result<String> {
     let base = match (&args.body, &args.body_file) {
         (Some(body), _) => body.clone(),
-        (None, Some(path)) => std::fs::read_to_string(path)?,
+        (None, Some(path)) => {
+            let path = if path.is_absolute() {
+                path.clone()
+            } else {
+                context.repo_root.join(path)
+            };
+            std::fs::read_to_string(path)?
+        }
         (None, None) => String::new(),
     };
     Ok(merge_signature(&base, &context.signature))
@@ -78,6 +85,13 @@ async fn github_client(context: &RepoContext) -> Result<Client> {
     let token = std::env::var("CODETETHER_TOKEN").ok();
     let worker_id = std::env::var("CODETETHER_WORKER_ID").ok();
     let path = format!("{}/{}.git", context.owner, context.repo);
+    tracing::debug!(
+        repo_root = %context.repo_root.display(),
+        workspace_id = %context.workspace_id,
+        github_installation_id = context.github_installation_id.as_deref().unwrap_or(""),
+        github_app_id = context.github_app_id.as_deref().unwrap_or(""),
+        "Requesting GitHub credentials for PR helper"
+    );
     let credentials = request_git_credentials(
         &server,
         &token,

--- a/src/k8s/mod.rs
+++ b/src/k8s/mod.rs
@@ -209,6 +209,18 @@ impl K8sManager {
         self.client.is_some()
     }
 
+    /// Return a clone scoped to an explicit namespace and/or deployment.
+    pub fn scoped(&self, namespace: Option<&str>, deployment_name: Option<&str>) -> Self {
+        let mut scoped = self.clone();
+        if let Some(namespace) = namespace.filter(|value| !value.trim().is_empty()) {
+            scoped.namespace = namespace.to_string();
+        }
+        if let Some(deployment_name) = deployment_name.filter(|value| !value.trim().is_empty()) {
+            scoped.deployment_name = Some(deployment_name.to_string());
+        }
+        scoped
+    }
+
     /// Get current status.
     pub async fn status(&self) -> K8sStatus {
         let (replicas, available) = if let Some(ref client) = self.client {
@@ -350,6 +362,14 @@ impl K8sManager {
 
     /// List pods belonging to our deployment.
     pub async fn list_pods(&self) -> Result<Vec<PodInfo>> {
+        self.list_pods_with_selector(None).await
+    }
+
+    /// List pods using an optional label selector override.
+    pub async fn list_pods_with_selector(
+        &self,
+        label_selector: Option<&str>,
+    ) -> Result<Vec<PodInfo>> {
         let client = self
             .client
             .as_ref()
@@ -357,10 +377,10 @@ impl K8sManager {
 
         let pods: Api<Pod> = Api::namespaced(client.clone(), &self.namespace);
 
-        let label_selector = self
-            .deployment_name
-            .as_ref()
-            .map(|n| format!("app={}", n))
+        let label_selector = label_selector
+            .filter(|value| !value.trim().is_empty())
+            .map(ToString::to_string)
+            .or_else(|| self.deployment_name.as_ref().map(|n| format!("app={}", n)))
             .unwrap_or_else(|| "app=codetether".to_string());
 
         let list = pods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cli;
 pub mod cloudevents;
 pub mod cognition;
 pub mod config;
+pub mod crash;
 pub mod event_stream;
 pub mod forage;
 pub mod github_pr;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,47 +10,12 @@
 //! Local development may also use env/AWS fallback credentials unless
 //! `CODETETHER_DISABLE_ENV_FALLBACK=1` is set for Vault-only mode.
 
-mod a2a;
-mod agent;
-mod audit;
-mod autochat;
-mod benchmark;
-mod browser;
-mod bus;
-mod cli;
-mod cloudevents;
-mod cognition;
-mod config;
-mod crash;
-mod event_stream;
-mod forage;
-mod github_pr;
-mod image_clipboard;
-mod indexer;
-mod k8s;
-mod lsp;
-pub mod mcp;
-mod moltbook;
-mod okr;
-mod provenance;
-mod provider;
-pub mod ralph;
-pub mod rlm;
-mod search;
-pub mod secrets;
-mod server;
-mod session;
-pub mod swarm;
-pub mod telemetry;
-mod tls;
-mod tool;
-mod tui;
-pub mod util;
-mod worker_server;
-mod worktree;
-
 use clap::Parser;
 use cli::{Cli, Command};
+use codetether_agent::{
+    a2a, benchmark, bus, cli, config, crash, forage, github_pr, indexer, mcp, moltbook, okr,
+    provider, ralph, rlm, secrets, server, swarm, telemetry, tool, tui, worker_server, worktree,
+};
 use std::io::IsTerminal;
 use std::sync::Arc;
 use swarm::{DecompositionStrategy, ExecutionMode, SwarmExecutor};
@@ -855,11 +820,11 @@ async fn main() -> anyhow::Result<()> {
                     tracing::info!("Starting MCP server over stdio...");
 
                     // Create agent bus + S3 sink so tool calls sync to MinIO
-                    let bus = crate::bus::AgentBus::new().into_arc();
-                    crate::bus::s3_sink::spawn_bus_s3_sink(bus.clone());
+                    let bus = bus::AgentBus::new().into_arc();
+                    bus::s3_sink::spawn_bus_s3_sink(bus.clone());
 
                     // Try to load provider from Vault so tools like Ralph can execute autonomously
-                    let registry = match crate::provider::ProviderRegistry::from_vault().await {
+                    let registry = match provider::ProviderRegistry::from_vault().await {
                         Ok(provider_registry) => {
                             let fallbacks = [
                                 "zai",
@@ -1498,7 +1463,7 @@ async fn main() -> anyhow::Result<()> {
 
         // OKR commands
         Some(Command::Okr(args)) => {
-            use crate::okr::{KeyResult, Okr, OkrRepository, OkrStatus};
+            use okr::{KeyResult, Okr, OkrRepository, OkrStatus};
             use uuid::Uuid;
 
             let repo = OkrRepository::from_config().await?;
@@ -1644,8 +1609,8 @@ async fn main() -> anyhow::Result<()> {
                     if args.json {
                         #[derive(serde::Serialize)]
                         struct RunsOutput {
-                            okrs: Vec<crate::okr::Okr>,
-                            runs: Vec<crate::okr::OkrRun>,
+                            okrs: Vec<okr::Okr>,
+                            runs: Vec<okr::OkrRun>,
                         }
                         println!(
                             "{}",
@@ -1680,8 +1645,8 @@ async fn main() -> anyhow::Result<()> {
 
                     #[derive(serde::Serialize)]
                     struct ExportData {
-                        okrs: Vec<crate::okr::Okr>,
-                        runs: Vec<crate::okr::OkrRun>,
+                        okrs: Vec<okr::Okr>,
+                        runs: Vec<okr::OkrRun>,
                         exported_at: chrono::DateTime<chrono::Utc>,
                     }
 
@@ -1741,8 +1706,8 @@ async fn main() -> anyhow::Result<()> {
                         if args.json {
                             #[derive(serde::Serialize)]
                             struct OkrReport {
-                                okr: crate::okr::Okr,
-                                runs: Vec<crate::okr::OkrRun>,
+                                okr: okr::Okr,
+                                runs: Vec<okr::OkrRun>,
                                 total_progress: f64,
                             }
                             let runs = repo.query_runs_by_okr(uuid).await?;
@@ -1822,8 +1787,8 @@ async fn main() -> anyhow::Result<()> {
                             let okr = repo.get_okr(run.okr_id).await?;
                             #[derive(serde::Serialize)]
                             struct RunReport {
-                                run: crate::okr::OkrRun,
-                                okr: Option<crate::okr::Okr>,
+                                run: okr::OkrRun,
+                                okr: Option<okr::Okr>,
                             }
                             let report = RunReport {
                                 run: run.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -821,7 +821,7 @@ async fn main() -> anyhow::Result<()> {
 
                     // Create agent bus + S3 sink so tool calls sync to MinIO
                     let bus = bus::AgentBus::new().into_arc();
-                    bus::s3_sink::spawn_bus_s3_sink(bus.clone());
+                    codetether_agent::bus::s3_sink::spawn_bus_s3_sink(bus.clone());
 
                     // Try to load provider from Vault so tools like Ralph can execute autonomously
                     let registry = match provider::ProviderRegistry::from_vault().await {
@@ -1463,7 +1463,7 @@ async fn main() -> anyhow::Result<()> {
 
         // OKR commands
         Some(Command::Okr(args)) => {
-            use okr::{KeyResult, Okr, OkrRepository, OkrStatus};
+            use okr::{KeyResult, Okr, OkrRepository, OkrRun, OkrStatus};
             use uuid::Uuid;
 
             let repo = OkrRepository::from_config().await?;
@@ -1609,8 +1609,8 @@ async fn main() -> anyhow::Result<()> {
                     if args.json {
                         #[derive(serde::Serialize)]
                         struct RunsOutput {
-                            okrs: Vec<okr::Okr>,
-                            runs: Vec<okr::OkrRun>,
+                            okrs: Vec<Okr>,
+                            runs: Vec<OkrRun>,
                         }
                         println!(
                             "{}",
@@ -1645,8 +1645,8 @@ async fn main() -> anyhow::Result<()> {
 
                     #[derive(serde::Serialize)]
                     struct ExportData {
-                        okrs: Vec<okr::Okr>,
-                        runs: Vec<okr::OkrRun>,
+                        okrs: Vec<Okr>,
+                        runs: Vec<OkrRun>,
                         exported_at: chrono::DateTime<chrono::Utc>,
                     }
 
@@ -1706,8 +1706,8 @@ async fn main() -> anyhow::Result<()> {
                         if args.json {
                             #[derive(serde::Serialize)]
                             struct OkrReport {
-                                okr: okr::Okr,
-                                runs: Vec<okr::OkrRun>,
+                                okr: Okr,
+                                runs: Vec<OkrRun>,
                                 total_progress: f64,
                             }
                             let runs = repo.query_runs_by_okr(uuid).await?;
@@ -1787,8 +1787,8 @@ async fn main() -> anyhow::Result<()> {
                             let okr = repo.get_okr(run.okr_id).await?;
                             #[derive(serde::Serialize)]
                             struct RunReport {
-                                run: okr::OkrRun,
-                                okr: Option<okr::Okr>,
+                                run: OkrRun,
+                                okr: Option<Okr>,
                             }
                             let report = RunReport {
                                 run: run.clone(),

--- a/src/provider/openai_codex.rs
+++ b/src/provider/openai_codex.rs
@@ -447,6 +447,7 @@ impl OpenAiCodexProvider {
         Ok(request)
     }
 
+    #[cfg(test)]
     fn build_responses_ws_request_with_base_url(
         base_url: &str,
         token: &str,
@@ -1162,6 +1163,7 @@ impl OpenAiCodexProvider {
         }
     }
 
+    #[cfg(test)]
     fn resolve_model_and_reasoning_effort(model: &str) -> (String, Option<ThinkingLevel>) {
         let (base_model, level, _) =
             Self::resolve_model_and_reasoning_effort_and_service_tier(model);
@@ -1231,6 +1233,7 @@ impl OpenAiCodexProvider {
         format!("OpenAI API error ({status}): {body}")
     }
 
+    #[cfg(test)]
     fn build_responses_ws_create_event(
         request: &CompletionRequest,
         model: &str,

--- a/src/ralph/ralph_loop.rs
+++ b/src/ralph/ralph_loop.rs
@@ -2303,69 +2303,8 @@ Respond with the implementation and any shell commands needed.
 
     /// Run quality gates and emit events for each check
     async fn run_quality_gates_with_events(&self, story_id: &str) -> anyhow::Result<bool> {
-        // Find the Cargo root (where Cargo.toml lives)
-        let cargo_root = Self::find_cargo_root(&self.state.working_dir);
-        debug!(
-            working_dir = %self.state.working_dir.display(),
-            cargo_root = %cargo_root.display(),
-            "Running quality gates"
-        );
-
-        let checks = &self.state.prd.quality_checks;
-        let mut all_passed = true;
-
-        for (name, cmd) in [
-            ("typecheck", &checks.typecheck),
-            ("lint", &checks.lint),
-            ("test", &checks.test),
-            ("build", &checks.build),
-        ] {
-            if let Some(command) = cmd {
-                debug!("Running {} check in {:?}: {}", name, cargo_root, command);
-                let output = Command::new("/bin/sh")
-                    .arg("-c")
-                    .arg(command)
-                    .current_dir(&cargo_root)
-                    .output()
-                    .map_err(|e| {
-                        anyhow::anyhow!("Failed to run quality check '{}': {}", name, e)
-                    })?;
-
-                let passed = output.status.success();
-                self.try_send_event(RalphEvent::StoryQualityCheck {
-                    story_id: story_id.to_string(),
-                    check_name: name.to_string(),
-                    passed,
-                });
-
-                if !passed {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    let combined = format!("{}\n{}", stdout, stderr);
-                    let error_summary: String = combined
-                        .lines()
-                        .filter(|line| {
-                            line.starts_with("error")
-                                || line.contains("error:")
-                                || line.contains("error[")
-                        })
-                        .take(5)
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    warn!(
-                        check = %name,
-                        cargo_root = %cargo_root.display(),
-                        error_summary = %error_summary.chars().take(300).collect::<String>(),
-                        "{} check failed in {:?}",
-                        name, cargo_root
-                    );
-                    all_passed = false;
-                    break; // Short-circuit: stop at first failure to save time
-                }
-            }
-        }
-
-        Ok(all_passed)
+        self.run_quality_gates_in_dir_with_events(&self.state.working_dir, story_id)
+            .await
     }
 
     /// Commit changes for a story

--- a/src/rlm/oracle/mod.rs
+++ b/src/rlm/oracle/mod.rs
@@ -45,6 +45,7 @@ mod types;
 mod validator;
 
 pub use grep_oracle::{GrepOracle, GrepVerification};
+pub use query_type::QueryType;
 pub use record::OracleTraceRecord;
 pub use schema::{AstPayload, AstResult, FinalPayload, GrepMatch, GrepPayload, SemanticPayload};
 pub use storage::{
@@ -55,17 +56,6 @@ pub use trace_types::{OracleResult, ValidatedTrace};
 pub use tree_sitter_oracle::{TreeSitterOracle, TreeSitterVerification};
 pub use types::{TraceStep, VerificationMethod};
 pub use validator::{BatchValidationStats, SplitWriteStats, TraceValidator};
-
-/// Query type classification for routing to the appropriate oracle.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum QueryType {
-    /// Pattern-match query (grep-based: line numbers, text matches)
-    PatternMatch,
-    /// Structural query (AST-based: function signatures, struct fields)
-    Structural,
-    /// Semantic query (requires LLM understanding - no deterministic oracle)
-    Semantic,
-}
 
 /// Classification of an RLM FINAL() answer format.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/session/helper/compression.rs
+++ b/src/session/helper/compression.rs
@@ -219,6 +219,10 @@ pub(crate) struct CompressContext {
     pub subcall_provider: Option<Arc<dyn crate::provider::Provider>>,
     /// Model name resolved alongside [`Self::subcall_provider`].
     pub subcall_model: Option<String>,
+    /// CADMAS-CTX routing state used to rank fallback RLM compaction models.
+    pub delegation: crate::session::delegation::DelegationState,
+    /// Context bucket for the current transcript projection.
+    pub bucket: crate::session::relevance::Bucket,
 }
 
 impl CompressContext {
@@ -229,6 +233,8 @@ impl CompressContext {
             session_id: session.id.clone(),
             subcall_provider: session.metadata.subcall_provider.clone(),
             subcall_model: session.metadata.subcall_model_name.clone(),
+            delegation: session.metadata.delegation.clone(),
+            bucket: crate::session::relevance::bucket_for_messages(&session.messages),
         }
     }
 }
@@ -288,7 +294,11 @@ pub(crate) async fn compress_messages_keep_last(
     // Prefer a cheap dedicated RLM model over the caller's main model
     // to keep compaction cost bounded. Falls back to the caller's
     // provider/model if the dedicated model cannot be resolved.
-    let (rlm_provider, rlm_model) = match resolve_rlm_model(&ctx.rlm_config) {
+    let (rlm_provider, rlm_model) = match resolve_rlm_model_bandit(
+        &ctx.rlm_config,
+        &ctx.delegation,
+        ctx.bucket,
+    ) {
         Some(target_model) if target_model != model => {
             match crate::provider::ProviderRegistry::shared_from_vault().await {
                 Ok(registry) => match registry.resolve_model(&target_model) {
@@ -544,7 +554,7 @@ fn extract_message_text(msg: &Message) -> String {
 /// # Errors
 ///
 /// Propagates any error from the underlying core.
-pub(crate) async fn compress_history_keep_last(
+pub async fn compress_history_keep_last(
     session: &mut Session,
     provider: Arc<dyn crate::provider::Provider>,
     model: &str,
@@ -765,7 +775,7 @@ pub(crate) async fn enforce_on_messages(
 /// # Errors
 ///
 /// Propagates any error from the underlying core.
-pub(crate) async fn enforce_context_window(
+pub async fn enforce_context_window(
     session: &mut Session,
     provider: Arc<dyn crate::provider::Provider>,
     model: &str,

--- a/src/tool/k8s_tool.rs
+++ b/src/tool/k8s_tool.rs
@@ -115,6 +115,14 @@ impl Tool for K8sTool {
                               "spawn_pod","delete_pod","pod_state","logs","recent_actions"],
                     "description": "The Kubernetes action to perform."
                 },
+                "namespace": {
+                    "type": "string",
+                    "description": "Namespace override for this action."
+                },
+                "deployment": {
+                    "type": "string",
+                    "description": "Deployment override for status, scale, rolling_restart, and list_pods."
+                },
                 "replicas": {
                     "type": "integer",
                     "description": "Number of replicas (required for scale)."
@@ -169,11 +177,11 @@ impl Tool for K8sTool {
             ));
         }
 
-        match params.action {
-            K8sAction::Status => Self::exec_status(manager).await,
-            K8sAction::ListPods => Self::exec_list_pods(manager).await,
+        match params.action.clone() {
+            K8sAction::Status => Self::exec_status(manager, params).await,
+            K8sAction::ListPods => Self::exec_list_pods(manager, params).await,
             K8sAction::Scale => Self::exec_scale(manager, params).await,
-            K8sAction::RollingRestart => Self::exec_rolling_restart(manager).await,
+            K8sAction::RollingRestart => Self::exec_rolling_restart(manager, params).await,
             K8sAction::SpawnPod => Self::exec_spawn_pod(manager, params).await,
             K8sAction::DeletePod => Self::exec_delete_pod(manager, params).await,
             K8sAction::PodState => Self::exec_pod_state(manager, params).await,
@@ -188,8 +196,9 @@ impl Tool for K8sTool {
 // ---------------------------------------------------------------------------
 
 impl K8sTool {
-    async fn exec_status(manager: &K8sManager) -> Result<ToolResult> {
-        let status = manager.status().await;
+    async fn exec_status(manager: &K8sManager, params: K8sInput) -> Result<ToolResult> {
+        let target = manager.scoped(params.namespace.as_deref(), params.deployment.as_deref());
+        let status = target.status().await;
         let output = serde_json::to_string_pretty(&json!({
             "in_cluster": status.in_cluster,
             "namespace": status.namespace,
@@ -201,8 +210,11 @@ impl K8sTool {
         Ok(ToolResult::success(output))
     }
 
-    async fn exec_list_pods(manager: &K8sManager) -> Result<ToolResult> {
-        let pods = manager.list_pods().await?;
+    async fn exec_list_pods(manager: &K8sManager, params: K8sInput) -> Result<ToolResult> {
+        let target = manager.scoped(params.namespace.as_deref(), params.deployment.as_deref());
+        let pods = target
+            .list_pods_with_selector(params.label_selector.as_deref())
+            .await?;
         let pods_json: Vec<Value> = pods
             .iter()
             .map(|p| {
@@ -216,7 +228,7 @@ impl K8sTool {
             .collect();
 
         let output = json!({
-            "namespace": manager.status().await.namespace,
+            "namespace": target.status().await.namespace,
             "pods": pods_json,
             "count": pods_json.len(),
         });
@@ -224,10 +236,11 @@ impl K8sTool {
     }
 
     async fn exec_scale(manager: &K8sManager, params: K8sInput) -> Result<ToolResult> {
+        let target = manager.scoped(params.namespace.as_deref(), params.deployment.as_deref());
         let replicas = params
             .replicas
             .ok_or_else(|| anyhow!("'replicas' is required for the scale action"))?;
-        let action = manager.scale(replicas).await?;
+        let action = target.scale(replicas).await?;
         Ok(ToolResult::success(serde_json::to_string_pretty(&json!({
             "action": action.action,
             "success": action.success,
@@ -236,8 +249,9 @@ impl K8sTool {
         }))?))
     }
 
-    async fn exec_rolling_restart(manager: &K8sManager) -> Result<ToolResult> {
-        let action = manager.rolling_restart().await?;
+    async fn exec_rolling_restart(manager: &K8sManager, params: K8sInput) -> Result<ToolResult> {
+        let target = manager.scoped(params.namespace.as_deref(), params.deployment.as_deref());
+        let action = target.rolling_restart().await?;
         Ok(ToolResult::success(serde_json::to_string_pretty(&json!({
             "action": action.action,
             "success": action.success,
@@ -247,6 +261,7 @@ impl K8sTool {
     }
 
     async fn exec_spawn_pod(manager: &K8sManager, params: K8sInput) -> Result<ToolResult> {
+        let target = manager.scoped(params.namespace.as_deref(), params.deployment.as_deref());
         let subagent_id = params
             .subagent_id
             .as_deref()
@@ -260,7 +275,7 @@ impl K8sTool {
             args: params.args,
         };
 
-        let action = manager
+        let action = target
             .spawn_subagent_pod_with_spec(subagent_id, spec)
             .await?;
         Ok(ToolResult::success(serde_json::to_string_pretty(&json!({
@@ -272,11 +287,12 @@ impl K8sTool {
     }
 
     async fn exec_delete_pod(manager: &K8sManager, params: K8sInput) -> Result<ToolResult> {
+        let target = manager.scoped(params.namespace.as_deref(), params.deployment.as_deref());
         let subagent_id = params
             .subagent_id
             .as_deref()
             .ok_or_else(|| anyhow!("'subagent_id' is required for the delete_pod action"))?;
-        let action = manager.delete_subagent_pod(subagent_id).await?;
+        let action = target.delete_subagent_pod(subagent_id).await?;
         Ok(ToolResult::success(serde_json::to_string_pretty(&json!({
             "action": action.action,
             "success": action.success,
@@ -286,12 +302,13 @@ impl K8sTool {
     }
 
     async fn exec_pod_state(manager: &K8sManager, params: K8sInput) -> Result<ToolResult> {
+        let target = manager.scoped(params.namespace.as_deref(), params.deployment.as_deref());
         let subagent_id = params
             .subagent_id
             .as_deref()
             .ok_or_else(|| anyhow!("'subagent_id' is required for the pod_state action"))?;
 
-        let state = manager
+        let state = target
             .get_subagent_pod_state(subagent_id)
             .await?
             .ok_or_else(|| anyhow!("Pod for sub-agent '{}' not found", subagent_id))?;
@@ -308,13 +325,12 @@ impl K8sTool {
     }
 
     async fn exec_logs(manager: &K8sManager, params: K8sInput) -> Result<ToolResult> {
+        let target = manager.scoped(params.namespace.as_deref(), params.deployment.as_deref());
         let subagent_id = params
             .subagent_id
             .as_deref()
             .ok_or_else(|| anyhow!("'subagent_id' is required for the logs action"))?;
-        let logs = manager
-            .subagent_logs(subagent_id, params.tail_lines)
-            .await?;
+        let logs = target.subagent_logs(subagent_id, params.tail_lines).await?;
         Ok(ToolResult::success(logs))
     }
 

--- a/src/tool/k8s_tool.rs
+++ b/src/tool/k8s_tool.rs
@@ -117,11 +117,11 @@ impl Tool for K8sTool {
                 },
                 "namespace": {
                     "type": "string",
-                    "description": "Namespace override for this action."
+                    "description": "Namespace override. Respected by list_pods, status, scale, rolling_restart, spawn_pod, delete_pod, pod_state, and logs."
                 },
                 "deployment": {
                     "type": "string",
-                    "description": "Deployment override for status, scale, rolling_restart, and list_pods."
+                    "description": "Deployment name override. Respected by status, scale, rolling_restart, and list_pods."
                 },
                 "replicas": {
                     "type": "integer",

--- a/src/tui/agent_identity/mod.rs
+++ b/src/tui/agent_identity/mod.rs
@@ -8,3 +8,10 @@ mod profiles;
 mod relay_format;
 mod text_preview;
 mod tool_args;
+
+pub use avatars::agent_avatar;
+pub use format::{format_agent_identity, format_agent_profile_summary};
+pub use profiles::{AgentProfile, agent_profile};
+pub use relay_format::{format_relay_handoff_line, format_relay_participant};
+pub use text_preview::build_text_preview;
+pub use tool_args::{build_tool_arguments_preview, format_tool_call_arguments};

--- a/src/tui/app/commands.rs
+++ b/src/tui/app/commands.rs
@@ -688,6 +688,11 @@ pub async fn handle_slash_command(
     let normalized = normalize_easy_command(command);
     let normalized = normalize_slash_command(&normalized);
 
+    if let Some(rest) = command_with_optional_args(&normalized, "/go") {
+        handle_go_command(app, session, registry, rest).await;
+        return;
+    }
+
     if let Some(rest) = command_with_optional_args(&normalized, "/image") {
         let cleaned = rest.trim().trim_matches(|c| c == '"' || c == '\'');
         if cleaned.is_empty() {

--- a/src/tui/app/event_handlers/mod.rs
+++ b/src/tui/app/event_handlers/mod.rs
@@ -28,9 +28,12 @@ mod paste;
 mod scroll_down;
 mod scroll_up;
 mod tests;
+#[cfg(not(test))]
 mod voice;
+#[cfg(not(test))]
 mod voice_capture;
 mod voice_drain;
+#[cfg(not(test))]
 mod voice_transcribe;
 
 use std::path::Path;

--- a/src/tui/token_display.rs
+++ b/src/tui/token_display.rs
@@ -6,17 +6,11 @@ use ratatui::{
 };
 
 /// Enhanced token usage display with costs and warnings
-pub struct TokenDisplay {
-    /// Pricing data (not context limits — those come from the canonical
-    /// [`crate::provider::limits::context_window_for_model`]).
-    model_pricing: std::collections::HashMap<String, (f64, f64)>,
-}
+pub struct TokenDisplay;
 
 impl TokenDisplay {
     pub fn new() -> Self {
-        Self {
-            model_pricing: std::collections::HashMap::new(),
-        }
+        Self
     }
 
     /// Get context limit for a model by delegating to the canonical
@@ -40,9 +34,6 @@ impl TokenDisplay {
     /// [`crate::provider::pricing::pricing_for_model`] so costs in the TUI
     /// stay in sync with the cost-guardrail enforcement path.
     fn get_model_pricing(&self, model: &str) -> (f64, f64) {
-        if let Some(pricing) = self.model_pricing.get(model) {
-            return *pricing;
-        }
         crate::provider::pricing::pricing_for_model(model)
     }
 

--- a/src/tui/token_display.rs
+++ b/src/tui/token_display.rs
@@ -40,6 +40,9 @@ impl TokenDisplay {
     /// [`crate::provider::pricing::pricing_for_model`] so costs in the TUI
     /// stay in sync with the cost-guardrail enforcement path.
     fn get_model_pricing(&self, model: &str) -> (f64, f64) {
+        if let Some(pricing) = self.model_pricing.get(model) {
+            return *pricing;
+        }
         crate::provider::pricing::pricing_for_model(model)
     }
 


### PR DESCRIPTION
## Summary
- route the binary through the library crate to avoid duplicate module-tree dead-code warnings
- wire previously-unused features instead of deleting them, including TUI /go dispatch, K8s scope overrides, RLM compaction bandit selection, oracle QueryType reuse, and agent identity exports
- remove build-script warning noise and exercise the oracle demo validator path

## Validation
- cargo check
- cargo check --all-targets