### PR TITLE
fix: tail-load large TUI sessions

### DIFF
--- a/src/tui/app/codex_sessions.rs
+++ b/src/tui/app/codex_sessions.rs
@@ -1,5 +1,8 @@
-use crate::session::{Session, import_codex_sessions_for_directory, load_or_import_session};
+use crate::session::{Session, import_codex_sessions_for_directory};
 use crate::tui::app::message_text::sync_messages_from_session;
+use crate::tui::app::session_fork::fork_if_truncated;
+use crate::tui::app::session_load_status::load_status_with_original;
+use crate::tui::app::session_loader::load_session_for_tui;
 use crate::tui::app::session_sync::{refresh_sessions, return_to_chat};
 use crate::tui::app::state::App;
 use std::path::Path;
@@ -10,9 +13,12 @@ pub async fn load_selected_session(
     session: &mut Session,
     session_id: &str,
 ) {
-    match load_or_import_session(session_id).await {
+    match load_session_for_tui(session_id).await {
         Ok(loaded) => {
-            *session = loaded;
+            let dropped = loaded.dropped;
+            let file_bytes = loaded.file_bytes;
+            *session = loaded.session;
+            let original_id = fork_if_truncated(session, dropped);
             session.attach_global_bus_if_missing();
             app.state.auto_apply_edits = session.metadata.auto_apply_edits;
             app.state.use_worktree = session.metadata.use_worktree;
@@ -21,10 +27,8 @@ pub async fn load_selected_session(
             refresh_sessions(app, cwd).await;
             app.state.clear_session_filter();
             return_to_chat(app);
-            app.state.status = format!(
-                "Loaded session {}",
-                session.title.clone().unwrap_or_else(|| session.id.clone())
-            );
+            app.state.status =
+                load_status_with_original(session, dropped, file_bytes, original_id.as_deref());
         }
         Err(error) => {
             app.state.status = format!("Failed to load session: {error}");

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -19,8 +19,12 @@ pub mod model_picker;
 pub mod navigation;
 pub mod okr_gate;
 pub mod panic_cleanup;
+pub mod resume_window;
 pub mod run;
 pub mod session_events;
+pub mod session_fork;
+pub mod session_load_status;
+pub mod session_loader;
 pub mod session_sync;
 pub mod settings;
 pub mod signal_shutdown;
@@ -34,5 +38,9 @@ pub mod text;
 pub mod watchdog;
 pub mod worker_bridge;
 
+#[cfg(test)]
+mod session_loader_real_tests;
+#[cfg(test)]
+mod session_loader_tests;
 #[cfg(test)]
 mod tests;

--- a/src/tui/app/resume_window.rs
+++ b/src/tui/app/resume_window.rs
@@ -1,0 +1,21 @@
+const DEFAULT_WINDOW: usize = 1_000;
+const MAX_WINDOW: usize = 10_000;
+
+pub fn session_resume_window() -> usize {
+    let parsed = std::env::var("CODETETHER_SESSION_RESUME_WINDOW")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0);
+    match parsed {
+        Some(value) if value > MAX_WINDOW => {
+            tracing::warn!(
+                requested = value,
+                clamped = MAX_WINDOW,
+                "session resume window too large; clamping"
+            );
+            MAX_WINDOW
+        }
+        Some(value) => value,
+        None => DEFAULT_WINDOW,
+    }
+}

--- a/src/tui/app/run.rs
+++ b/src/tui/app/run.rs
@@ -14,6 +14,7 @@ use crate::session::{Session, SessionEvent};
 use crate::tui::app::event_loop::run_event_loop;
 use crate::tui::app::message_text::sync_messages_from_session;
 use crate::tui::app::panic_cleanup::install_panic_cleanup_hook;
+use crate::tui::app::resume_window::session_resume_window;
 use crate::tui::app::state::App;
 use crate::tui::app::terminal_state::{TerminalGuard, restore_terminal_state};
 use crate::tui::ui::main::ui;
@@ -37,31 +38,6 @@ enum SessionLoadOutcome {
     NewFallback {
         reason: String,
     },
-}
-
-/// Default number of trailing messages + tool uses kept when resuming a
-/// prior session. Older entries are dropped to bound startup memory; the
-/// user is notified in the status line when truncation occurs.
-const DEFAULT_SESSION_RESUME_WINDOW: usize = 1_000;
-const MAX_SESSION_RESUME_WINDOW: usize = 10_000;
-
-fn session_resume_window() -> usize {
-    let parsed = std::env::var("CODETETHER_SESSION_RESUME_WINDOW")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0);
-    match parsed {
-        Some(value) if value > MAX_SESSION_RESUME_WINDOW => {
-            tracing::warn!(
-                requested = value,
-                clamped = MAX_SESSION_RESUME_WINDOW,
-                "session resume window too large; clamping"
-            );
-            MAX_SESSION_RESUME_WINDOW
-        }
-        Some(value) => value,
-        None => DEFAULT_SESSION_RESUME_WINDOW,
-    }
 }
 
 async fn init_tui_secrets_manager() {

--- a/src/tui/app/session_fork.rs
+++ b/src/tui/app/session_fork.rs
@@ -1,0 +1,15 @@
+use crate::session::Session;
+
+pub fn fork_if_truncated(session: &mut Session, dropped: usize) -> Option<String> {
+    if dropped == 0 {
+        return None;
+    }
+    let original = session.id.clone();
+    let title = session
+        .title
+        .clone()
+        .unwrap_or_else(|| "large session".to_string());
+    session.id = uuid::Uuid::new_v4().to_string();
+    session.title = Some(format!("{title} (continued)"));
+    Some(original)
+}

--- a/src/tui/app/session_load_status.rs
+++ b/src/tui/app/session_load_status.rs
@@ -1,0 +1,19 @@
+use crate::session::Session;
+
+pub fn load_status_with_original(
+    session: &Session,
+    dropped: usize,
+    file_bytes: u64,
+    original_id: Option<&str>,
+) -> String {
+    let label = session.title.clone().unwrap_or_else(|| session.id.clone());
+    if dropped == 0 {
+        return format!("Loaded session {label}");
+    }
+    let mb = file_bytes as f64 / (1024.0 * 1024.0);
+    format!(
+        "Loaded large session {label}: showing last {} entries, dropped {dropped} ({mb:.1} MiB); original {} preserved",
+        session.messages.len(),
+        original_id.unwrap_or("unknown")
+    )
+}

--- a/src/tui/app/session_loader.rs
+++ b/src/tui/app/session_loader.rs
@@ -1,0 +1,33 @@
+use crate::session::Session;
+use crate::tui::app::resume_window::session_resume_window;
+use anyhow::Result;
+
+pub struct LoadedSession {
+    pub session: Session,
+    pub dropped: usize,
+    pub file_bytes: u64,
+}
+
+pub async fn load_session_for_tui(id: &str) -> Result<LoadedSession> {
+    match Session::load_tail(id, session_resume_window()).await {
+        Ok(load) => Ok(LoadedSession {
+            session: load.session,
+            dropped: load.dropped,
+            file_bytes: load.file_bytes,
+        }),
+        Err(native_error) => load_codex(id, native_error).await,
+    }
+}
+
+async fn load_codex(id: &str, native_error: anyhow::Error) -> Result<LoadedSession> {
+    match crate::session::load_or_import_session(id).await {
+        Ok(session) => Ok(LoadedSession {
+            session,
+            dropped: 0,
+            file_bytes: 0,
+        }),
+        Err(codex_error) => {
+            Err(native_error.context(format!("Codex import also failed: {codex_error}")))
+        }
+    }
+}

--- a/src/tui/app/session_loader_real_tests.rs
+++ b/src/tui/app/session_loader_real_tests.rs
@@ -1,0 +1,20 @@
+use super::session_loader::load_session_for_tui;
+
+#[tokio::test]
+async fn loads_env_native_session_with_tail_window() {
+    let Some(id) = std::env::var("CODETETHER_REAL_SESSION_ID").ok() else {
+        return;
+    };
+    let start = std::time::Instant::now();
+    let loaded = load_session_for_tui(&id).await.unwrap();
+    let elapsed = start.elapsed();
+    eprintln!(
+        "loaded {} messages, dropped {}, file {} bytes in {:?}",
+        loaded.session.messages.len(),
+        loaded.dropped,
+        loaded.file_bytes,
+        elapsed
+    );
+    assert_eq!(loaded.session.id, id);
+    assert!(loaded.dropped > 0);
+}

--- a/src/tui/app/session_loader_tests.rs
+++ b/src/tui/app/session_loader_tests.rs
@@ -1,0 +1,28 @@
+use super::session_fork::fork_if_truncated;
+use super::session_loader::load_session_for_tui;
+use crate::provider::{ContentPart, Message, Role};
+use crate::session::Session;
+
+#[tokio::test]
+async fn loads_native_session_with_tail_window() {
+    let temp = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("CODETETHER_DATA_DIR", temp.path());
+        std::env::set_var("CODETETHER_SESSION_RESUME_WINDOW", "2");
+    }
+    let mut session = Session::new().await.unwrap();
+    session.id = "tail-native-session".to_string();
+    for text in ["one", "two", "three"] {
+        session.messages.push(Message {
+            role: Role::User,
+            content: vec![ContentPart::Text { text: text.into() }],
+        });
+    }
+    session.save().await.unwrap();
+    let mut loaded = load_session_for_tui("tail-native-session").await.unwrap();
+    let original = fork_if_truncated(&mut loaded.session, loaded.dropped);
+    assert_eq!(loaded.session.messages.len(), 2);
+    assert_eq!(loaded.dropped, 1);
+    assert_eq!(original.as_deref(), Some("tail-native-session"));
+    assert_ne!(loaded.session.id, "tail-native-session");
+}


### PR DESCRIPTION
## Summary
- Load selected TUI sessions with the bounded tail loader before falling back to Codex import
- Share the TUI resume-window configuration between startup and manual session loading
- Fork truncated manual loads so later saves cannot overwrite the full original transcript
- Add focused native-tail regression tests and optional env-gated real-session validation

## Validation
- ./check_file_limits.sh
- cargo test loads_native_session_with_tail_window -- --nocapture
- LSP diagnostics checked on changed TUI session-loading files

## Performance audit
- Real 105.3 MiB session loaded via production tail loader with CODETETHER_SESSION_RESUME_WINDOW=1000
- Loaded 1000 messages, dropped 11053, peak RSS observed around 82 MiB from already-built test binary
