### PR TITLE
fix: retry TUI context errors with RLM compaction

### DIFF
--- a/src/session/helper/mod.rs
+++ b/src/session/helper/mod.rs
@@ -19,6 +19,7 @@ pub mod experimental;
 pub mod loop_constants;
 pub mod markup;
 pub mod prompt;
+pub mod prompt_call;
 pub mod prompt_events;
 pub mod provider;
 pub mod request_state;
@@ -28,3 +29,8 @@ pub mod stream;
 pub mod text;
 pub mod token;
 pub mod validation;
+
+#[cfg(test)]
+mod prompt_events_test_provider;
+#[cfg(test)]
+mod prompt_events_tests;

--- a/src/session/helper/prompt_call.rs
+++ b/src/session/helper/prompt_call.rs
@@ -1,0 +1,27 @@
+//! Provider completion helper for one agent step.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::sync::mpsc;
+
+use crate::provider::{CompletionRequest, CompletionResponse, Provider};
+use crate::session::SessionEvent;
+
+use super::stream::collect_stream_completion_with_events;
+
+/// Execute one provider completion without bypassing retryable errors.
+pub(super) async fn complete_step(
+    provider: &Arc<dyn Provider>,
+    request: CompletionRequest,
+    supports_tools: bool,
+    event_tx: Option<&mpsc::Sender<SessionEvent>>,
+) -> Result<CompletionResponse> {
+    if !supports_tools {
+        return provider.complete(request).await;
+    }
+    match provider.complete_stream(request).await {
+        Ok(stream) => collect_stream_completion_with_events(stream, event_tx).await,
+        Err(error) => Err(error),
+    }
+}

--- a/src/session/helper/prompt_call.rs
+++ b/src/session/helper/prompt_call.rs
@@ -20,8 +20,6 @@ pub(super) async fn complete_step(
     if !supports_tools {
         return provider.complete(request).await;
     }
-    match provider.complete_stream(request).await {
-        Ok(stream) => collect_stream_completion_with_events(stream, event_tx).await,
-        Err(error) => Err(error),
-    }
+    let stream = provider.complete_stream(request).await?;
+    collect_stream_completion_with_events(stream, event_tx).await
 }

--- a/src/session/helper/prompt_events.rs
+++ b/src/session/helper/prompt_events.rs
@@ -55,7 +55,6 @@ use super::router::{build_proactive_lsp_context_message, choose_router_target_ba
 use super::runtime::{
     enrich_tool_input_with_runtime_context, is_codesearch_no_match_output, is_interactive_tool,
 };
-use super::stream::collect_stream_completion_with_events;
 use super::text::extract_text_content;
 use super::token::{
     context_window_for_model, estimate_tokens_for_messages, session_completion_max_tokens,
@@ -235,12 +234,13 @@ pub(crate) async fn run_prompt_with_events(
                 max_tokens: Some(session_completion_max_tokens()),
                 stop: Vec::new(),
             };
-            let completion_result = if model_supports_tools {
-                let stream = provider.complete_stream(request.clone()).await?;
-                collect_stream_completion_with_events(stream, Some(&event_tx)).await
-            } else {
-                provider.complete(request.clone()).await
-            };
+            let completion_result = super::prompt_call::complete_step(
+                &provider,
+                request,
+                model_supports_tools,
+                Some(&event_tx),
+            )
+            .await;
 
             match completion_result {
                 Ok(r) => {

--- a/src/session/helper/prompt_events_test_provider.rs
+++ b/src/session/helper/prompt_events_test_provider.rs
@@ -1,0 +1,60 @@
+//! Mock providers for prompt event tests.
+
+use crate::provider::*;
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::stream::{self, BoxStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub struct StreamContextErrorProvider {
+    calls: AtomicUsize,
+}
+
+impl StreamContextErrorProvider {
+    pub const fn new() -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Provider for StreamContextErrorProvider {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        Ok(Vec::new())
+    }
+
+    async fn complete(&self, _: CompletionRequest) -> Result<CompletionResponse> {
+        Ok(response())
+    }
+
+    async fn complete_stream(
+        &self,
+        _: CompletionRequest,
+    ) -> Result<BoxStream<'static, StreamChunk>> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            Err(anyhow::anyhow!("context length exceeded"))
+        } else {
+            Ok(Box::pin(stream::iter([StreamChunk::Text("ok".into())])))
+        }
+    }
+}
+
+fn response() -> CompletionResponse {
+    CompletionResponse {
+        message: Message {
+            role: Role::Assistant,
+            content: vec![ContentPart::Text { text: "ok".into() }],
+        },
+        usage: Usage::default(),
+        finish_reason: FinishReason::Stop,
+    }
+}

--- a/src/session/helper/prompt_events_tests.rs
+++ b/src/session/helper/prompt_events_tests.rs
@@ -13,7 +13,8 @@ async fn streaming_context_errors_retry_with_forced_compaction() {
     let mut registry = ProviderRegistry::new();
     registry.register(provider.clone());
     let registry = Arc::new(registry);
-    let (tx, _rx) = mpsc::channel(16);
+    let (tx, mut rx) = mpsc::channel(64);
+    tokio::spawn(async move { while rx.recv().await.is_some() {} });
     let mut session = Session::new().await.expect("session");
     session.metadata.model = Some("mock/test".into());
     for _ in 0..7 {

--- a/src/session/helper/prompt_events_tests.rs
+++ b/src/session/helper/prompt_events_tests.rs
@@ -1,0 +1,34 @@
+//! Tests for streaming prompt event behavior.
+
+use super::prompt_events::run_prompt_with_events;
+use super::prompt_events_test_provider::StreamContextErrorProvider;
+use crate::provider::{ContentPart, Message, ProviderRegistry, Role};
+use crate::session::Session;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn streaming_context_errors_retry_with_forced_compaction() {
+    let provider = Arc::new(StreamContextErrorProvider::new());
+    let mut registry = ProviderRegistry::new();
+    registry.register(provider.clone());
+    let registry = Arc::new(registry);
+    let (tx, _rx) = mpsc::channel(16);
+    let mut session = Session::new().await.expect("session");
+    session.metadata.model = Some("mock/test".into());
+    for _ in 0..7 {
+        session.add_message(text_message());
+    }
+
+    let result = run_prompt_with_events(&mut session, "hello", Vec::new(), tx, registry).await;
+
+    assert!(result.is_ok());
+    assert_eq!(provider.calls(), 2);
+}
+
+fn text_message() -> Message {
+    Message {
+        role: Role::User,
+        content: vec![ContentPart::Text { text: "old".into() }],
+    }
+}


### PR DESCRIPTION
## Summary
- route streaming provider startup errors through the existing prompt-too-long retry path
- add a small provider completion helper for the TUI prompt loop
- add a regression test proving stream context errors retry after compaction

## Testing
- cargo fmt
- ./check_file_limits.sh src/session/helper/prompt_events.rs src/session/helper/prompt_call.rs src/session/helper/prompt_events_tests.rs src/session/helper/prompt_events_test_provider.rs src/session/helper/mod.rs
- cargo test streaming_context_errors_retry_with_forced_compaction