### PR TITLE
users are reporting websocket streming erros and event type mismatch

### DIFF
--- a/src/provider/openai_codex.rs
+++ b/src/provider/openai_codex.rs
@@ -1337,12 +1337,11 @@ impl OpenAiCodexProvider {
                     Self::finish_responses_tool_call(parser, key, chunks);
                 }
             }
-            Some("response.completed") | Some("response.done") => {
-                if let Some(output) = event
-                    .get("response")
-                    .and_then(|response| response.get("output"))
-                    .and_then(Value::as_array)
-                {
+            Some("response.completed") | Some("response.done")
+                if event.pointer("/response/status").and_then(Value::as_str)
+                    != Some("in_progress") =>
+            {
+                if let Some(output) = event.pointer("/response/output").and_then(Value::as_array) {
                     for item in output {
                         if item.get("type").and_then(Value::as_str) == Some("function_call")
                             && let Some(key) = item

--- a/src/tool/voice_input/recorder.rs
+++ b/src/tool/voice_input/recorder.rs
@@ -7,8 +7,8 @@ use std::time::{Duration, Instant};
 use anyhow::{Result, anyhow};
 use cpal::traits::{HostTrait, StreamTrait};
 
-use super::stderr_guard::silence_alsa;
 use super::input_stream;
+use super::stderr_guard::silence_alsa;
 
 /// Capture audio from the default microphone at 16kHz mono.
 ///


### PR DESCRIPTION
**Prompt:** users are reporting websocket streming erros and event type mismatch with the open ai codex provider on gpt 5.5 anf 5.5-fast, find out if there is a new shemca live test it first, use cnode.js repl and the keys from the vault

- ade31d8 codetether: TUI agent work (tui_7ce0f14b12594c87b574c1c6579b5e91)