### PR TITLE
feat(tui): summarise large pastes with sidecar buffer

### DIFF
--- a/src/tui/app/event_handlers/clipboard.rs
+++ b/src/tui/app/event_handlers/clipboard.rs
@@ -60,7 +60,31 @@ pub(super) fn handle_clipboard_paste(app: &mut App) {
 /// contents stay in the input buffer instead of each line submitting
 /// itself as a separate chat message.
 fn insert_clipboard_text(app: &mut App, text: &str) {
+    use crate::tui::app::input::pasted_text;
+
     let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+    if pasted_text::should_summarize(&normalized) {
+        let line_count = normalized.lines().count();
+        let byte_count = normalized.len();
+        let size = pasted_text::format_size(byte_count);
+        let placeholder = pasted_text::attach_paste(&mut app.state, normalized);
+        let id = app
+            .state
+            .pending_text_pastes
+            .last()
+            .map(|p| p.id)
+            .unwrap_or(0);
+        if app.state.input.starts_with('/') {
+            app.state.input_mode = InputMode::Command;
+        } else {
+            app.state.input_mode = InputMode::Editing;
+        }
+        app.state.insert_text(&placeholder);
+        app.state.status = format!(
+            "Pasted {line_count} lines ({size}) from clipboard summarised as #{id}; full text will be sent to the agent."
+        );
+        return;
+    }
     app.state.input_mode = if app.state.input.is_empty() && normalized.starts_with('/') {
         InputMode::Command
     } else if app.state.input.starts_with('/') {

--- a/src/tui/app/input/chat_submit.rs
+++ b/src/tui/app/input/chat_submit.rs
@@ -22,6 +22,7 @@ use crate::tui::worker_bridge::TuiWorkerBridge;
 
 use super::chat_helpers::push_user_messages;
 use super::chat_submit_dispatch::dispatch_prompt;
+use super::pasted_text::expand_paste_placeholders;
 
 /// Submit the chat input to the provider.
 ///
@@ -58,9 +59,16 @@ pub(super) async fn handle_enter_chat(
     }
 
     let pending_images = std::mem::take(&mut app.state.pending_images);
+    let pending_text_pastes = std::mem::take(&mut app.state.pending_text_pastes);
     if prompt.is_empty() && pending_images.is_empty() {
         return;
     }
+
+    // The user-facing chat history shows the compact placeholder so a
+    // 1-line summary stands in for what would otherwise be an
+    // 1000-line wall of text. The agent receives the expanded form
+    // with the full pasted content wrapped in delimiters.
+    let agent_prompt = expand_paste_placeholders(&prompt, &pending_text_pastes);
 
     push_user_messages(app, &prompt, &pending_images);
     dispatch_prompt(
@@ -69,7 +77,7 @@ pub(super) async fn handle_enter_chat(
         session,
         registry,
         worker_bridge,
-        &prompt,
+        &agent_prompt,
         pending_images,
         event_tx,
         result_tx,

--- a/src/tui/app/input/mod.rs
+++ b/src/tui/app/input/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod image;
 mod image_data_paste;
 mod merge;
 mod paste;
+pub(crate) mod pasted_text;
 mod pr;
 mod pr_body;
 mod pr_command;

--- a/src/tui/app/input/paste.rs
+++ b/src/tui/app/input/paste.rs
@@ -61,6 +61,10 @@ fn paste_into_chat(app: &mut App, normalized: &str) {
     if super::try_attach_data_url(app, normalized) {
         return;
     }
+    if super::pasted_text::should_summarize(normalized) {
+        attach_summarised_paste(app, normalized);
+        return;
+    }
     app.state.input_mode = if app.state.input.is_empty() && normalized.starts_with('/') {
         InputMode::Command
     } else if app.state.input.starts_with('/') {
@@ -75,4 +79,28 @@ fn paste_into_chat(app: &mut App, normalized: &str) {
     } else {
         "Pasted into input".to_string()
     };
+}
+
+/// Attach a large paste to the sidecar and insert a placeholder at
+/// the cursor instead of the full text.
+fn attach_summarised_paste(app: &mut App, normalized: &str) {
+    let line_count = normalized.lines().count();
+    let byte_count = normalized.len();
+    let size = super::pasted_text::format_size(byte_count);
+    let placeholder = super::pasted_text::attach_paste(&mut app.state, normalized.to_string());
+    let id = app
+        .state
+        .pending_text_pastes
+        .last()
+        .map(|p| p.id)
+        .unwrap_or(0);
+    if app.state.input.starts_with('/') {
+        app.state.input_mode = InputMode::Command;
+    } else {
+        app.state.input_mode = InputMode::Editing;
+    }
+    app.state.insert_text(&placeholder);
+    app.state.status = format!(
+        "Pasted {line_count} lines ({size}) summarised as #{id}; full text will be sent to the agent."
+    );
 }

--- a/src/tui/app/input/pasted_text.rs
+++ b/src/tui/app/input/pasted_text.rs
@@ -1,0 +1,206 @@
+//! Sidecar buffer for large multi-line paste blocks.
+//!
+//! When a paste arrives that is large or multi-line, we don't want to
+//! flood the input box with thousands of characters. Instead the full
+//! content lands in [`AppState::pending_text_pastes`] and the visible
+//! input gets a short placeholder like
+//! `[Pasted text #1: 42 lines, 1.2 KiB]`. On submit, the placeholder
+//! is expanded back to the full content for the agent prompt while
+//! the user-facing chat history keeps the compact summary.
+
+use crate::tui::app::state::AppState;
+
+/// Threshold above which a paste is summarised instead of being
+/// inlined into the input buffer.
+///
+/// Multi-line snippets shorter than this are still useful to see
+/// inline (short addresses, two-line commands, etc.). Anything
+/// longer becomes visual noise that hides the user's actual prompt
+/// text.
+const PASTE_SUMMARIZE_LINES: usize = 5;
+const PASTE_SUMMARIZE_BYTES: usize = 400;
+
+/// One sidecar entry for a paste that was summarised in the input
+/// buffer. The `id` shows up in the placeholder rendered for the
+/// user; expansion at submit time matches by that id's placeholder.
+#[derive(Debug, Clone)]
+pub struct PendingTextPaste {
+    pub id: u32,
+    pub content: String,
+}
+
+impl PendingTextPaste {
+    pub fn lines(&self) -> usize {
+        self.content.lines().count().max(1)
+    }
+
+    pub fn bytes(&self) -> usize {
+        self.content.len()
+    }
+
+    /// User-visible compact summary that takes the place of the full
+    /// pasted text in the input buffer and in the chat-history user
+    /// message. The agent receives the expanded form at submit time.
+    pub fn placeholder(&self) -> String {
+        format!(
+            "[Pasted text #{}: {} lines, {}]",
+            self.id,
+            self.lines(),
+            format_size(self.bytes())
+        )
+    }
+}
+
+/// Format a byte count as a short human-readable string (e.g. `1.2 KiB`).
+pub fn format_size(bytes: usize) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    if bytes < 1024 {
+        format!("{bytes} B")
+    } else if (bytes as f64) < MIB {
+        format!("{:.1} KiB", bytes as f64 / KIB)
+    } else {
+        format!("{:.1} MiB", bytes as f64 / MIB)
+    }
+}
+
+/// Decide whether a paste is large enough to warrant summarisation.
+pub fn should_summarize(text: &str) -> bool {
+    let lines = text.lines().count();
+    let bytes = text.len();
+    lines >= PASTE_SUMMARIZE_LINES || bytes >= PASTE_SUMMARIZE_BYTES
+}
+
+/// Allocate the next paste id.
+fn next_paste_id(pastes: &[PendingTextPaste]) -> u32 {
+    pastes.iter().map(|p| p.id).max().map(|m| m + 1).unwrap_or(1)
+}
+
+/// Push a new sidecar entry and return the placeholder string the
+/// caller should insert into the input buffer at the cursor.
+pub fn attach_paste(state: &mut AppState, content: String) -> String {
+    let id = next_paste_id(&state.pending_text_pastes);
+    let paste = PendingTextPaste { id, content };
+    let placeholder = paste.placeholder();
+    state.pending_text_pastes.push(paste);
+    placeholder
+}
+
+/// Replace each `[Pasted text #N: …]` placeholder in `prompt` with
+/// the corresponding sidecar content wrapped in delimiters that the
+/// agent can recognise. Pastes whose placeholder no longer appears
+/// in the prompt are dropped silently — the user must have edited
+/// them out before submitting.
+pub fn expand_paste_placeholders(prompt: &str, pastes: &[PendingTextPaste]) -> String {
+    let mut out = prompt.to_string();
+    for paste in pastes {
+        let ph = paste.placeholder();
+        if !out.contains(&ph) {
+            continue;
+        }
+        let expansion = format!(
+            "\n\n--- Begin pasted text #{id} ({lines} lines, {bytes} bytes) ---\n{content}\n--- End pasted text #{id} ---",
+            id = paste.id,
+            lines = paste.lines(),
+            bytes = paste.bytes(),
+            content = paste.content,
+        );
+        out = out.replacen(&ph, &expansion, 1);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paste(id: u32, content: &str) -> PendingTextPaste {
+        PendingTextPaste {
+            id,
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn format_size_human_readable() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(512), "512 B");
+        assert_eq!(format_size(1024), "1.0 KiB");
+        assert_eq!(format_size(1536), "1.5 KiB");
+        assert_eq!(format_size(2 * 1024 * 1024), "2.0 MiB");
+    }
+
+    #[test]
+    fn placeholder_reports_lines_and_size() {
+        let p = paste(7, "a\nb\nc");
+        assert_eq!(p.placeholder(), "[Pasted text #7: 3 lines, 5 B]");
+    }
+
+    #[test]
+    fn placeholder_single_line_still_reports_one_line() {
+        let p = paste(1, "single line");
+        assert_eq!(p.lines(), 1);
+        assert!(p.placeholder().contains("1 lines"));
+    }
+
+    #[test]
+    fn should_summarize_thresholds() {
+        // 2 lines, 22 bytes — stay inline.
+        assert!(!should_summarize("first line\nsecond line"));
+        // 3 lines, 28 bytes — stay inline.
+        assert!(!should_summarize("line one\nline two\nline three"));
+        // 5 lines — summarise.
+        assert!(should_summarize("a\nb\nc\nd\ne"));
+        // 1 line, 400+ bytes — summarise.
+        let big = "x".repeat(400);
+        assert!(should_summarize(&big));
+        // 1 line, 399 bytes — stay inline.
+        let almost = "x".repeat(399);
+        assert!(!should_summarize(&almost));
+    }
+
+    #[test]
+    fn expand_replaces_placeholder_with_full_content() {
+        let pastes = vec![paste(1, "hello\nworld")];
+        let prompt = "please review [Pasted text #1: 2 lines, 11 B] and respond";
+        let out = expand_paste_placeholders(prompt, &pastes);
+        assert!(out.contains("--- Begin pasted text #1 (2 lines, 11 bytes) ---"));
+        assert!(out.contains("hello\nworld"));
+        assert!(out.contains("--- End pasted text #1 ---"));
+        assert!(out.starts_with("please review "));
+        assert!(out.ends_with(" and respond"));
+    }
+
+    #[test]
+    fn expand_drops_pastes_whose_placeholder_was_deleted() {
+        let pastes = vec![paste(1, "hello"), paste(2, "world")];
+        // Only #2's placeholder is present.
+        let prompt = "look at [Pasted text #2: 1 lines, 5 B]";
+        let out = expand_paste_placeholders(prompt, &pastes);
+        assert!(out.contains("world"));
+        assert!(!out.contains("hello"));
+        assert!(!out.contains("#1"));
+    }
+
+    #[test]
+    fn expand_replaces_only_first_occurrence_per_paste() {
+        // If the user typed the same placeholder string twice, only the
+        // first match expands so the sidecar content is never duplicated.
+        let pastes = vec![paste(1, "DATA")];
+        let prompt =
+            "[Pasted text #1: 1 lines, 4 B] then again [Pasted text #1: 1 lines, 4 B]";
+        let out = expand_paste_placeholders(prompt, &pastes);
+        assert_eq!(out.matches("DATA").count(), 1);
+        assert_eq!(out.matches("[Pasted text #1: 1 lines, 4 B]").count(), 1);
+    }
+
+    #[test]
+    fn next_paste_id_starts_at_one_and_increments() {
+        let mut pastes: Vec<PendingTextPaste> = Vec::new();
+        assert_eq!(next_paste_id(&pastes), 1);
+        pastes.push(paste(1, "a"));
+        assert_eq!(next_paste_id(&pastes), 2);
+        pastes.push(paste(2, "b"));
+        assert_eq!(next_paste_id(&pastes), 3);
+    }
+}

--- a/src/tui/app/input/tests_paste.rs
+++ b/src/tui/app/input/tests_paste.rs
@@ -79,6 +79,102 @@ mod tests {
     /// The inline variant: typed (or pasted) text that already contains
     /// newlines — e.g. after Alt+Enter / Shift+Enter inserts a `\n` —
     /// must also submit as a single message on Enter.
+    /// A paste large enough to exceed the summarise threshold must NOT
+    /// flood the input with the full content. Instead the input gets a
+    /// short `[Pasted text #N: …]` placeholder and the full content is
+    /// stashed in the sidecar for expansion at submit time.
+    #[tokio::test]
+    async fn large_paste_is_summarised_into_sidecar() {
+        let mut app = App::default();
+        app.state.view_mode = ViewMode::Chat;
+
+        // 6 lines — over the 5-line threshold.
+        let pasted = "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta";
+        handle_paste(&mut app, pasted).await;
+
+        // Input shows the placeholder, not the body.
+        assert!(
+            app.state.input.starts_with("[Pasted text #1:"),
+            "input should be a placeholder, got: {:?}",
+            app.state.input
+        );
+        assert!(!app.state.input.contains("epsilon"));
+
+        // Sidecar holds the real content, keyed by id 1.
+        assert_eq!(app.state.pending_text_pastes.len(), 1);
+        assert_eq!(app.state.pending_text_pastes[0].id, 1);
+        assert_eq!(app.state.pending_text_pastes[0].content, pasted);
+
+        // Status surfaces the line / size summary.
+        assert!(
+            app.state.status.contains("6 lines"),
+            "status missing line count: {:?}",
+            app.state.status
+        );
+        assert!(app.state.status.contains("#1"));
+    }
+
+    /// On submit, the user-facing chat message keeps the placeholder
+    /// (so the chat scroll-back stays compact) but the prompt sent to
+    /// the dispatch layer is the expanded form with the full pasted
+    /// body so the agent can actually see the content.
+    #[tokio::test]
+    async fn submit_expands_placeholder_into_agent_prompt() {
+        use crate::tui::app::input::pasted_text::expand_paste_placeholders;
+
+        let mut app = App::default();
+        app.state.view_mode = ViewMode::Chat;
+
+        let pasted = "one\ntwo\nthree\nfour\nfive\nsix";
+        handle_paste(&mut app, pasted).await;
+        // Type a question after the placeholder.
+        app.state.insert_text("\nplease summarise this");
+
+        // What the user sees in chat history.
+        let display_prompt = app.state.input.trim().to_string();
+        assert!(display_prompt.starts_with("[Pasted text #1:"));
+        assert!(display_prompt.ends_with("please summarise this"));
+        assert!(!display_prompt.contains("four"));
+
+        // What the agent will receive.
+        let agent_prompt =
+            expand_paste_placeholders(&display_prompt, &app.state.pending_text_pastes);
+        assert!(agent_prompt.contains("--- Begin pasted text #1"));
+        assert!(agent_prompt.contains("four\nfive\nsix"));
+        assert!(agent_prompt.contains("--- End pasted text #1 ---"));
+        assert!(agent_prompt.contains("please summarise this"));
+    }
+
+    /// Two consecutive large pastes produce two distinct sidecar
+    /// entries with monotonically increasing ids, and both placeholders
+    /// land in the input buffer side-by-side.
+    #[tokio::test]
+    async fn two_large_pastes_get_independent_ids() {
+        let mut app = App::default();
+        app.state.view_mode = ViewMode::Chat;
+
+        handle_paste(&mut app, "a\nb\nc\nd\ne\nf").await;
+        handle_paste(&mut app, "g\nh\ni\nj\nk\nl").await;
+
+        assert_eq!(app.state.pending_text_pastes.len(), 2);
+        assert_eq!(app.state.pending_text_pastes[0].id, 1);
+        assert_eq!(app.state.pending_text_pastes[1].id, 2);
+        assert!(app.state.input.contains("[Pasted text #1:"));
+        assert!(app.state.input.contains("[Pasted text #2:"));
+    }
+
+    /// A short multi-line paste must continue to land inline. This
+    /// guards against regressing the existing behaviour that the
+    /// summarise threshold was tuned around.
+    #[tokio::test]
+    async fn short_multiline_paste_still_inlines() {
+        let mut app = App::default();
+        app.state.view_mode = ViewMode::Chat;
+        handle_paste(&mut app, "alpha\nbeta").await;
+        assert_eq!(app.state.input, "alpha\nbeta");
+        assert!(app.state.pending_text_pastes.is_empty());
+    }
+
     #[tokio::test]
     async fn typed_newline_then_enter_submits_as_single_message() {
         let mut app = App::default();

--- a/src/tui/app/state/default_impl.rs
+++ b/src/tui/app/state/default_impl.rs
@@ -69,6 +69,7 @@ impl Default for super::AppState {
             last_tool_latency_ms: None,
             last_tool_success: None,
             pending_images: Vec::new(),
+            pending_text_pastes: Vec::new(),
             current_turn_cancel: None,
             auto_apply_edits: false,
             allow_network: false,

--- a/src/tui/app/state/mod.rs
+++ b/src/tui/app/state/mod.rs
@@ -125,6 +125,13 @@ pub struct AppState {
     pub last_tool_latency_ms: Option<u64>,
     pub last_tool_success: Option<bool>,
     pub pending_images: Vec<ImageAttachment>,
+    /// Sidecar buffer for paste blocks that were too large to inline
+    /// into the input box. Each entry is rendered in the input as a
+    /// short placeholder like `[Pasted text #1: 42 lines, 1.2 KiB]`,
+    /// and the full content is expanded back into the prompt sent to
+    /// the agent at submit time. See
+    /// [`crate::tui::app::input::pasted_text`].
+    pub pending_text_pastes: Vec<crate::tui::app::input::pasted_text::PendingTextPaste>,
     pub auto_apply_edits: bool,
     pub allow_network: bool,
     pub slash_autocomplete: bool,


### PR DESCRIPTION
## Summary
- **Problem**: Pasting a multi-line block into the chat input flooded the input box with the full content — visually noisy, scrolled the prompt off-screen, and hid any text the user wanted to add. Bracketed paste was already atomic at the wire level, but there was no summary layer between paste and render.
- **Fix**: Mirror the existing `pending_images` pattern with a `pending_text_pastes` sidecar.
  - Pastes with ≥ 5 lines **or** ≥ 400 bytes land in the sidecar; the input gets a compact placeholder: `[Pasted text #1: 42 lines, 1.2 KiB]`.
  - Both code paths share the same threshold: bracketed paste (`src/tui/app/input/paste.rs`) and Ctrl+V (`src/tui/app/event_handlers/clipboard.rs`).
  - On Enter, the user-facing chat history keeps the compact placeholder, but the prompt sent to the agent is expanded into a fenced `--- Begin pasted text #N (lines, bytes) --- … --- End pasted text #N ---` block holding the verbatim content.
  - Pastes whose placeholder was edited out before submit are silently dropped — same lifecycle as `pending_images`.
- Short multi-line snippets (under both thresholds) keep the existing inline behaviour, so the regression tests for "paste 2-line / 3-line text inline" still pass.

## Behaviour after this change
1. User pastes 60 lines of code.
2. Input box shows: `[Pasted text #1: 60 lines, 1.4 KiB]` — one short line.
3. Status line: `Pasted 60 lines (1.4 KiB) summarised as #1; full text will be sent to the agent.`
4. User types ` please review for SQL injection` after the placeholder and presses Enter.
5. Chat history shows: `[Pasted text #1: 60 lines, 1.4 KiB] please review for SQL injection` (compact).
6. Agent receives the full 60-line body wrapped in `--- Begin pasted text #1 …` delimiters plus the user's question.

## Test plan
- [x] `cargo build --lib` clean
- [x] `cargo test --lib pasted_text` — 8/8 passing (size formatter, placeholder shape, threshold tuning, expansion, dropped placeholders, monotonic ids, single-occurrence replacement)
- [x] `cargo test --lib tests_paste` — 7/7 passing (4 new + 3 existing) covering inline-vs-summarised regimes, two-paste id allocation, and submit-time expansion
- [x] `cargo test --lib tui::app::input` — 24/24 passing
- [x] `cargo test --lib tui::app::event_handlers` — 7/7 passing
- [x] `cargo test --lib tui::app::state` — 9/9 passing
- [ ] Manual TUI smoke: paste 100-line block → see placeholder; paste short 2-line block → see inline; type after placeholder; press Enter; confirm agent prompt contains expanded block via debug log