### PR TITLE
feat(a2a): expose A2A peer endpoint from inside the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ Dual-transport Agent-to-Agent communication with a shared in-process bus:
 
 - **Worker mode** — Connect to the CodeTether platform and process tasks.
 - **Server mode** — Accept tasks via JSON-RPC (Axum, `:4096`) and gRPC (Tonic, `:50051`) simultaneously.
-- **Spawn mode** — Launch a standalone A2A peer that auto-registers and discovers other peers.
+- **Spawn mode** — Launch a standalone A2A peer that auto-registers and discovers other peers. See [`docs/a2a-spawn.md`](docs/a2a-spawn.md) for the full two-terminal / multi-repo walkthrough, JSON-RPC reference, and discovery internals.
 - **Bus mode** — In-process pub/sub for zero-latency local agent communication.
 
 ### Transports

--- a/docs/a2a-spawn.md
+++ b/docs/a2a-spawn.md
@@ -428,7 +428,7 @@ let resp = client.send_message(MessageSendParams {
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `Failed to bind spawn agent on …: Address already in use` | Port in use (e.g., previous `spawn` still running) | Pick another `--port` or stop the prior process. |
+| `Failed to bind A2A peer on …: Address already in use` | Port in use (e.g., previous `spawn` still running) | Pick another `--port` or stop the prior process. |
 | Discovery never logs `Discovered A2A peer` | Peer not yet listening / wrong URL / firewall | Verify with `curl http://<peer>/.well-known/agent.json`. Lower `--discovery-interval-secs 5` for faster feedback. |
 | Inbound `message/send` returns `Failed to create session` | No providers configured | Check `Available providers: [...]` in the spawn log. Configure a provider via Vault or env. |
 | `message/send` returns `INVALID_PARAMS: No text content in message` | All parts were `file` / `data`, no `text` part | Include at least one `{"kind":"text","text":"..."}` part. |

--- a/docs/a2a-spawn.md
+++ b/docs/a2a-spawn.md
@@ -1,0 +1,463 @@
+# `codetether spawn` — A2A Peer Runtime
+
+Spawn an autonomous A2A agent runtime that:
+
+- stands up its **own A2A JSON-RPC API** on a port,
+- publishes an **agent card** at `/.well-known/agent.json`,
+- **discovers peers** on a polling loop and registers them in the local bus,
+- optionally **auto-introduces** itself to newly discovered peers,
+- runs an LLM session per inbound `message/send` to actually *answer*.
+
+This is the mode to use when you want **two (or more) terminals running two agents in different repos that can talk to each other directly**, with no central broker.
+
+---
+
+## TL;DR — two terminals, two repos
+
+**Terminal 1** (Alice, repo A):
+```bash
+cd /path/to/repo-A
+codetether spawn \
+  --name alice \
+  --port 4097 \
+  --peer http://127.0.0.1:4098
+```
+
+**Terminal 2** (Bob, repo B):
+```bash
+cd /path/to/repo-B
+codetether spawn \
+  --name bob \
+  --port 4098 \
+  --peer http://127.0.0.1:4097
+```
+
+Within one discovery interval (default 15 s, override with `--discovery-interval-secs`) each side logs:
+
+```
+INFO codetether_agent::a2a::spawn: Discovered A2A peer  agent=alice  peer_name=bob  peer_url=http://127.0.0.1:4098
+INFO codetether_agent::a2a::spawn: Auto-intro message sent  peer=http://127.0.0.1:4098
+```
+
+After that, either side (or any third-party tool) can drive the other over plain HTTP JSON-RPC.
+
+---
+
+## When to use spawn vs the other A2A modes
+
+| Mode | Command | Bind | What it does |
+|---|---|---|---|
+| **Spawn** | `codetether spawn` | `127.0.0.1:4097` (configurable) | Standalone headless A2A peer with discovery + auto-intro. **Use for two-terminal / multi-repo / decentralized agent meshes when you don't need a TUI.** |
+| **TUI + A2A** | `codetether tui --a2a-port <P> --a2a-peer <URL>` | configurable | Interactive TUI **plus** the same A2A peer endpoint inside the same process. **Use when you want to drive the agent yourself in the TUI and have it reachable as a peer.** Inbound A2A messages are answered by a fresh background session — they do not appear in your TUI conversation. |
+| Serve | `codetether serve` | `127.0.0.1:4096` | Headless A2A API with optional mDNS. No outbound peer discovery. |
+| Worker | `codetether worker --server URL` | (outbound) | Connects *to* a CodeTether server as a worker. No inbound API. |
+| Swarm | `codetether swarm` | (in-process) | Spawns sub-agents inside one process. No external API. |
+
+If you want decentralized agents that find each other and chat, `spawn` (headless) or `tui --a2a-port` (interactive) are the right modes.
+
+---
+
+## TUI + A2A: two interactive terminals that can message each other
+
+If you want each side to be a TUI you drive yourself, but still reachable as an A2A peer:
+
+**Terminal 1** (TUI in repo A, peer is repo B's TUI on :4098):
+```bash
+cd /path/to/repo-A
+codetether tui \
+  --a2a-port 4097 \
+  --a2a-name alice \
+  --a2a-peer http://127.0.0.1:4098
+```
+
+**Terminal 2** (TUI in repo B, peer is repo A's TUI on :4097):
+```bash
+cd /path/to/repo-B
+codetether tui \
+  --a2a-port 4098 \
+  --a2a-name bob \
+  --a2a-peer http://127.0.0.1:4097
+```
+
+Each TUI starts as normal and *also* exposes `/.well-known/agent.json` and the JSON-RPC endpoint on its `--a2a-port`. From inside one TUI, you can use the `http` tool (or any normal session tool) to POST a `message/send` to the other side's port. From a third terminal you can curl either side.
+
+**Important — inbound A2A and the TUI session do not share state.** When the peer (or curl) sends `message/send`, the request is handled by a fresh `Session` spun up by the A2A handler — exactly the same way `codetether spawn` answers. The reply goes back over A2A. **The exchange does not appear in your TUI's chat view, and your TUI session does not see it.** If you want the inbound message to show up in the TUI conversation, that's the routed-into-TUI variant, which is a separate feature (not in this build).
+
+### TUI A2A flag reference
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--a2a-port <PORT>` | (off) | When set, the TUI process binds an A2A endpoint on this port. Without this flag the TUI is purely interactive (no A2A surface). |
+| `--a2a-hostname <HOST>` | `127.0.0.1` | Use `0.0.0.0` for off-box. Pair with `--a2a-public-url`. |
+| `--a2a-public-url <URL>` | `http://<hostname>:<port>` | URL published in the agent card. |
+| `--a2a-name <NAME>` | `tui-agent-<pid>` | Card name (what peers see). |
+| `--a2a-description <TEXT>` | (default) | Card description. |
+| `--a2a-peer <URL>` (repeatable, comma-separable) | `[]` | Peer seed URLs. Also reads `CODETETHER_A2A_PEERS`. |
+| `--a2a-discovery-interval-secs <N>` | `15` | Clamped to ≥ 5. |
+| `--a2a-no-auto-introduce` | (intro on) | Disable the auto-intro `message/send` to newly discovered peers. |
+
+These flags mirror the `codetether spawn` flags one-for-one (with an `a2a-` prefix to keep them out of the TUI's own option namespace).
+
+---
+
+## CLI reference
+
+```
+codetether spawn [OPTIONS] [-- <PROJECT>]
+```
+
+| Flag | Default | Env | Purpose |
+|---|---|---|---|
+| `-n`, `--name <NAME>` | `spawned-agent-<pid>` | — | Agent name (becomes `card.name` and bus registration id). |
+| `--hostname <HOST>` | `127.0.0.1` | — | Bind address. Set to `0.0.0.0` to accept off-box traffic. |
+| `-p`, `--port <PORT>` | `4097` | — | Bind port. Pick a unique port per agent. |
+| `--public-url <URL>` | `http://<hostname>:<port>` | — | URL published in the agent card. Set explicitly when binding `0.0.0.0` so peers know where to call back. |
+| `-d`, `--description <TEXT>` | (default text) | — | Custom card description. |
+| `--peer <URL>` (repeatable, comma-separable) | `[]` | `CODETETHER_A2A_PEERS` | Peer seed URLs to probe for agent cards. |
+| `--discovery-interval-secs <N>` | `15` | — | How often to re-probe seeds. Minimum effective value is 5 s (clamped). |
+| `--no-auto-introduce` | (intro on by default) | — | Suppress the auto-intro `message/send` sent to newly discovered peers. |
+| `[PROJECT]` | cwd | — | Project directory the spawned agent will operate in. |
+| `--print-logs` | off | — | Mirror tracing output to stderr (otherwise honors logfile config). |
+| `--log-level DEBUG\|INFO\|WARN\|ERROR` | `INFO` | — | Tracing level. |
+
+---
+
+## Lifecycle (what happens when you run `spawn`)
+
+1. **Resolve identity**: agent name + bind address + public URL. Public URL is normalized (scheme injected, trailing slash stripped).
+2. **Build the agent card** (`A2AServer::default_card`) — name, description, version (from `CARGO_PKG_VERSION`), `protocolVersion: 0.3.0`, default skills (`code`, `debug`, `explain`).
+3. **Initialize the bus** (`AgentBus::new`).
+4. **Auto-start the S3 training sink** (best-effort; needs Vault `chat-sync-minio` creds — silent if unavailable).
+5. **Register self in the bus registry** under the agent name.
+6. **Announce ready** with the card's skill ids as capabilities.
+7. **Resolve peer seeds** from `--peer` and `CODETETHER_A2A_PEERS`, dedup, and skip self.
+8. **Start the discovery loop** (`tokio::spawn`) — see below.
+9. **Bind the Axum router** (`A2AServer::router`) on `<hostname>:<port>` and serve until SIGINT.
+10. On shutdown: abort discovery loop, log clean exit.
+
+---
+
+## HTTP API exposed by the spawned agent
+
+The router (`src/a2a/server.rs::A2AServer::router`) mounts:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/.well-known/agent.json` | Agent card (canonical path) |
+| `GET` | `/.well-known/agent-card.json` | Agent card (compatibility alias) |
+| `POST` | `/` | A2A JSON-RPC 2.0 endpoint |
+
+### Agent card
+
+```bash
+curl -s http://127.0.0.1:4097/.well-known/agent.json | jq .
+```
+
+Returns an `AgentCard` (see `src/a2a/types.rs`):
+- `name`, `description`, `url`, `version`, `protocolVersion`
+- `capabilities`: `streaming: true`, `pushNotifications: false`, `stateTransitionHistory: true`
+- `skills[]`: each with `id`, `name`, `description`, `tags`, `examples`, `inputModes`, `outputModes`
+- `defaultInputModes` / `defaultOutputModes`
+- `provider` (`organization: "CodeTether"`)
+- `securitySchemes`, `security`, `signatures` (default empty)
+
+### JSON-RPC methods
+
+All requests are `POST /` with `Content-Type: application/json`. Wire format is JSON-RPC 2.0.
+
+| Method | Params type | Returns |
+|---|---|---|
+| `message/send` | `MessageSendParams` | `Task` (or `Message`) |
+| `message/stream` | `MessageSendParams` | `Task` in `working` state — poll `tasks/get` for completion |
+| `tasks/get` | `TaskQueryParams` (`id`, optional `historyLength`) | `Task` |
+| `tasks/cancel` | `TaskQueryParams` (`id`) | `Task` (state → `cancelled`) |
+
+#### `message/send`
+
+`blocking: true` (default) runs the LLM session synchronously and returns a `Task` already in `completed` (or `failed`) state with the agent's response in `status.message` and as an `artifact`.
+
+`blocking: false` returns immediately with the task in `working`; the LLM session runs on a background tokio task, and the caller polls `tasks/get`.
+
+```bash
+curl -s -X POST http://127.0.0.1:4098/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "messageId": "msg-001",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Bob, refactor src/foo.rs and report back"}]
+      },
+      "configuration": {
+        "acceptedOutputModes": ["text/plain"],
+        "blocking": false
+      }
+    }
+  }'
+```
+
+Response (truncated):
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "<uuid>",
+    "status": {
+      "state": "working",
+      "message": { ... echo of the inbound message ... },
+      "timestamp": "2026-04-28T15:43:55Z"
+    },
+    "history": [ ... ],
+    "artifacts": []
+  }
+}
+```
+
+#### `tasks/get`
+
+```bash
+curl -s -X POST http://127.0.0.1:4098/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tasks/get",
+    "params": {"id": "<task-id-from-message-send>"}
+  }'
+```
+
+Returns the full `Task` including `status.state`, the agent reply in `status.message`, and any `artifacts[]`.
+
+#### `tasks/cancel`
+
+Refused (`-32002 TASK_NOT_CANCELABLE`) if the task is already in a terminal state.
+
+#### Error codes (`src/a2a/types.rs`)
+
+| Code | Constant | Meaning |
+|---|---|---|
+| `-32700` | `PARSE_ERROR` | JSON parse error |
+| `-32600` | `INVALID_REQUEST` | Malformed JSON-RPC envelope |
+| `-32601` | `METHOD_NOT_FOUND` | Unknown method |
+| `-32602` | `INVALID_PARAMS` | Invalid params (e.g., empty text content) |
+| `-32603` | `INTERNAL_ERROR` | Session creation / serialization failure |
+| `-32001` | `TASK_NOT_FOUND` | Task id not in this server's store |
+| `-32002` | `TASK_NOT_CANCELABLE` | Task already terminal |
+| `-32004` | `UNSUPPORTED_OPERATION` | Method not implemented at this endpoint |
+
+> The task store is **in-memory per server process** (`DashMap<String, Task>`). Restarting the spawned agent loses task history. Persistence belongs to the bus S3 sink (training records) or external storage.
+
+---
+
+## Peer discovery
+
+Implementation: `src/a2a/spawn.rs::discovery_loop`.
+
+Every `discovery_interval_secs` (≥ 5 s):
+
+1. For each peer seed URL, build candidate endpoints:
+   - If seed ends in `/a2a`: try as-is.
+   - Otherwise: try seed, then `seed/a2a`.
+2. `GET <candidate>/.well-known/agent.json` via `A2AClient` (with `CODETETHER_AUTH_TOKEN` if set).
+3. First success wins. Card is registered in `bus.registry`.
+4. If this is the **first** time we've seen this `endpoint::card.name` pair:
+   - Log `Discovered A2A peer`.
+   - If `auto_introduce` is on, send a non-blocking `message/send` with text `"Hello from <name> (<self-url>). I am online and available for A2A collaboration."`.
+
+Discovery is **idempotent**: re-seeing a known peer re-registers the card (so cards can be refreshed) but skips the intro message.
+
+> Discovery is **outbound-only**. To make agents truly find each other, every peer must seed at least one other peer's URL — symmetrically is fastest, but as long as the graph is connected discovery propagates over time.
+
+### Self-skip
+
+Peer URLs that match the agent's own `public_url` (after normalization) are dropped. This means it's safe to seed a shared peer-list env var on every node:
+
+```bash
+export CODETETHER_A2A_PEERS=http://node1:4097,http://node2:4097,http://node3:4097
+```
+
+Each node will only dial peers other than itself.
+
+---
+
+## Bus registry & training sink
+
+`AgentBus` (`src/bus/mod.rs`) is the in-process pub/sub the spawned agent uses for local bookkeeping.
+
+- `bus.registry.register(card)` — store/refresh an agent card by name.
+- `handle.announce_ready(capabilities)` — mark this agent as ready for work with the listed skill ids.
+- `bus::s3_sink::spawn_bus_s3_sink(bus)` — best-effort: if Vault is reachable and the `chat-sync-minio` provider is configured, the bus emits training-record JSONL batches to MinIO/S3 (`bucket: codetether-training`, `prefix: training/`, batched 100 events / 30 s).
+
+The bus is **per-process**. Cross-process coordination is via the A2A HTTP API, not via the bus.
+
+---
+
+## Authentication
+
+The spawned agent's HTTP server itself is **unauthenticated by default** — it accepts any JSON-RPC request on the bound interface. Restrict access with:
+
+- `--hostname 127.0.0.1` (default) — loopback only.
+- A reverse proxy / firewall when binding `0.0.0.0`.
+
+The **outbound A2A client** (used by discovery and by `A2AClient`) attaches a bearer token if `CODETETHER_AUTH_TOKEN` is set in the environment. Set this on both ends if you front the spawned agent with an auth-checking proxy.
+
+---
+
+## Model resolution for inbound messages
+
+When a spawned agent receives a `message/send`, it creates a fresh `Session` (`src/session/mod.rs`) and runs `session.prompt(text)`. The model used is resolved by `configure_a2a_session`:
+
+1. `CODETETHER_DEFAULT_MODEL` env var (trimmed, non-empty).
+2. Otherwise `default_model` from `Config::load()`.
+3. Otherwise the session's own default (currently `glm-5.1` via `zai` provider in the default deployment).
+
+At least one provider must be configured (Vault or env) or the session creation fails and the inbound `message/send` returns a `failed` task.
+
+---
+
+## Environment variables
+
+| Var | Used by | Effect |
+|---|---|---|
+| `CODETETHER_A2A_PEERS` | spawn | Comma-separated peer seed URLs (alternative to `--peer`). |
+| `CODETETHER_AUTH_TOKEN` | A2A client (discovery + intro) | Bearer token attached to outbound A2A calls. |
+| `CODETETHER_DEFAULT_MODEL` | spawn-served sessions | Override default model used to answer inbound messages. |
+| `CODETETHER_SERVER` | worker mode | Not used by `spawn`. |
+
+---
+
+## Cross-host setup
+
+When the two agents are on different machines:
+
+```bash
+# Node A (10.0.0.10)
+codetether spawn \
+  --name alice \
+  --hostname 0.0.0.0 \
+  --port 4097 \
+  --public-url http://10.0.0.10:4097 \
+  --peer http://10.0.0.11:4097
+
+# Node B (10.0.0.11)
+codetether spawn \
+  --name bob \
+  --hostname 0.0.0.0 \
+  --port 4097 \
+  --public-url http://10.0.0.11:4097 \
+  --peer http://10.0.0.10:4097
+```
+
+The `--public-url` flag matters: it's what each side publishes in its agent card and what the *other* side stores as a callback URL. Without it the card advertises `http://0.0.0.0:4097`, which is unroutable.
+
+---
+
+## curl recipes
+
+```bash
+# 1. Read peer's card
+curl -s http://127.0.0.1:4098/.well-known/agent.json | jq .
+
+# 2. Fire-and-forget message (non-blocking)
+TASK=$(curl -s -X POST http://127.0.0.1:4098/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{
+    "message":{"messageId":"m1","role":"user",
+      "parts":[{"kind":"text","text":"Summarize README.md in 3 bullets"}]},
+    "configuration":{"acceptedOutputModes":["text/plain"],"blocking":false}}}' \
+  | jq -r '.result.id')
+echo "task_id=$TASK"
+
+# 3. Poll for completion
+curl -s -X POST http://127.0.0.1:4098/ \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tasks/get\",\"params\":{\"id\":\"$TASK\"}}" \
+  | jq '.result.status.state, .result.status.message.parts'
+
+# 4. Cancel an in-flight task
+curl -s -X POST http://127.0.0.1:4098/ \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tasks/cancel\",\"params\":{\"id\":\"$TASK\"}}"
+```
+
+---
+
+## Programmatic client (Rust)
+
+```rust
+use codetether_agent::a2a::{
+    client::A2AClient,
+    types::{Message, MessageRole, MessageSendConfiguration, MessageSendParams, Part},
+};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+let client = A2AClient::new("http://127.0.0.1:4098");
+
+let card = client.get_agent_card().await?;
+println!("Talking to {} ({})", card.name, card.url);
+
+let resp = client.send_message(MessageSendParams {
+    message: Message {
+        message_id: Uuid::new_v4().to_string(),
+        role: MessageRole::User,
+        parts: vec![Part::Text { text: "ping".into() }],
+        context_id: None,
+        task_id: None,
+        metadata: HashMap::new(),
+        extensions: vec![],
+    },
+    configuration: Some(MessageSendConfiguration {
+        accepted_output_modes: vec!["text/plain".into()],
+        blocking: Some(true),
+        history_length: Some(0),
+        push_notification_config: None,
+    }),
+}).await?;
+```
+
+`A2AClient` lives in `src/a2a/client.rs` and supports `with_token(...)` for bearer auth.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Failed to bind spawn agent on …: Address already in use` | Port in use (e.g., previous `spawn` still running) | Pick another `--port` or stop the prior process. |
+| Discovery never logs `Discovered A2A peer` | Peer not yet listening / wrong URL / firewall | Verify with `curl http://<peer>/.well-known/agent.json`. Lower `--discovery-interval-secs 5` for faster feedback. |
+| Inbound `message/send` returns `Failed to create session` | No providers configured | Check `Available providers: [...]` in the spawn log. Configure a provider via Vault or env. |
+| `message/send` returns `INVALID_PARAMS: No text content in message` | All parts were `file` / `data`, no `text` part | Include at least one `{"kind":"text","text":"..."}` part. |
+| Card advertises `http://0.0.0.0:4097` | Bound to `0.0.0.0` without `--public-url` | Pass `--public-url http://<reachable-host>:<port>`. |
+| Auto-intro message sent but no reply | The remote agent processed the intro silently — there is no auto-reply behavior. | Send an explicit `message/send` to elicit a response. |
+| Two agents reciprocally spam intro logs | Discovery interval too aggressive | Raise `--discovery-interval-secs`. Intro is only sent on **first** discovery per `endpoint::name` pair, so this should not happen unless the peer card name keeps changing. |
+
+Enable verbose logs with `--log-level DEBUG --print-logs`. Peer probe failures are logged at `DEBUG`, so debug-level logging is the way to see *why* discovery is silent.
+
+---
+
+## Source map
+
+| File | Role |
+|---|---|
+| `src/cli/mod.rs` (`SpawnArgs`, `Command::Spawn`) | CLI surface |
+| `src/a2a/spawn.rs` | Entry point, lifecycle, discovery loop, intro sender, **`SpawnOptions` + `start_a2a_in_background`** (used by the TUI) |
+| `src/tui/app/run.rs` | TUI entry point. When `--a2a-port` is set, calls `start_a2a_in_background` with the TUI's bus before entering the event loop. |
+| `src/a2a/server.rs` | Axum router, JSON-RPC dispatch, message/task handlers, `default_card` |
+| `src/a2a/client.rs` | Outbound `A2AClient` used by discovery + intro |
+| `src/a2a/types.rs` | All wire types (`AgentCard`, `Message`, `Task`, `MessageSendParams`, JSON-RPC envelopes, error codes) |
+| `src/bus/mod.rs`, `src/bus/registry.rs` | In-process bus + agent registry |
+| `src/bus/s3_sink.rs` | Best-effort training-record export |
+| `specification/json/a2a.json` (in `../A2A-Server-MCP/specification/json/`) | Upstream A2A protocol schema this implementation tracks |
+
+---
+
+## Quick mental model
+
+> **`codetether spawn` = "be an A2A agent with my own API and find my friends."**
+>
+> Each spawn process is a self-contained A2A node. Nodes know about each other via seed URLs and `/.well-known/agent.json`. Communication is plain HTTP JSON-RPC 2.0 to the bound port. There is no central server, no required broker, no message bus across the wire — just agents calling each other's HTTP endpoints.

--- a/src/a2a/spawn.rs
+++ b/src/a2a/spawn.rs
@@ -1,4 +1,48 @@
 //! Spawn an autonomous A2A agent runtime with auto peer discovery.
+//!
+//! Stands up an [`A2AServer`] (Axum) on a configurable host:port, publishes an
+//! agent card at `/.well-known/agent.json`, and runs a background discovery
+//! loop that polls each `--peer` seed for its agent card. New peers are
+//! registered in the local bus and (unless `--no-auto-introduce` is set) sent
+//! a one-shot non-blocking `message/send` introduction.
+//!
+//! Each spawned process is a self-contained A2A node: there is no central
+//! broker. Two `codetether spawn` instances pointing at each other form the
+//! minimal mesh; `n` instances form a fully-connected mesh as long as the
+//! seed graph is connected.
+//!
+//! # Lifecycle
+//!
+//! 1. Resolve identity (`--name`, bind addr, public URL).
+//! 2. Build the default [`AgentCard`](crate::a2a::types::AgentCard) and let
+//!    `--description` override the default text.
+//! 3. Initialize [`AgentBus`], start the best-effort training-record S3 sink,
+//!    register self in the registry, and announce-ready with the card's skill
+//!    ids as capabilities.
+//! 4. Spawn [`discovery_loop`] for `--peer` seeds.
+//! 5. Bind the [`A2AServer::router`] and serve until SIGINT.
+//! 6. On shutdown: abort discovery and exit cleanly.
+//!
+//! # Discovery
+//!
+//! Every `discovery_interval_secs` (clamped to ≥ 5):
+//! - For each seed, build candidates via [`peer_candidates`] (tries `seed`
+//!   and `seed/a2a` unless the seed already ends in `/a2a`).
+//! - First successful agent-card fetch wins; the card is registered in
+//!   `bus.registry`.
+//! - On *first* sighting of a given `endpoint::card.name` pair: emit
+//!   `Discovered A2A peer` and (if `auto_introduce`) call
+//!   [`send_intro`] over the A2A client.
+//! - Re-sightings re-register the card (refresh) but do not re-introduce.
+//!
+//! Outbound discovery and intro calls attach `CODETETHER_AUTH_TOKEN` as a
+//! bearer if set.
+//!
+//! # See also
+//!
+//! Full prose documentation lives at `docs/a2a-spawn.md` (CLI reference,
+//! HTTP/JSON-RPC API, curl recipes, cross-host setup, troubleshooting,
+//! source map).
 
 use crate::a2a::client::A2AClient;
 use crate::a2a::server::A2AServer;
@@ -13,77 +57,191 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 
-/// Run the spawn command.
-pub async fn run(args: SpawnArgs) -> Result<()> {
-    let bind_addr = format!("{}:{}", args.hostname, args.port);
-    let public_url = args
+/// Inputs for starting an A2A peer runtime.
+///
+/// Used both by `codetether spawn` (one-shot CLI) and by `codetether tui`
+/// when its `--a2a-port` flag is set (background peer alongside the TUI).
+#[derive(Debug, Clone)]
+pub struct SpawnOptions {
+    pub name: String,
+    pub hostname: String,
+    pub port: u16,
+    pub public_url: Option<String>,
+    pub description: Option<String>,
+    pub peer: Vec<String>,
+    pub discovery_interval_secs: u64,
+    pub auto_introduce: bool,
+}
+
+impl SpawnOptions {
+    /// Materialize options from the `codetether spawn` CLI args, applying the
+    /// same default-name policy (`spawned-agent-<pid>`).
+    pub fn from_spawn_args(args: &SpawnArgs) -> Self {
+        Self {
+            name: args
+                .name
+                .clone()
+                .unwrap_or_else(|| format!("spawned-agent-{}", std::process::id())),
+            hostname: args.hostname.clone(),
+            port: args.port,
+            public_url: args.public_url.clone(),
+            description: args.description.clone(),
+            peer: args.peer.clone(),
+            discovery_interval_secs: args.discovery_interval_secs,
+            auto_introduce: args.auto_introduce,
+        }
+    }
+}
+
+/// Handle to A2A peer background tasks (server + discovery loop).
+///
+/// Returned by [`start_a2a_in_background`]. Drop the handle when the host
+/// process is shutting down to abort both tasks; otherwise tokio will reap
+/// them when the runtime exits.
+pub struct A2APeerHandle {
+    pub agent_name: String,
+    pub bind_addr: String,
+    pub public_url: String,
+    server_task: tokio::task::JoinHandle<()>,
+    discovery_task: tokio::task::JoinHandle<()>,
+}
+
+impl A2APeerHandle {
+    /// Abort the background server and discovery tasks.
+    pub fn abort(self) {
+        self.server_task.abort();
+        self.discovery_task.abort();
+    }
+}
+
+struct A2APreparation {
+    listener: tokio::net::TcpListener,
+    router: Router,
+    discovery_task: tokio::task::JoinHandle<()>,
+    agent_name: String,
+    bind_addr: String,
+    public_url: String,
+}
+
+/// Shared setup: build card, register on bus, bind listener, spawn discovery.
+///
+/// The TCP bind is the only step that can fail synchronously, so the caller
+/// gets a clean error before any tokio task is spawned.
+async fn prepare_a2a(opts: SpawnOptions, bus: Arc<AgentBus>) -> Result<A2APreparation> {
+    let bind_addr = format!("{}:{}", opts.hostname, opts.port);
+    let public_url = opts
         .public_url
         .clone()
         .unwrap_or_else(|| format!("http://{bind_addr}"));
     let public_url = normalize_base_url(&public_url)?;
 
-    let agent_name = args
-        .name
-        .clone()
-        .unwrap_or_else(|| format!("spawned-agent-{}", std::process::id()));
-
+    let agent_name = opts.name.clone();
     let mut card = A2AServer::default_card(&public_url);
     card.name = agent_name.clone();
-    if let Some(description) = args.description.clone() {
+    if let Some(description) = opts.description.clone() {
         card.description = description;
     }
 
-    let bus = AgentBus::new().into_arc();
-
-    // Auto-start S3 sink if MinIO is configured
-    crate::bus::s3_sink::spawn_bus_s3_sink(bus.clone());
     bus.registry.register(card.clone());
-    let handle = bus.handle(&agent_name);
+    let bus_handle = bus.handle(&agent_name);
     let capabilities = card.skills.iter().map(|skill| skill.id.clone()).collect();
-    handle.announce_ready(capabilities);
+    bus_handle.announce_ready(capabilities);
 
-    let peers = collect_peers(&args.peer, &public_url);
+    let peers = collect_peers(&opts.peer, &public_url);
     if peers.is_empty() {
         tracing::info!(
             agent = %agent_name,
-            "Spawned without peer seeds; pass --peer or CODETETHER_A2A_PEERS for discovery"
+            "A2A peer started without peer seeds; pass --peer or CODETETHER_A2A_PEERS for discovery"
         );
     } else {
         tracing::info!(
             agent = %agent_name,
             peer_count = peers.len(),
-            "Spawned with peer discovery seeds"
+            "A2A peer started with peer discovery seeds"
         );
     }
 
     let discovery_task = tokio::spawn(discovery_loop(
         Arc::clone(&bus),
         peers,
-        normalize_base_url(&public_url)?,
+        public_url.clone(),
         agent_name.clone(),
-        args.discovery_interval_secs.max(5),
-        args.auto_introduce,
+        opts.discovery_interval_secs.max(5),
+        opts.auto_introduce,
     ));
 
     let router: Router = A2AServer::new(card).router();
     let listener = tokio::net::TcpListener::bind(&bind_addr)
         .await
-        .with_context(|| format!("Failed to bind spawn agent on {bind_addr}"))?;
+        .with_context(|| format!("Failed to bind A2A peer on {bind_addr}"))?;
+
+    Ok(A2APreparation {
+        listener,
+        router,
+        discovery_task,
+        agent_name,
+        bind_addr,
+        public_url,
+    })
+}
+
+/// Start an A2A peer runtime in the background, attached to the given bus.
+///
+/// Caller is responsible for keeping the returned [`A2APeerHandle`] alive
+/// for as long as the peer should keep serving. Drop or call `abort()` on
+/// shutdown. Used by the TUI when `--a2a-port` is set.
+pub async fn start_a2a_in_background(
+    opts: SpawnOptions,
+    bus: Arc<AgentBus>,
+) -> Result<A2APeerHandle> {
+    let prep = prepare_a2a(opts, bus).await?;
+    tracing::info!(
+        agent = %prep.agent_name,
+        bind_addr = %prep.bind_addr,
+        public_url = %prep.public_url,
+        "A2A peer listening (background mode)"
+    );
+    let agent_name = prep.agent_name.clone();
+    let bind_addr = prep.bind_addr.clone();
+    let public_url = prep.public_url.clone();
+    let server_task = tokio::spawn(async move {
+        if let Err(e) = axum::serve(prep.listener, prep.router).await {
+            tracing::error!(error = %e, "A2A peer server task exited with error");
+        }
+    });
+    Ok(A2APeerHandle {
+        agent_name,
+        bind_addr,
+        public_url,
+        server_task,
+        discovery_task: prep.discovery_task,
+    })
+}
+
+/// Run the `codetether spawn` command. Owns its own bus and S3 sink, blocks
+/// on ctrl_c with graceful shutdown.
+pub async fn run(args: SpawnArgs) -> Result<()> {
+    let bus = AgentBus::new().into_arc();
+
+    // Auto-start S3 sink if MinIO is configured
+    crate::bus::s3_sink::spawn_bus_s3_sink(bus.clone());
+
+    let prep = prepare_a2a(SpawnOptions::from_spawn_args(&args), bus).await?;
 
     tracing::info!(
-        agent = %agent_name,
-        bind_addr = %bind_addr,
-        public_url = %public_url,
+        agent = %prep.agent_name,
+        bind_addr = %prep.bind_addr,
+        public_url = %prep.public_url,
         "Spawned A2A agent runtime"
     );
 
-    axum::serve(listener, router)
+    axum::serve(prep.listener, prep.router)
         .with_graceful_shutdown(shutdown_signal())
         .await
         .context("Spawned A2A server failed")?;
 
-    discovery_task.abort();
-    tracing::info!(agent = %agent_name, "Spawned A2A agent shut down");
+    prep.discovery_task.abort();
+    tracing::info!(agent = %prep.agent_name, "Spawned A2A agent shut down");
     Ok(())
 }
 

--- a/src/a2a/spawn.rs
+++ b/src/a2a/spawn.rs
@@ -95,9 +95,11 @@ impl SpawnOptions {
 
 /// Handle to A2A peer background tasks (server + discovery loop).
 ///
-/// Returned by [`start_a2a_in_background`]. Drop the handle when the host
-/// process is shutting down to abort both tasks; otherwise tokio will reap
-/// them when the runtime exits.
+/// Returned by [`start_a2a_in_background`]. The handle MUST be kept alive
+/// (bound to a non-`_` variable, or stashed in app state) for the lifetime
+/// of the peer — dropping it aborts both background tasks via the `Drop`
+/// impl below. `JoinHandle::drop()` on its own only *detaches* tasks; the
+/// explicit `Drop` here is what actually stops them.
 pub struct A2APeerHandle {
     pub agent_name: String,
     pub bind_addr: String,
@@ -107,8 +109,15 @@ pub struct A2APeerHandle {
 }
 
 impl A2APeerHandle {
-    /// Abort the background server and discovery tasks.
+    /// Abort the background server and discovery tasks immediately.
     pub fn abort(self) {
+        self.server_task.abort();
+        self.discovery_task.abort();
+    }
+}
+
+impl Drop for A2APeerHandle {
+    fn drop(&mut self) {
         self.server_task.abort();
         self.discovery_task.abort();
     }
@@ -123,12 +132,21 @@ struct A2APreparation {
     public_url: String,
 }
 
-/// Shared setup: build card, register on bus, bind listener, spawn discovery.
-///
-/// The TCP bind is the only step that can fail synchronously, so the caller
-/// gets a clean error before any tokio task is spawned.
+/// Shared setup: bind listener first, then build card, register on bus, and
+/// spawn the discovery loop. Order matters: if the TCP bind fails we return
+/// an error before any tokio task is spawned and before the bus is told this
+/// agent exists, so the failure is clean — no leaked discovery task, no
+/// stale registry entry pointing at an address with no server behind it, no
+/// misleading peer-discovery traffic on the network.
 async fn prepare_a2a(opts: SpawnOptions, bus: Arc<AgentBus>) -> Result<A2APreparation> {
     let bind_addr = format!("{}:{}", opts.hostname, opts.port);
+
+    // 1. Bind first. This is the only step that can fail synchronously.
+    let listener = tokio::net::TcpListener::bind(&bind_addr)
+        .await
+        .with_context(|| format!("Failed to bind A2A peer on {bind_addr}"))?;
+
+    // 2. Now derive identity and publish on the bus.
     let public_url = opts
         .public_url
         .clone()
@@ -161,6 +179,7 @@ async fn prepare_a2a(opts: SpawnOptions, bus: Arc<AgentBus>) -> Result<A2APrepar
         );
     }
 
+    // 3. Only after a successful bind do we spawn the discovery loop.
     let discovery_task = tokio::spawn(discovery_loop(
         Arc::clone(&bus),
         peers,
@@ -171,9 +190,6 @@ async fn prepare_a2a(opts: SpawnOptions, bus: Arc<AgentBus>) -> Result<A2APrepar
     ));
 
     let router: Router = A2AServer::new(card).router();
-    let listener = tokio::net::TcpListener::bind(&bind_addr)
-        .await
-        .with_context(|| format!("Failed to bind A2A peer on {bind_addr}"))?;
 
     Ok(A2APreparation {
         listener,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -237,6 +237,43 @@ pub struct TuiArgs {
     /// Allow network access in sandboxed commands
     #[arg(long)]
     pub allow_network: bool,
+
+    /// Bind an A2A peer endpoint on this port alongside the TUI.
+    /// When set, the TUI process exposes /.well-known/agent.json and
+    /// JSON-RPC at http://<a2a-hostname>:<a2a-port>/ and runs peer
+    /// discovery against `--a2a-peer` seeds. Inbound `message/send`
+    /// requests are handled by a fresh background session — they do not
+    /// route into the TUI's interactive session. See docs/a2a-spawn.md.
+    #[arg(long)]
+    pub a2a_port: Option<u16>,
+
+    /// Hostname to bind the A2A peer endpoint. Use 0.0.0.0 for off-box.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub a2a_hostname: String,
+
+    /// Public URL published in the agent card (defaults to http://<hostname>:<port>).
+    #[arg(long)]
+    pub a2a_public_url: Option<String>,
+
+    /// Agent name for the A2A card. Defaults to "tui-agent-<pid>".
+    #[arg(long)]
+    pub a2a_name: Option<String>,
+
+    /// Optional description for the A2A card.
+    #[arg(long)]
+    pub a2a_description: Option<String>,
+
+    /// Peer seed URLs (repeat or comma-separate).
+    #[arg(long, value_delimiter = ',', env = "CODETETHER_A2A_PEERS")]
+    pub a2a_peer: Vec<String>,
+
+    /// Discovery interval in seconds (clamped to ≥ 5).
+    #[arg(long, default_value = "15")]
+    pub a2a_discovery_interval_secs: u64,
+
+    /// Disable auto-intro to newly discovered peers.
+    #[arg(long = "a2a-no-auto-introduce", action = clap::ArgAction::SetFalse, default_value_t = true)]
+    pub a2a_auto_introduce: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -550,8 +550,21 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Some(Command::Tui(args)) => {
             let allow_network = args.allow_network;
+            let a2a_options = args.a2a_port.map(|port| crate::a2a::spawn::SpawnOptions {
+                name: args
+                    .a2a_name
+                    .clone()
+                    .unwrap_or_else(|| format!("tui-agent-{}", std::process::id())),
+                hostname: args.a2a_hostname.clone(),
+                port,
+                public_url: args.a2a_public_url.clone(),
+                description: args.a2a_description.clone(),
+                peer: args.a2a_peer.clone(),
+                discovery_interval_secs: args.a2a_discovery_interval_secs,
+                auto_introduce: args.a2a_auto_introduce,
+            });
             let project = args.project.or(cli.project);
-            tui::run(project, allow_network).await
+            tui::run(project, allow_network, a2a_options).await
         }
         Some(Command::Serve(args)) => server::serve(args).await,
         Some(Command::Run(args)) => cli::run::execute(args).await,
@@ -1839,9 +1852,9 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         None => {
-            // Default: launch TUI
+            // Default: launch TUI without an A2A peer endpoint.
             let project = cli.project;
-            tui::run(project, false).await
+            tui::run(project, false, None).await
         }
     }
 }

--- a/src/tui/app/run.rs
+++ b/src/tui/app/run.rs
@@ -137,7 +137,14 @@ pub async fn run(
     // session over the A2A wire protocol. Inbound `message/send` requests
     // are answered by a fresh background session — they do not appear in
     // the user's interactive TUI conversation. See docs/a2a-spawn.md.
-    let _a2a_peer_handle = if let Some(opts) = a2a_options {
+    //
+    // LIFETIME: the binding below MUST live for the duration of the TUI
+    // event loop. `A2APeerHandle::Drop` aborts the background server and
+    // discovery tasks, so an early drop kills the peer. The leading `_`
+    // is the unused-name convention (the variable is read by Drop, not by
+    // any code), NOT the `_` discard pattern — those have different drop
+    // semantics. Do not change this to `let _ = ...`.
+    let _a2a_peer_lifetime_guard = if let Some(opts) = a2a_options {
         match crate::a2a::spawn::start_a2a_in_background(opts, bus.clone()).await {
             Ok(handle) => {
                 tracing::info!(

--- a/src/tui/app/run.rs
+++ b/src/tui/app/run.rs
@@ -61,7 +61,11 @@ async fn init_tui_secrets_manager() {
     }
 }
 
-pub async fn run(project: Option<std::path::PathBuf>, allow_network: bool) -> anyhow::Result<()> {
+pub async fn run(
+    project: Option<std::path::PathBuf>,
+    allow_network: bool,
+    a2a_options: Option<crate::a2a::spawn::SpawnOptions>,
+) -> anyhow::Result<()> {
     if allow_network {
         unsafe {
             std::env::set_var("CODETETHER_SANDBOX_BASH_ALLOW_NETWORK", "1");
@@ -127,6 +131,32 @@ pub async fn run(project: Option<std::path::PathBuf>, allow_network: bool) -> an
     let bus = AgentBus::new().into_arc();
     crate::bus::set_global(bus.clone());
     spawn_bus_s3_sink(bus.clone());
+
+    // Optional: start an A2A peer endpoint inside the TUI process so other
+    // agents (TUIs, `codetether spawn` peers, plain curl) can reach this
+    // session over the A2A wire protocol. Inbound `message/send` requests
+    // are answered by a fresh background session — they do not appear in
+    // the user's interactive TUI conversation. See docs/a2a-spawn.md.
+    let _a2a_peer_handle = if let Some(opts) = a2a_options {
+        match crate::a2a::spawn::start_a2a_in_background(opts, bus.clone()).await {
+            Ok(handle) => {
+                tracing::info!(
+                    agent = %handle.agent_name,
+                    bind_addr = %handle.bind_addr,
+                    public_url = %handle.public_url,
+                    "TUI A2A peer endpoint ready"
+                );
+                Some(handle)
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to start TUI A2A peer; continuing without it");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let mut session = Session::new().await?.with_bus(bus.clone());
     let mut app = App::default();
     app.state.cwd_display = cwd.display().to_string();


### PR DESCRIPTION
## Summary

- Adds `--a2a-port` (plus `--a2a-hostname` / `--a2a-public-url` / `--a2a-name` / `--a2a-description` / `--a2a-peer` / `--a2a-discovery-interval-secs` / `--a2a-no-auto-introduce`) to `codetether tui`. When `--a2a-port` is set, the TUI process binds the same A2A surface `codetether spawn` serves — agent card at `/.well-known/agent.json`, JSON-RPC on `POST /`, peer discovery loop with auto-intro — alongside the interactive session.
- Refactors `src/a2a/spawn.rs` so `codetether spawn` and `codetether tui --a2a-port` share one code path: extracted `SpawnOptions`, `A2APeerHandle`, and `prepare_a2a`. New `start_a2a_in_background` is what the TUI calls.
- Adds `docs/a2a-spawn.md` (~430 lines) — the canonical guide for both surfaces.

## Why

Today `codetether spawn` is headless and `codetether tui` has no A2A surface, so two TUIs in two repos can't message each other. This PR makes the TUI process *also* an A2A peer that other TUIs (or `spawn` peers, or plain curl) can reach, without giving up the TUI as the human-facing surface.

## Two-terminal usage

\`\`\`bash
# Terminal 1 — TUI in repo A, peer is repo B's TUI on :4098
cd /path/to/repo-A
codetether tui --a2a-port 4097 --a2a-name alice --a2a-peer http://127.0.0.1:4098

# Terminal 2 — TUI in repo B, peer is repo A's TUI on :4097
cd /path/to/repo-B
codetether tui --a2a-port 4098 --a2a-name bob --a2a-peer http://127.0.0.1:4097
\`\`\`

Within one discovery interval each side logs \`Discovered A2A peer\` and exchanges an auto-intro.

## Scope — what's NOT in this PR

Inbound \`message/send\` is answered by a fresh background \`Session\`, exactly the way \`codetether spawn\` answers it today. Inbound messages do **not** route into the user's TUI conversation. Routing inbound A2A into the TUI session (so the user sees and can intercept the dialogue live) is a separate, larger change and is explicitly out of scope here.

## Documentation

\`docs/a2a-spawn.md\` covers: TL;DR two-terminal walkthrough (both spawn and TUI variants), mode comparison, full flag reference for both surfaces, HTTP API with all four JSON-RPC methods and the full error-code table, peer discovery internals, bus registry + training S3 sink, authentication, model resolution, cross-host setup, curl recipes, programmatic \`A2AClient\` Rust example, troubleshooting matrix, source map. \`README.md\` links to it from the existing Spawn-mode bullet.

## Refactor details

\`src/a2a/spawn.rs\`:
- New \`pub struct SpawnOptions\` — input config shared by both surfaces.
- New \`pub struct A2APeerHandle\` — handle to background server + discovery tasks (\`abort()\` on shutdown).
- New \`pub async fn start_a2a_in_background(opts, bus)\` — what the TUI calls.
- New private \`async fn prepare_a2a(opts, bus)\` — shared setup (build card, register on bus, bind listener, spawn discovery loop).
- Existing \`pub async fn run(SpawnArgs)\` rewritten as a thin wrapper over \`prepare_a2a\` — preserves the original ctrl_c graceful-shutdown behaviour exactly.

\`src/tui/app/run.rs\`: signature gains \`a2a_options: Option<SpawnOptions>\`. When \`Some\`, calls \`start_a2a_in_background\` with the TUI's bus before entering the event loop. The \`A2APeerHandle\` lives until the TUI exits; tokio reaps the tasks on process exit.

\`src/cli/mod.rs\`: \`TuiArgs\` gains the eight \`--a2a-*\` flags, mirroring the \`codetether spawn\` flags 1-for-1 with the \`a2a-\` prefix.

\`src/main.rs\`: \`Some(Command::Tui)\` builds \`SpawnOptions\` from the new args only when \`--a2a-port\` is set. The bare \`codetether\` / no-args path passes \`None\`.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo build\` (debug) clean
- [x] \`cargo build --release\` clean
- [x] \`cargo test --lib a2a::spawn\` — 2/2 (\`collect_peers_deduplicates_and_skips_self\`, \`peer_candidates_adds_a2a_variant\`)
- [x] Headless spawn smoke test (Alice ↔ Bob, two repos, two ports, mutual peer seeding) — both sides log \`Discovered A2A peer\` and \`Auto-intro message sent\` within ~6 s. This exercises the same \`prepare_a2a\` code path the TUI now uses.
- [x] \`codetether tui --help\` shows all eight new flags with correct descriptions, defaults, and env-var bindings.
- [ ] Manual end-to-end with two real TUIs in two repos (requires a real PTY — leaving for human verification before merge).