### PR TITLE
feat(a2a): zero-config peer discovery via mDNS, default-on in TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
  "directories 6.0.0",
  "dotenvy",
  "futures",
- "gethostname 0.5.0",
+ "gethostname",
  "glob",
  "hex",
  "hmac",
@@ -1200,7 +1200,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2365,21 +2365,11 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
-dependencies = [
- "rustix 0.38.44",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "windows-link",
 ]
 
@@ -3435,12 +3425,6 @@ checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.1",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5203,19 +5187,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -5223,7 +5194,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -5914,7 +5885,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -7754,8 +7725,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
- "gethostname 1.1.0",
- "rustix 1.1.4",
+ "gethostname",
+ "rustix",
  "x11rb-protocol",
 ]
 
@@ -7772,7 +7743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,12 +886,14 @@ dependencies = [
  "directories 6.0.0",
  "dotenvy",
  "futures",
+ "gethostname 0.5.0",
  "glob",
  "hex",
  "hmac",
  "hound",
  "html-escape",
  "http",
+ "if-addrs",
  "ignore",
  "image",
  "insta",
@@ -902,6 +904,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "lsp-types",
+ "mdns-sd",
  "memchr",
  "memmap2",
  "minio",
@@ -1197,7 +1200,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1960,6 +1963,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,11 +2365,21 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link",
 ]
 
@@ -2704,7 +2728,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2847,6 +2871,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3404,6 +3438,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -3518,6 +3558,20 @@ name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "mdns-sd"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328f4e1041f7cfeb3affccb814ddbe2f004856a2ce769c8bf22080d74c5204c6"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket2 0.5.10",
+]
 
 [[package]]
 name = "memchr"
@@ -4585,7 +4639,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4623,7 +4677,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5149,6 +5203,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -5156,7 +5223,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -5626,12 +5693,31 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5828,7 +5914,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6076,7 +6162,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6309,7 +6395,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -7276,6 +7362,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -7659,8 +7754,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
- "gethostname",
- "rustix",
+ "gethostname 1.1.0",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -7677,7 +7772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ tree-sitter = "0.24"
 tree-sitter-rust = "0.23"
 streaming-iterator = "0.1.9"
 mdns-sd = "0.13"
-gethostname = "0.5"
+gethostname = "1"
 if-addrs = "0.13"
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,9 @@ tokenizers = "0.22.2"
 tree-sitter = "0.24"
 tree-sitter-rust = "0.23"
 streaming-iterator = "0.1.9"
+mdns-sd = "0.13"
+gethostname = "0.5"
+if-addrs = "0.13"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.181"

--- a/docs/a2a-spawn.md
+++ b/docs/a2a-spawn.md
@@ -2,44 +2,76 @@
 
 Spawn an autonomous A2A agent runtime that:
 
-- stands up its **own A2A JSON-RPC API** on a port,
+- stands up its **own A2A JSON-RPC API** on an OS-assigned port (or a
+  port you specify),
+- auto-picks an **agent name** of the form `<host>-<repo>-<short-pid>`,
 - publishes an **agent card** at `/.well-known/agent.json`,
-- **discovers peers** on a polling loop and registers them in the local bus,
-- optionally **auto-introduces** itself to newly discovered peers,
+- **discovers peers** automatically over **mDNS / DNS-SD** on
+  `_codetether-a2a._tcp.local.` — no seed list required,
+- also accepts explicit `--peer` URLs for cross-host setups where mDNS
+  isn't routable,
+- **auto-introduces** itself to newly discovered peers (default on),
 - runs an LLM session per inbound `message/send` to actually *answer*.
 
-This is the mode to use when you want **two (or more) terminals running two agents in different repos that can talk to each other directly**, with no central broker.
+This is the mode to use when you want **two (or more) terminals running
+two agents in different repos that can talk to each other directly**,
+with no central broker, no flags, no seed list.
 
 ---
 
-## TL;DR — two terminals, two repos
+## TL;DR — zero-config, two terminals, two repos
 
-**Terminal 1** (Alice, repo A):
+**Terminal 1**:
 ```bash
 cd /path/to/repo-A
-codetether spawn \
-  --name alice \
-  --port 4097 \
-  --peer http://127.0.0.1:4098
+codetether spawn --hostname 0.0.0.0
 ```
 
-**Terminal 2** (Bob, repo B):
+**Terminal 2**:
 ```bash
 cd /path/to/repo-B
+codetether spawn --hostname 0.0.0.0
+```
+
+That's it. Each agent picks its own port, derives a name from
+`<hostname>-<repo>-<pid>`, announces itself on mDNS, and discovers the
+other within a couple of seconds. Logs show:
+
+```
+INFO codetether_agent::a2a::mdns:  Announced A2A peer over mDNS  instance=ubuntu-dev-repo-a-dcd8  port=39941
+INFO codetether_agent::a2a::spawn: Spawned A2A agent runtime       agent=ubuntu-dev-repo-a-dcd8  bind_addr=0.0.0.0:39941  public_url=http://192.168.50.101:39941  mdns=true
+INFO codetether_agent::a2a::spawn: Discovered A2A peer             agent=ubuntu-dev-repo-a-dcd8  peer_name=ubuntu-dev-repo-b-ddd0  peer_url=http://192.168.50.101:37195  endpoint=http://192.168.50.101:37195  via="mdns"
+INFO codetether_agent::a2a::spawn: Auto-intro message sent         peer=http://192.168.50.101:37195
+```
+
+After that, either side (or any third-party tool) can drive the other
+over plain HTTP JSON-RPC.
+
+> **Why `--hostname 0.0.0.0`?** mDNS multicast doesn't traverse the
+> Linux loopback interface (it lacks the `MULTICAST` flag by default),
+> so binding to `127.0.0.1` doesn't broadcast. `0.0.0.0` binds all
+> interfaces — peers on the same host see the announcement over the
+> LAN interface (multicast is looped back), and same-LAN hosts also
+> see it. The published `public_url` automatically substitutes the
+> first non-loopback IPv4 address for `0.0.0.0`, so the card
+> advertises a routable URL.
+
+---
+
+## Explicit overrides
+
+You can still pin any field if zero-config defaults don't fit:
+
+```bash
 codetether spawn \
-  --name bob \
-  --port 4098 \
-  --peer http://127.0.0.1:4097
+  --name alice \
+  --hostname 0.0.0.0 \
+  --port 4097 \
+  --peer http://10.0.0.42:4097      # explicit cross-host seed
 ```
 
-Within one discovery interval (default 15 s, override with `--discovery-interval-secs`) each side logs:
-
-```
-INFO codetether_agent::a2a::spawn: Discovered A2A peer  agent=alice  peer_name=bob  peer_url=http://127.0.0.1:4098
-INFO codetether_agent::a2a::spawn: Auto-intro message sent  peer=http://127.0.0.1:4098
-```
-
-After that, either side (or any third-party tool) can drive the other over plain HTTP JSON-RPC.
+`--peer` seeds are **additive** to mDNS-discovered peers — useful for
+cross-LAN/WAN deployments where multicast isn't routable.
 
 ---
 
@@ -59,42 +91,52 @@ If you want decentralized agents that find each other and chat, `spawn` (headles
 
 ## TUI + A2A: two interactive terminals that can message each other
 
-If you want each side to be a TUI you drive yourself, but still reachable as an A2A peer:
+The TUI binds an A2A peer endpoint **by default** with the same
+zero-config behaviour as `codetether spawn` — auto-port, auto-name,
+mDNS announce + browse. Pass `--no-a2a` to opt out.
 
-**Terminal 1** (TUI in repo A, peer is repo B's TUI on :4098):
+**Terminal 1** (TUI in repo A — no flags needed):
 ```bash
 cd /path/to/repo-A
-codetether tui \
-  --a2a-port 4097 \
-  --a2a-name alice \
-  --a2a-peer http://127.0.0.1:4098
+codetether tui --a2a-hostname 0.0.0.0
 ```
 
-**Terminal 2** (TUI in repo B, peer is repo A's TUI on :4097):
+**Terminal 2** (TUI in repo B — no flags needed):
 ```bash
 cd /path/to/repo-B
-codetether tui \
-  --a2a-port 4098 \
-  --a2a-name bob \
-  --a2a-peer http://127.0.0.1:4097
+codetether tui --a2a-hostname 0.0.0.0
 ```
 
-Each TUI starts as normal and *also* exposes `/.well-known/agent.json` and the JSON-RPC endpoint on its `--a2a-port`. From inside one TUI, you can use the `http` tool (or any normal session tool) to POST a `message/send` to the other side's port. From a third terminal you can curl either side.
+That's the whole setup. Each TUI starts as normal and *also* exposes
+`/.well-known/agent.json` and the JSON-RPC endpoint on an OS-assigned
+port. mDNS handles peer discovery within ~3 s. From inside one TUI,
+you can use the `http` tool (or any normal session tool) to POST a
+`message/send` to the other side's URL (look in the startup log for
+`A2A peer listening` to find the chosen port).
 
-**Important — inbound A2A and the TUI session do not share state.** When the peer (or curl) sends `message/send`, the request is handled by a fresh `Session` spun up by the A2A handler — exactly the same way `codetether spawn` answers. The reply goes back over A2A. **The exchange does not appear in your TUI's chat view, and your TUI session does not see it.** If you want the inbound message to show up in the TUI conversation, that's the routed-into-TUI variant, which is a separate feature (not in this build).
+**Important — inbound A2A and the TUI session do not share state.**
+When the peer (or curl) sends `message/send`, the request is handled
+by a fresh `Session` spun up by the A2A handler — exactly the same
+way `codetether spawn` answers. The reply goes back over A2A. **The
+exchange does not appear in your TUI's chat view, and your TUI
+session does not see it.** If you want the inbound message to show up
+in the TUI conversation, that's the routed-into-TUI variant, which is
+a separate feature (not in this build).
 
 ### TUI A2A flag reference
 
 | Flag | Default | Notes |
 |---|---|---|
-| `--a2a-port <PORT>` | (off) | When set, the TUI process binds an A2A endpoint on this port. Without this flag the TUI is purely interactive (no A2A surface). |
-| `--a2a-hostname <HOST>` | `127.0.0.1` | Use `0.0.0.0` for off-box. Pair with `--a2a-public-url`. |
-| `--a2a-public-url <URL>` | `http://<hostname>:<port>` | URL published in the agent card. |
-| `--a2a-name <NAME>` | `tui-agent-<pid>` | Card name (what peers see). |
+| `--no-a2a` | (A2A on) | Disable the A2A peer entirely. The TUI becomes purely interactive. |
+| `--a2a-port <PORT>` | `0` (OS-assigned) | Pin a specific port if you need a stable URL for curl scripts. |
+| `--a2a-hostname <HOST>` | `127.0.0.1` | Use `0.0.0.0` for LAN reachability and to enable mDNS discovery (loopback doesn't multicast on Linux). |
+| `--a2a-public-url <URL>` | derived from bind addr (substituting first LAN IPv4 for `0.0.0.0`) | URL published in the agent card. |
+| `--a2a-name <NAME>` | auto: `<host>-<repo>-<short-pid>` | Card name (what peers see). |
 | `--a2a-description <TEXT>` | (default) | Card description. |
-| `--a2a-peer <URL>` (repeatable, comma-separable) | `[]` | Peer seed URLs. Also reads `CODETETHER_A2A_PEERS`. |
-| `--a2a-discovery-interval-secs <N>` | `15` | Clamped to ≥ 5. |
+| `--a2a-peer <URL>` (repeatable, comma-separable) | `[]` | Explicit peer seed URLs (in addition to mDNS). Useful for cross-host setups. Also reads `CODETETHER_A2A_PEERS`. |
+| `--a2a-discovery-interval-secs <N>` | `15` | Clamped to ≥ 5. mDNS is event-driven, not polled. |
 | `--a2a-no-auto-introduce` | (intro on) | Disable the auto-intro `message/send` to newly discovered peers. |
+| `--a2a-no-mdns` | (mDNS on) | Disable mDNS announce + browse. Only explicit `--a2a-peer` seeds will be discovered. |
 
 These flags mirror the `codetether spawn` flags one-for-one (with an `a2a-` prefix to keep them out of the TUI's own option namespace).
 
@@ -108,17 +150,49 @@ codetether spawn [OPTIONS] [-- <PROJECT>]
 
 | Flag | Default | Env | Purpose |
 |---|---|---|---|
-| `-n`, `--name <NAME>` | `spawned-agent-<pid>` | — | Agent name (becomes `card.name` and bus registration id). |
-| `--hostname <HOST>` | `127.0.0.1` | — | Bind address. Set to `0.0.0.0` to accept off-box traffic. |
-| `-p`, `--port <PORT>` | `4097` | — | Bind port. Pick a unique port per agent. |
-| `--public-url <URL>` | `http://<hostname>:<port>` | — | URL published in the agent card. Set explicitly when binding `0.0.0.0` so peers know where to call back. |
+| `-n`, `--name <NAME>` | auto: `<host>-<repo>-<short-pid>` | — | Agent name (becomes `card.name` and bus registration id). |
+| `--hostname <HOST>` | `127.0.0.1` | — | Bind address. Use `0.0.0.0` for LAN reachability and to enable mDNS discovery (loopback doesn't multicast on Linux). |
+| `-p`, `--port <PORT>` | `0` (OS-assigned) | — | Bind port. `0` lets the OS pick an available port; specify a port if you need a stable URL for curl scripts. |
+| `--public-url <URL>` | derived from effective bind addr (substituting first LAN IPv4 for `0.0.0.0`) | — | URL published in the agent card. |
 | `-d`, `--description <TEXT>` | (default text) | — | Custom card description. |
-| `--peer <URL>` (repeatable, comma-separable) | `[]` | `CODETETHER_A2A_PEERS` | Peer seed URLs to probe for agent cards. |
-| `--discovery-interval-secs <N>` | `15` | — | How often to re-probe seeds. Minimum effective value is 5 s (clamped). |
-| `--no-auto-introduce` | (intro on by default) | — | Suppress the auto-intro `message/send` sent to newly discovered peers. |
+| `--peer <URL>` (repeatable, comma-separable) | `[]` | `CODETETHER_A2A_PEERS` | Explicit peer seed URLs (in addition to mDNS-discovered peers). Useful for cross-host setups where mDNS isn't routable. |
+| `--discovery-interval-secs <N>` | `15` | — | Polling interval for explicit `--peer` seeds (clamped to ≥ 5). mDNS discovery is event-driven, not polled. |
+| `--no-auto-introduce` | (intro on) | — | Suppress the auto-intro `message/send` sent to newly discovered peers. |
+| `--no-mdns` | (mDNS on) | — | Disable mDNS announce + browse. Without mDNS, only explicit `--peer` seeds are discovered. |
 | `[PROJECT]` | cwd | — | Project directory the spawned agent will operate in. |
 | `--print-logs` | off | — | Mirror tracing output to stderr (otherwise honors logfile config). |
 | `--log-level DEBUG\|INFO\|WARN\|ERROR` | `INFO` | — | Tracing level. |
+
+### Auto-name derivation
+
+When `--name` is not supplied, the agent name is derived as:
+
+```
+<short-hostname>-<cwd-basename>-<short-pid>
+```
+
+- `short-hostname` — the leftmost label of `gethostname()` (e.g.
+  `ubuntu-dev` rather than `ubuntu-dev.lan`).
+- `cwd-basename` — the basename of the current working directory.
+- `short-pid` — last 16 bits of the process ID, hex-formatted.
+
+The full name is lowercased and any non-`[a-z0-9-]` chars become `-`,
+so the result is always a valid mDNS instance name and DNS hostname.
+
+### mDNS service shape
+
+When `--mdns` is on (default), the agent announces:
+
+- **Service type**: `_codetether-a2a._tcp.local.`
+- **Instance name**: `<agent-name>` (the auto-derived or user-specified name)
+- **Port**: the effective bound port (after `--port 0` resolution)
+- **TXT records**: `name=<agent-name>`, `path=/`, `protocol=a2a-jsonrpc`, `version=<crate-version>`
+
+Other CodeTether peers on the LAN browse for the same service type and
+discover this agent within seconds. See
+[a2a-public-agents.md](a2a-public-agents.md) for how mDNS-based
+discovery composes with the Agent Provenance Framework for safe public
+deployments.
 
 ---
 
@@ -445,8 +519,9 @@ Enable verbose logs with `--log-level DEBUG --print-logs`. Peer probe failures a
 | File | Role |
 |---|---|
 | `src/cli/mod.rs` (`SpawnArgs`, `Command::Spawn`) | CLI surface |
-| `src/a2a/spawn.rs` | Entry point, lifecycle, discovery loop, intro sender, **`SpawnOptions` + `start_a2a_in_background`** (used by the TUI) |
-| `src/tui/app/run.rs` | TUI entry point. When `--a2a-port` is set, calls `start_a2a_in_background` with the TUI's bus before entering the event loop. |
+| `src/a2a/spawn.rs` | Entry point, lifecycle, explicit-seed discovery loop, intro sender, **`SpawnOptions` + `start_a2a_in_background`** (used by the TUI), **`SpawnOptions::auto()`**, **auto-name derivation**, **`first_lan_ipv4`** for `0.0.0.0` URL substitution, **mDNS intake loop with name-based dedup** |
+| `src/a2a/mdns.rs` | mDNS / DNS-SD announce + browse. Service type `_codetether-a2a._tcp.local.`. Forwards resolved peers to the spawn intake loop via an mpsc channel. |
+| `src/tui/app/run.rs` | TUI entry point. Calls `start_a2a_in_background` with the TUI's bus before entering the event loop unless `--no-a2a` was passed. |
 | `src/a2a/server.rs` | Axum router, JSON-RPC dispatch, message/task handlers, `default_card` |
 | `src/a2a/client.rs` | Outbound `A2AClient` used by discovery + intro |
 | `src/a2a/types.rs` | All wire types (`AgentCard`, `Message`, `Task`, `MessageSendParams`, JSON-RPC envelopes, error codes) |

--- a/src/a2a/mdns.rs
+++ b/src/a2a/mdns.rs
@@ -1,0 +1,226 @@
+//! mDNS / DNS-SD discovery for true peer-to-peer A2A.
+//!
+//! Each A2A peer announces itself as a `_codetether-a2a._tcp.local.` service
+//! and browses for the same service type. Peers find each other on the LAN
+//! (and on loopback for single-machine multi-agent setups) without any
+//! central registry, broker, or seed file.
+//!
+//! # Service shape
+//!
+//! - Service type: `_codetether-a2a._tcp.local.`
+//! - Instance name: the agent's card name (must be unique on the LAN; the
+//!   default name template `<host>-<repo>-<short-pid>` ensures this).
+//! - Port: the agent's bound A2A port.
+//! - TXT records:
+//!   - `name=<card-name>`
+//!   - `path=/` (JSON-RPC root)
+//!   - `protocol=a2a-jsonrpc`
+//!   - `version=<crate version>`
+//!
+//! # Why mDNS
+//!
+//! - **No central state.** No file, no broker, no seed list — true P2P.
+//! - **Zero-config.** Two `codetether tui` processes on one box, or two
+//!   on the same LAN, find each other on launch.
+//! - **Standard.** Same protocol as Bonjour/Avahi/Chromecast/AirPlay.
+//!
+//! # Loopback
+//!
+//! `mdns-sd` enables the loopback interface by default in addition to all
+//! detected non-loopback interfaces, so two agents bound to `127.0.0.1`
+//! on the same host will discover each other.
+
+use anyhow::{Context, Result};
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+/// mDNS service type used by all CodeTether A2A peers.
+pub const SERVICE_TYPE: &str = "_codetether-a2a._tcp.local.";
+
+/// Handle to a registered mDNS service. Drop or call [`Self::shutdown`] to
+/// unregister and stop the daemon.
+pub struct MdnsHandle {
+    daemon: Arc<ServiceDaemon>,
+    fullname: String,
+}
+
+impl MdnsHandle {
+    /// Best-effort unregister and shut the daemon down.
+    pub fn shutdown(self) {
+        // Calling unregister is best-effort; the daemon may already be
+        // gone if shutdown_signal arrived twice.
+        let _ = self.daemon.unregister(&self.fullname);
+        let _ = self.daemon.shutdown();
+    }
+}
+
+impl Drop for MdnsHandle {
+    fn drop(&mut self) {
+        let _ = self.daemon.unregister(&self.fullname);
+        let _ = self.daemon.shutdown();
+    }
+}
+
+/// A peer discovered over mDNS — just a URL, the existing A2A discovery
+/// flow takes it from there (fetches the agent card, registers, intros).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DiscoveredPeer {
+    /// `http://<addr>:<port>` — base URL the agent card lives under.
+    pub url: String,
+    /// Service instance name reported by mDNS (== card name).
+    pub instance_name: String,
+}
+
+/// Announce ourselves on mDNS and start a browse loop that emits every
+/// resolved peer (other than ourselves) onto `peer_tx`.
+///
+/// Returns once the service is registered and the browse loop is running
+/// in a background tokio task. The returned [`MdnsHandle`] keeps the
+/// daemon alive — drop it on shutdown.
+pub fn announce_and_browse(
+    instance_name: &str,
+    bind_port: u16,
+    bound_addrs: Vec<IpAddr>,
+    peer_tx: mpsc::Sender<DiscoveredPeer>,
+) -> Result<MdnsHandle> {
+    let daemon = ServiceDaemon::new().context("Failed to start mDNS daemon")?;
+    let daemon = Arc::new(daemon);
+
+    // Properties surfaced in TXT records so peers can sanity-check us.
+    let mut props: HashMap<String, String> = HashMap::new();
+    props.insert("name".to_string(), instance_name.to_string());
+    props.insert("path".to_string(), "/".to_string());
+    props.insert("protocol".to_string(), "a2a-jsonrpc".to_string());
+    props.insert("version".to_string(), env!("CARGO_PKG_VERSION").to_string());
+
+    // mdns-sd's hostname must end with `.local.` and be unique per service
+    // instance on the LAN. We derive it from the instance name.
+    let mdns_hostname = format!("{}.local.", sanitize_hostname(instance_name));
+
+    let addrs: Vec<IpAddr> = if bound_addrs.is_empty() {
+        // No specific bind addrs given — let mdns-sd pick from interfaces.
+        // We must still pass at least one address; use loopback so the
+        // service registers, and rely on mdns-sd's interface enumeration
+        // for the actual broadcast.
+        vec!["127.0.0.1".parse().unwrap()]
+    } else {
+        bound_addrs.clone()
+    };
+
+    let service = ServiceInfo::new(
+        SERVICE_TYPE,
+        instance_name,
+        &mdns_hostname,
+        addrs.as_slice(),
+        bind_port,
+        Some(props),
+    )
+    .context("Failed to construct mDNS ServiceInfo")?
+    .enable_addr_auto();
+
+    let fullname = service.get_fullname().to_string();
+    daemon
+        .register(service)
+        .context("Failed to register mDNS service")?;
+
+    tracing::info!(
+        instance = %instance_name,
+        port = bind_port,
+        service_type = SERVICE_TYPE,
+        "Announced A2A peer over mDNS"
+    );
+
+    // Browse for the same service type. The daemon returns a flume receiver
+    // (sync) — we spawn a blocking task that forwards events into our async
+    // channel.
+    let receiver = daemon
+        .browse(SERVICE_TYPE)
+        .context("Failed to start mDNS browse")?;
+    let self_fullname = fullname.clone();
+    let self_port = bind_port;
+    tokio::task::spawn_blocking(move || {
+        while let Ok(event) = receiver.recv() {
+            match event {
+                ServiceEvent::SearchStarted(svc) => {
+                    tracing::debug!(service = %svc, "mDNS browse search started");
+                }
+                ServiceEvent::ServiceFound(svc, fullname) => {
+                    tracing::debug!(service = %svc, fullname = %fullname, "mDNS service found");
+                }
+                ServiceEvent::ServiceResolved(info) => {
+                    let info_fullname = info.get_fullname().to_string();
+                    tracing::debug!(
+                        fullname = %info_fullname,
+                        port = info.get_port(),
+                        addrs = ?info.get_addresses(),
+                        "mDNS service resolved"
+                    );
+                    if info_fullname == self_fullname {
+                        continue;
+                    }
+                    let port = info.get_port();
+                    let Some(addr) = info.get_addresses().iter().find(|a| a.is_ipv4()).copied()
+                    else {
+                        continue;
+                    };
+                    if port == self_port && addr.is_loopback() {
+                        continue;
+                    }
+                    let url = format!("http://{addr}:{port}");
+                    let instance = info_fullname
+                        .strip_suffix(SERVICE_TYPE)
+                        .unwrap_or(&info_fullname)
+                        .trim_end_matches('.')
+                        .to_string();
+                    let peer = DiscoveredPeer {
+                        url,
+                        instance_name: instance,
+                    };
+                    if peer_tx.blocking_send(peer).is_err() {
+                        break;
+                    }
+                }
+                ServiceEvent::ServiceRemoved(svc, fullname) => {
+                    tracing::debug!(service = %svc, fullname = %fullname, "mDNS service removed");
+                }
+                ServiceEvent::SearchStopped(svc) => {
+                    tracing::debug!(service = %svc, "mDNS browse search stopped");
+                }
+            }
+        }
+    });
+
+    Ok(MdnsHandle { daemon, fullname })
+}
+
+/// Replace characters that aren't valid in DNS hostnames with `-`.
+fn sanitize_hostname(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_hostname;
+
+    #[test]
+    fn sanitize_hostname_preserves_alnum_and_dash() {
+        assert_eq!(sanitize_hostname("alice-7"), "alice-7");
+    }
+
+    #[test]
+    fn sanitize_hostname_replaces_dots_and_underscores() {
+        assert_eq!(sanitize_hostname("my.host_name"), "my-host-name");
+    }
+}

--- a/src/a2a/mdns.rs
+++ b/src/a2a/mdns.rs
@@ -20,15 +20,27 @@
 //! # Why mDNS
 //!
 //! - **No central state.** No file, no broker, no seed list — true P2P.
-//! - **Zero-config.** Two `codetether tui` processes on one box, or two
-//!   on the same LAN, find each other on launch.
+//! - **Zero-config.** Peers on the same LAN find each other on launch
+//!   without any flags. Same-host setups also work *as long as the agents
+//!   bind a real network interface* (e.g. `--hostname 0.0.0.0`); see the
+//!   loopback note below.
 //! - **Standard.** Same protocol as Bonjour/Avahi/Chromecast/AirPlay.
 //!
-//! # Loopback
+//! # Loopback caveat
 //!
-//! `mdns-sd` enables the loopback interface by default in addition to all
-//! detected non-loopback interfaces, so two agents bound to `127.0.0.1`
-//! on the same host will discover each other.
+//! `mdns-sd` is willing to use the loopback interface, but on Linux the
+//! `lo` interface lacks the `MULTICAST` flag by default — multicast
+//! traffic does not traverse it, so two agents both bound to `127.0.0.1`
+//! will NOT find each other via mDNS even though they're on the same
+//! host. The reliable single-host pattern is to bind `0.0.0.0`: each
+//! agent advertises on the real LAN interface, and multicast loopback
+//! through that interface (controlled by `IP_MULTICAST_LOOP`, default on)
+//! delivers the announcement to other same-host listeners.
+//!
+//! Code in `spawn.rs` mirrors this by passing only the bound IPs that are
+//! actually reachable: loopback addrs alone when `--hostname 127.0.0.1`,
+//! and an empty list (which `enable_addr_auto` then expands to all
+//! detected interfaces) when `--hostname 0.0.0.0` is requested.
 
 use anyhow::{Context, Result};
 use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
@@ -64,12 +76,16 @@ impl Drop for MdnsHandle {
     }
 }
 
-/// A peer discovered over mDNS — just a URL, the existing A2A discovery
-/// flow takes it from there (fetches the agent card, registers, intros).
+/// A peer discovered over mDNS — every reachable URL the resolver saw,
+/// so the existing A2A discovery flow can try them in order.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DiscoveredPeer {
-    /// `http://<addr>:<port>` — base URL the agent card lives under.
-    pub url: String,
+    /// All `http://<addr>:<port>` URLs reported for this peer's service
+    /// record. In multi-homed environments mDNS may resolve several IPs
+    /// (LAN, VPN, docker bridge, etc.); the intake loop tries them in
+    /// order until one responds with a valid agent card. The first entry
+    /// is whichever address mdns-sd reported first (network-dependent).
+    pub urls: Vec<String>,
     /// Service instance name reported by mDNS (== card name).
     pub instance_name: String,
 }
@@ -100,17 +116,24 @@ pub fn announce_and_browse(
     // instance on the LAN. We derive it from the instance name.
     let mdns_hostname = format!("{}.local.", sanitize_hostname(instance_name));
 
-    let addrs: Vec<IpAddr> = if bound_addrs.is_empty() {
-        // No specific bind addrs given — let mdns-sd pick from interfaces.
-        // We must still pass at least one address; use loopback so the
-        // service registers, and rely on mdns-sd's interface enumeration
-        // for the actual broadcast.
+    // If the caller passed concrete bound addrs (e.g. for `--hostname
+    // 127.0.0.1` they pass loopback only) we use exactly those — that
+    // matches what the HTTP server will actually accept.
+    //
+    // If the caller passed an empty list (i.e. they bound `0.0.0.0` and
+    // genuinely want all interfaces advertised), we ask mdns-sd to
+    // auto-detect interface addrs via `enable_addr_auto`. We must still
+    // pass at least one address to ServiceInfo::new for it to construct,
+    // so use loopback as a placeholder — the auto-detect will replace
+    // it with real interface IPs.
+    let auto_detect = bound_addrs.is_empty();
+    let addrs: Vec<IpAddr> = if auto_detect {
         vec!["127.0.0.1".parse().unwrap()]
     } else {
         bound_addrs.clone()
     };
 
-    let service = ServiceInfo::new(
+    let mut service = ServiceInfo::new(
         SERVICE_TYPE,
         instance_name,
         &mdns_hostname,
@@ -118,8 +141,10 @@ pub fn announce_and_browse(
         bind_port,
         Some(props),
     )
-    .context("Failed to construct mDNS ServiceInfo")?
-    .enable_addr_auto();
+    .context("Failed to construct mDNS ServiceInfo")?;
+    if auto_detect {
+        service = service.enable_addr_auto();
+    }
 
     let fullname = service.get_fullname().to_string();
     daemon
@@ -162,21 +187,28 @@ pub fn announce_and_browse(
                         continue;
                     }
                     let port = info.get_port();
-                    let Some(addr) = info.get_addresses().iter().find(|a| a.is_ipv4()).copied()
-                    else {
-                        continue;
-                    };
-                    if port == self_port && addr.is_loopback() {
+                    // Collect every reachable IPv4 the resolver knows about.
+                    // The intake loop will try them in order — useful when
+                    // the same agent is reachable on a LAN IP, a VPN IP,
+                    // and a docker bridge IP, where the "right" one varies
+                    // by caller's network position.
+                    let urls: Vec<String> = info
+                        .get_addresses()
+                        .iter()
+                        .filter(|a| a.is_ipv4())
+                        .filter(|a| !(port == self_port && a.is_loopback()))
+                        .map(|a| format!("http://{a}:{port}"))
+                        .collect();
+                    if urls.is_empty() {
                         continue;
                     }
-                    let url = format!("http://{addr}:{port}");
                     let instance = info_fullname
                         .strip_suffix(SERVICE_TYPE)
                         .unwrap_or(&info_fullname)
                         .trim_end_matches('.')
                         .to_string();
                     let peer = DiscoveredPeer {
-                        url,
+                        urls,
                         instance_name: instance,
                     };
                     if peer_tx.blocking_send(peer).is_err() {
@@ -196,18 +228,33 @@ pub fn announce_and_browse(
     Ok(MdnsHandle { daemon, fullname })
 }
 
-/// Replace characters that aren't valid in DNS hostnames with `-`.
+/// Produce a valid DNS label: ascii alnum + `-` only, lowercase, no
+/// leading/trailing hyphen, ≤ 63 chars (RFC 1035 §2.3.1). An empty
+/// result falls back to "agent" so the caller never gets an invalid
+/// hostname (which would silently break `ServiceInfo::new`).
 fn sanitize_hostname(input: &str) -> String {
-    input
+    const MAX_LABEL: usize = 63;
+    let mut s: String = input
         .chars()
         .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else if c == '-' {
                 c
             } else {
                 '-'
             }
         })
-        .collect()
+        .collect();
+    if s.len() > MAX_LABEL {
+        s.truncate(MAX_LABEL);
+    }
+    let trimmed = s.trim_matches('-');
+    if trimmed.is_empty() {
+        "agent".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 #[cfg(test)]
@@ -222,5 +269,31 @@ mod tests {
     #[test]
     fn sanitize_hostname_replaces_dots_and_underscores() {
         assert_eq!(sanitize_hostname("my.host_name"), "my-host-name");
+    }
+
+    #[test]
+    fn sanitize_hostname_lowercases() {
+        assert_eq!(sanitize_hostname("Alice-Host"), "alice-host");
+    }
+
+    #[test]
+    fn sanitize_hostname_trims_leading_and_trailing_dashes() {
+        assert_eq!(sanitize_hostname(".alice."), "alice");
+        assert_eq!(sanitize_hostname("---bob---"), "bob");
+    }
+
+    #[test]
+    fn sanitize_hostname_truncates_to_63_chars() {
+        let long = "a".repeat(100);
+        let out = sanitize_hostname(&long);
+        assert_eq!(out.len(), 63);
+        assert!(out.chars().all(|c| c == 'a'));
+    }
+
+    #[test]
+    fn sanitize_hostname_falls_back_when_all_dashes() {
+        assert_eq!(sanitize_hostname("..."), "agent");
+        assert_eq!(sanitize_hostname(""), "agent");
+        assert_eq!(sanitize_hostname("---"), "agent");
     }
 }

--- a/src/a2a/mod.rs
+++ b/src/a2a/mod.rs
@@ -13,6 +13,7 @@ pub mod client;
 #[path = "git_credentials/mod.rs"]
 pub mod git_credentials;
 pub mod grpc;
+pub mod mdns;
 pub mod server;
 pub mod spawn;
 pub mod types;

--- a/src/a2a/spawn.rs
+++ b/src/a2a/spawn.rs
@@ -307,9 +307,24 @@ async fn prepare_a2a(opts: SpawnOptions, bus: Arc<AgentBus>) -> Result<A2APrepar
     ));
 
     // 6. mDNS announce + browse (true P2P, default on).
+    //
+    // Pass concrete bound addrs to mdns-sd that match what the HTTP server
+    // will actually accept — anything else risks advertising a URL no
+    // peer can reach. For a wildcard bind (`0.0.0.0`) we leave the addr
+    // list empty so mdns-sd's `enable_addr_auto` enumerates the real
+    // interface IPs; for a loopback bind we pass loopback so we don't
+    // advertise LAN addrs the server isn't bound to.
+    let mdns_bind_addrs: Vec<std::net::IpAddr> = match opts.hostname.as_str() {
+        "0.0.0.0" | "::" | "[::]" => vec![],
+        other => other
+            .parse::<std::net::IpAddr>()
+            .ok()
+            .into_iter()
+            .collect(),
+    };
     let (mdns_handle, mdns_intake_task) = if opts.mdns {
         let (peer_tx, peer_rx) = mpsc::channel::<DiscoveredPeer>(64);
-        match mdns::announce_and_browse(&agent_name, effective_port, vec![], peer_tx) {
+        match mdns::announce_and_browse(&agent_name, effective_port, mdns_bind_addrs, peer_tx) {
             Ok(handle) => {
                 let intake = tokio::spawn(mdns_intake_loop(
                     Arc::clone(&bus),
@@ -347,13 +362,23 @@ async fn prepare_a2a(opts: SpawnOptions, bus: Arc<AgentBus>) -> Result<A2APrepar
     })
 }
 
+/// Per-peer card-fetch deadline. mDNS may resolve a peer via several IPs
+/// (LAN, VPN, docker bridge, link-local v6); we want to fail fast on the
+/// unreachable ones rather than blocking the queue.
+const MDNS_PEER_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Drain peers discovered over mDNS, fetch their cards, register them, and
 /// optionally send the same auto-intro the explicit-seed loop sends.
 ///
-/// Dedup is keyed by **agent name** (not by endpoint URL), so an agent that
-/// is reachable via multiple network interfaces — common when binding
-/// `0.0.0.0` on a host with several bridges — only triggers one discovery
-/// log line and one auto-intro across the lifetime of the process.
+/// Each discovered peer is processed on its own tokio task so a slow or
+/// unreachable peer cannot block the rest of the queue. Dedup is keyed
+/// by **agent name** (not by endpoint URL), so an agent reachable via
+/// multiple network interfaces — common when binding `0.0.0.0` on a
+/// multi-homed host — only triggers one discovery log line and one
+/// auto-intro across the lifetime of the process. The known-set is
+/// also pre-checked by mDNS instance name before any fetch is issued,
+/// which short-circuits the duplicate announcements that mdns-sd
+/// emits per interface.
 async fn mdns_intake_loop(
     bus: Arc<AgentBus>,
     mut peer_rx: mpsc::Receiver<DiscoveredPeer>,
@@ -361,17 +386,12 @@ async fn mdns_intake_loop(
     agent_name: String,
     auto_introduce: bool,
 ) {
-    let self_url = self_url.trim_end_matches('/').to_string();
+    let self_url = Arc::new(self_url.trim_end_matches('/').to_string());
     let known: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
 
     while let Some(peer) = peer_rx.recv().await {
-        if peer.url.trim_end_matches('/') == self_url {
-            continue;
-        }
-
-        // Skip on instance-name match before even probing — saves N-1
-        // wasteful card fetches when the same peer announces over many
-        // interfaces.
+        // Cheap pre-check by instance name to skip the per-interface
+        // duplicate announcements before we spawn anything.
         let already_known_by_instance = {
             let k = known.lock().await;
             k.contains(&peer.instance_name)
@@ -380,17 +400,45 @@ async fn mdns_intake_loop(
             continue;
         }
 
-        // Probe both base URL and `/a2a` variant the same way the explicit-
-        // seed loop does.
-        let candidates = peer_candidates(&peer.url);
-        let mut resolved = None;
-        for candidate in candidates {
-            match try_fetch_agent_card(&candidate).await {
-                Ok(card) => {
+        // Spawn one task per discovered peer so a slow/unreachable peer
+        // can't block the next event in the queue.
+        let bus = Arc::clone(&bus);
+        let known = Arc::clone(&known);
+        let self_url = Arc::clone(&self_url);
+        let agent_name = agent_name.clone();
+        tokio::spawn(async move {
+            handle_mdns_peer(bus, known, self_url, agent_name, peer, auto_introduce).await;
+        });
+    }
+}
+
+/// Try each URL the resolver gave us until one yields a valid agent card,
+/// then register and (optionally) intro. Each fetch attempt is bounded by
+/// `MDNS_PEER_PROBE_TIMEOUT`. Multi-homed peers commonly resolve to
+/// several addrs (LAN/VPN/docker); we cycle through them in order.
+async fn handle_mdns_peer(
+    bus: Arc<AgentBus>,
+    known: Arc<Mutex<HashSet<String>>>,
+    self_url: Arc<String>,
+    agent_name: String,
+    peer: DiscoveredPeer,
+    auto_introduce: bool,
+) {
+    let mut resolved: Option<(String, crate::a2a::types::AgentCard)> = None;
+
+    'urls: for url in &peer.urls {
+        if url.trim_end_matches('/') == self_url.as_str() {
+            continue;
+        }
+        for candidate in peer_candidates(url) {
+            match tokio::time::timeout(MDNS_PEER_PROBE_TIMEOUT, try_fetch_agent_card(&candidate))
+                .await
+            {
+                Ok(Ok(card)) => {
                     resolved = Some((candidate, card));
-                    break;
+                    break 'urls;
                 }
-                Err(error) => {
+                Ok(Err(error)) => {
                     tracing::debug!(
                         agent = %agent_name,
                         peer = %candidate,
@@ -398,42 +446,50 @@ async fn mdns_intake_loop(
                         "mDNS peer probe failed"
                     );
                 }
+                Err(_) => {
+                    tracing::debug!(
+                        agent = %agent_name,
+                        peer = %candidate,
+                        timeout_secs = MDNS_PEER_PROBE_TIMEOUT.as_secs(),
+                        "mDNS peer probe timed out"
+                    );
+                }
             }
         }
+    }
 
-        let Some((endpoint, card)) = resolved else {
-            continue;
-        };
+    let Some((endpoint, card)) = resolved else {
+        return;
+    };
 
-        let is_new = {
-            let mut k = known.lock().await;
-            // Insert both keys so future probes via either path short-circuit.
-            let inserted = k.insert(card.name.clone());
-            k.insert(peer.instance_name.clone());
-            inserted
-        };
+    let is_new = {
+        let mut k = known.lock().await;
+        // Insert both keys so future probes via either path short-circuit.
+        let inserted = k.insert(card.name.clone());
+        k.insert(peer.instance_name.clone());
+        inserted
+    };
 
-        bus.registry.register(card.clone());
+    bus.registry.register(card.clone());
 
-        if is_new {
-            tracing::info!(
+    if is_new {
+        tracing::info!(
+            agent = %agent_name,
+            peer_name = %card.name,
+            peer_url = %card.url,
+            endpoint = %endpoint,
+            via = "mdns",
+            "Discovered A2A peer"
+        );
+        if auto_introduce
+            && let Err(error) = send_intro(&endpoint, &agent_name, self_url.as_str()).await
+        {
+            tracing::warn!(
                 agent = %agent_name,
-                peer_name = %card.name,
-                peer_url = %card.url,
-                endpoint = %endpoint,
-                via = "mdns",
-                "Discovered A2A peer"
+                peer = %endpoint,
+                error = %error,
+                "Auto-intro message failed"
             );
-            if auto_introduce
-                && let Err(error) = send_intro(&endpoint, &agent_name, &self_url).await
-            {
-                tracing::warn!(
-                    agent = %agent_name,
-                    peer = %endpoint,
-                    error = %error,
-                    "Auto-intro message failed"
-                );
-            }
         }
     }
 }

--- a/src/a2a/spawn.rs
+++ b/src/a2a/spawn.rs
@@ -45,6 +45,7 @@
 //! source map).
 
 use crate::a2a::client::A2AClient;
+use crate::a2a::mdns::{self, DiscoveredPeer};
 use crate::a2a::server::A2AServer;
 use crate::a2a::types::{Message, MessageRole, MessageSendConfiguration, MessageSendParams, Part};
 use crate::bus::AgentBus;
@@ -56,32 +57,61 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
+use tokio::sync::mpsc;
 
 /// Inputs for starting an A2A peer runtime.
 ///
-/// Used both by `codetether spawn` (one-shot CLI) and by `codetether tui`
-/// when its `--a2a-port` flag is set (background peer alongside the TUI).
+/// Used by `codetether spawn` (one-shot CLI) and by `codetether tui` (which
+/// runs the same A2A surface in the background alongside the interactive
+/// session). Every field is optional / has an auto-pick default — the
+/// "default by default by default" experience is `SpawnOptions::auto()`.
 #[derive(Debug, Clone)]
 pub struct SpawnOptions {
-    pub name: String,
+    /// Agent name. `None` → auto-pick `<host>-<repo>-<short-pid>`.
+    pub name: Option<String>,
+    /// Bind hostname. `127.0.0.1` is loopback-only (still works for
+    /// single-machine multi-agent via mDNS over loopback). Use `0.0.0.0`
+    /// to be reachable across the LAN.
     pub hostname: String,
+    /// Bind port. `0` → OS picks an available port.
     pub port: u16,
+    /// Public URL published in the agent card. `None` → derived from the
+    /// effective bound address after binding.
     pub public_url: Option<String>,
+    /// Optional card description.
     pub description: Option<String>,
+    /// Explicit peer seeds — used in addition to mDNS discovery, mainly
+    /// for cross-host setups where mDNS isn't routable.
     pub peer: Vec<String>,
+    /// Polling interval for explicit peer seeds (mDNS is event-driven).
+    /// Clamped to ≥ 5.
     pub discovery_interval_secs: u64,
+    /// Send a non-blocking intro `message/send` on first sighting of a peer.
     pub auto_introduce: bool,
+    /// Enable mDNS announce + browse (true P2P discovery, no central state).
+    pub mdns: bool,
 }
 
 impl SpawnOptions {
-    /// Materialize options from the `codetether spawn` CLI args, applying the
-    /// same default-name policy (`spawned-agent-<pid>`).
+    /// Zero-config defaults: auto port, auto name, mDNS on, auto-intro on.
+    pub fn auto() -> Self {
+        Self {
+            name: None,
+            hostname: "127.0.0.1".to_string(),
+            port: 0,
+            public_url: None,
+            description: None,
+            peer: Vec::new(),
+            discovery_interval_secs: 15,
+            auto_introduce: true,
+            mdns: true,
+        }
+    }
+
+    /// Materialize options from the `codetether spawn` CLI args.
     pub fn from_spawn_args(args: &SpawnArgs) -> Self {
         Self {
-            name: args
-                .name
-                .clone()
-                .unwrap_or_else(|| format!("spawned-agent-{}", std::process::id())),
+            name: args.name.clone(),
             hostname: args.hostname.clone(),
             port: args.port,
             public_url: args.public_url.clone(),
@@ -89,30 +119,97 @@ impl SpawnOptions {
             peer: args.peer.clone(),
             discovery_interval_secs: args.discovery_interval_secs,
             auto_introduce: args.auto_introduce,
+            mdns: args.mdns,
         }
     }
 }
 
-/// Handle to A2A peer background tasks (server + discovery loop).
+/// Auto-derive a stable, human-readable agent name from
+/// `<short-host>-<repo-basename>-<short-pid>`. Falls back gracefully if any
+/// component is unavailable.
+pub fn auto_agent_name() -> String {
+    let host_full = gethostname::gethostname()
+        .into_string()
+        .unwrap_or_else(|_| "host".to_string());
+    let host_short = host_full
+        .split('.')
+        .next()
+        .unwrap_or(&host_full)
+        .to_string();
+    let repo = std::env::current_dir()
+        .ok()
+        .as_ref()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("repo")
+        .to_string();
+    let pid = std::process::id();
+    let short_pid = format!("{:04x}", pid & 0xffff);
+    let raw = format!("{host_short}-{repo}-{short_pid}");
+    sanitize_name(&raw)
+}
+
+fn sanitize_name(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// First non-loopback non-link-local IPv4 address on any UP interface.
+/// Used to substitute for `0.0.0.0` in the public agent-card URL so the
+/// card advertises a reachable address.
+fn first_lan_ipv4() -> Option<String> {
+    let ifaces = if_addrs::get_if_addrs().ok()?;
+    ifaces
+        .into_iter()
+        .filter_map(|iface| {
+            let std::net::IpAddr::V4(v4) = iface.ip() else {
+                return None;
+            };
+            if v4.is_loopback() || v4.is_link_local() || v4.is_unspecified() {
+                return None;
+            }
+            // Skip docker bridge and similar internal addresses by preferring
+            // the actual host LAN interface — but we don't filter by name
+            // since interface naming is platform-specific. The first match
+            // is good enough; users with strict requirements can pass
+            // `--public-url` explicitly.
+            Some(v4.to_string())
+        })
+        .next()
+}
+
+/// Handle to A2A peer background tasks (server + discovery loop + mDNS).
 ///
 /// Returned by [`start_a2a_in_background`]. The handle MUST be kept alive
 /// (bound to a non-`_` variable, or stashed in app state) for the lifetime
-/// of the peer — dropping it aborts both background tasks via the `Drop`
-/// impl below. `JoinHandle::drop()` on its own only *detaches* tasks; the
-/// explicit `Drop` here is what actually stops them.
+/// of the peer — dropping it aborts every background task and unregisters
+/// the mDNS service via the `Drop` impl below. `JoinHandle::drop()` on its
+/// own only *detaches* tasks; the explicit `Drop` here is what actually
+/// stops them.
 pub struct A2APeerHandle {
     pub agent_name: String,
     pub bind_addr: String,
     pub public_url: String,
     server_task: tokio::task::JoinHandle<()>,
     discovery_task: tokio::task::JoinHandle<()>,
+    mdns_intake_task: Option<tokio::task::JoinHandle<()>>,
+    /// Held to keep the daemon alive; on drop unregisters the service.
+    _mdns_handle: Option<mdns::MdnsHandle>,
 }
 
 impl A2APeerHandle {
-    /// Abort the background server and discovery tasks immediately.
+    /// Abort all background tasks and shut down mDNS immediately.
     pub fn abort(self) {
-        self.server_task.abort();
-        self.discovery_task.abort();
+        // Drop runs on `self` falling out of scope — it does the work.
+        drop(self);
     }
 }
 
@@ -120,6 +217,10 @@ impl Drop for A2APeerHandle {
     fn drop(&mut self) {
         self.server_task.abort();
         self.discovery_task.abort();
+        if let Some(t) = self.mdns_intake_task.as_ref() {
+            t.abort();
+        }
+        // _mdns_handle's own Drop unregisters the mDNS service.
     }
 }
 
@@ -127,33 +228,53 @@ struct A2APreparation {
     listener: tokio::net::TcpListener,
     router: Router,
     discovery_task: tokio::task::JoinHandle<()>,
+    mdns_intake_task: Option<tokio::task::JoinHandle<()>>,
+    mdns_handle: Option<mdns::MdnsHandle>,
     agent_name: String,
     bind_addr: String,
     public_url: String,
 }
 
-/// Shared setup: bind listener first, then build card, register on bus, and
-/// spawn the discovery loop. Order matters: if the TCP bind fails we return
-/// an error before any tokio task is spawned and before the bus is told this
-/// agent exists, so the failure is clean — no leaked discovery task, no
-/// stale registry entry pointing at an address with no server behind it, no
-/// misleading peer-discovery traffic on the network.
+/// Shared setup: bind listener (port 0 → OS-assigned), auto-pick name if
+/// missing, build card, register on bus, spawn explicit-seed discovery
+/// loop, and start mDNS announce + browse if enabled.
+///
+/// Bind happens first so we know the effective port before publishing a
+/// URL. The TCP bind is the only step that can fail synchronously — and
+/// because nothing is registered on the bus and no tasks are spawned
+/// before bind succeeds, a bind failure leaves no leaked state.
 async fn prepare_a2a(opts: SpawnOptions, bus: Arc<AgentBus>) -> Result<A2APreparation> {
-    let bind_addr = format!("{}:{}", opts.hostname, opts.port);
-
-    // 1. Bind first. This is the only step that can fail synchronously.
-    let listener = tokio::net::TcpListener::bind(&bind_addr)
+    // 1. Bind first so we know the effective port (handles --port 0) AND so
+    //    a bind failure short-circuits cleanly without leaving any
+    //    background task or stale bus registry entry behind.
+    let requested_bind_addr = format!("{}:{}", opts.hostname, opts.port);
+    let listener = tokio::net::TcpListener::bind(&requested_bind_addr)
         .await
-        .with_context(|| format!("Failed to bind A2A peer on {bind_addr}"))?;
+        .with_context(|| format!("Failed to bind A2A peer on {requested_bind_addr}"))?;
+    let local_addr = listener
+        .local_addr()
+        .context("Failed to read local addr from listener")?;
+    let effective_port = local_addr.port();
+    let bind_addr = format!("{}:{}", opts.hostname, effective_port);
 
-    // 2. Now derive identity and publish on the bus.
+    // 2. Auto-pick name if not provided.
+    let agent_name = opts.name.clone().unwrap_or_else(auto_agent_name);
+
+    // 3. Derive public_url from effective bind addr if not supplied.
+    //    A wildcard host (`0.0.0.0` / `::`) is not a usable URL — pick the
+    //    first non-loopback IPv4 address on a real interface so the card
+    //    advertises something callers can actually reach.
+    let public_host = match opts.hostname.as_str() {
+        "0.0.0.0" | "::" | "[::]" => first_lan_ipv4().unwrap_or_else(|| "127.0.0.1".to_string()),
+        other => other.to_string(),
+    };
     let public_url = opts
         .public_url
         .clone()
-        .unwrap_or_else(|| format!("http://{bind_addr}"));
+        .unwrap_or_else(|| format!("http://{public_host}:{effective_port}"));
     let public_url = normalize_base_url(&public_url)?;
 
-    let agent_name = opts.name.clone();
+    // 4. Build card.
     let mut card = A2AServer::default_card(&public_url);
     card.name = agent_name.clone();
     if let Some(description) = opts.description.clone() {
@@ -165,21 +286,17 @@ async fn prepare_a2a(opts: SpawnOptions, bus: Arc<AgentBus>) -> Result<A2APrepar
     let capabilities = card.skills.iter().map(|skill| skill.id.clone()).collect();
     bus_handle.announce_ready(capabilities);
 
+    // 5. Spawn explicit-seed discovery loop (additive to mDNS-discovered
+    //    peers — useful for cross-LAN/WAN seeds where multicast doesn't
+    //    route).
     let peers = collect_peers(&opts.peer, &public_url);
-    if peers.is_empty() {
-        tracing::info!(
-            agent = %agent_name,
-            "A2A peer started without peer seeds; pass --peer or CODETETHER_A2A_PEERS for discovery"
-        );
-    } else {
+    if !peers.is_empty() {
         tracing::info!(
             agent = %agent_name,
             peer_count = peers.len(),
-            "A2A peer started with peer discovery seeds"
+            "A2A peer started with explicit --peer seeds (additive to mDNS)"
         );
     }
-
-    // 3. Only after a successful bind do we spawn the discovery loop.
     let discovery_task = tokio::spawn(discovery_loop(
         Arc::clone(&bus),
         peers,
@@ -189,23 +306,143 @@ async fn prepare_a2a(opts: SpawnOptions, bus: Arc<AgentBus>) -> Result<A2APrepar
         opts.auto_introduce,
     ));
 
+    // 6. mDNS announce + browse (true P2P, default on).
+    let (mdns_handle, mdns_intake_task) = if opts.mdns {
+        let (peer_tx, peer_rx) = mpsc::channel::<DiscoveredPeer>(64);
+        match mdns::announce_and_browse(&agent_name, effective_port, vec![], peer_tx) {
+            Ok(handle) => {
+                let intake = tokio::spawn(mdns_intake_loop(
+                    Arc::clone(&bus),
+                    peer_rx,
+                    public_url.clone(),
+                    agent_name.clone(),
+                    opts.auto_introduce,
+                ));
+                (Some(handle), Some(intake))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    agent = %agent_name,
+                    error = %e,
+                    "mDNS unavailable; falling back to explicit --peer seeds only"
+                );
+                (None, None)
+            }
+        }
+    } else {
+        (None, None)
+    };
+
     let router: Router = A2AServer::new(card).router();
 
     Ok(A2APreparation {
         listener,
         router,
         discovery_task,
+        mdns_intake_task,
+        mdns_handle,
         agent_name,
         bind_addr,
         public_url,
     })
 }
 
+/// Drain peers discovered over mDNS, fetch their cards, register them, and
+/// optionally send the same auto-intro the explicit-seed loop sends.
+///
+/// Dedup is keyed by **agent name** (not by endpoint URL), so an agent that
+/// is reachable via multiple network interfaces — common when binding
+/// `0.0.0.0` on a host with several bridges — only triggers one discovery
+/// log line and one auto-intro across the lifetime of the process.
+async fn mdns_intake_loop(
+    bus: Arc<AgentBus>,
+    mut peer_rx: mpsc::Receiver<DiscoveredPeer>,
+    self_url: String,
+    agent_name: String,
+    auto_introduce: bool,
+) {
+    let self_url = self_url.trim_end_matches('/').to_string();
+    let known: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+
+    while let Some(peer) = peer_rx.recv().await {
+        if peer.url.trim_end_matches('/') == self_url {
+            continue;
+        }
+
+        // Skip on instance-name match before even probing — saves N-1
+        // wasteful card fetches when the same peer announces over many
+        // interfaces.
+        let already_known_by_instance = {
+            let k = known.lock().await;
+            k.contains(&peer.instance_name)
+        };
+        if already_known_by_instance {
+            continue;
+        }
+
+        // Probe both base URL and `/a2a` variant the same way the explicit-
+        // seed loop does.
+        let candidates = peer_candidates(&peer.url);
+        let mut resolved = None;
+        for candidate in candidates {
+            match try_fetch_agent_card(&candidate).await {
+                Ok(card) => {
+                    resolved = Some((candidate, card));
+                    break;
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        agent = %agent_name,
+                        peer = %candidate,
+                        error = %error,
+                        "mDNS peer probe failed"
+                    );
+                }
+            }
+        }
+
+        let Some((endpoint, card)) = resolved else {
+            continue;
+        };
+
+        let is_new = {
+            let mut k = known.lock().await;
+            // Insert both keys so future probes via either path short-circuit.
+            let inserted = k.insert(card.name.clone());
+            k.insert(peer.instance_name.clone());
+            inserted
+        };
+
+        bus.registry.register(card.clone());
+
+        if is_new {
+            tracing::info!(
+                agent = %agent_name,
+                peer_name = %card.name,
+                peer_url = %card.url,
+                endpoint = %endpoint,
+                via = "mdns",
+                "Discovered A2A peer"
+            );
+            if auto_introduce
+                && let Err(error) = send_intro(&endpoint, &agent_name, &self_url).await
+            {
+                tracing::warn!(
+                    agent = %agent_name,
+                    peer = %endpoint,
+                    error = %error,
+                    "Auto-intro message failed"
+                );
+            }
+        }
+    }
+}
+
 /// Start an A2A peer runtime in the background, attached to the given bus.
 ///
 /// Caller is responsible for keeping the returned [`A2APeerHandle`] alive
 /// for as long as the peer should keep serving. Drop or call `abort()` on
-/// shutdown. Used by the TUI when `--a2a-port` is set.
+/// shutdown. Used by the TUI on every launch (unless `--no-a2a` was set).
 pub async fn start_a2a_in_background(
     opts: SpawnOptions,
     bus: Arc<AgentBus>,
@@ -215,6 +452,7 @@ pub async fn start_a2a_in_background(
         agent = %prep.agent_name,
         bind_addr = %prep.bind_addr,
         public_url = %prep.public_url,
+        mdns = prep.mdns_handle.is_some(),
         "A2A peer listening (background mode)"
     );
     let agent_name = prep.agent_name.clone();
@@ -231,6 +469,8 @@ pub async fn start_a2a_in_background(
         public_url,
         server_task,
         discovery_task: prep.discovery_task,
+        mdns_intake_task: prep.mdns_intake_task,
+        _mdns_handle: prep.mdns_handle,
     })
 }
 
@@ -248,16 +488,25 @@ pub async fn run(args: SpawnArgs) -> Result<()> {
         agent = %prep.agent_name,
         bind_addr = %prep.bind_addr,
         public_url = %prep.public_url,
+        mdns = prep.mdns_handle.is_some(),
         "Spawned A2A agent runtime"
     );
+
+    let agent_name = prep.agent_name.clone();
+    let discovery_task = prep.discovery_task;
+    let mdns_intake_task = prep.mdns_intake_task;
+    let _mdns_handle = prep.mdns_handle; // dropped at end of fn → unregisters
 
     axum::serve(prep.listener, prep.router)
         .with_graceful_shutdown(shutdown_signal())
         .await
         .context("Spawned A2A server failed")?;
 
-    prep.discovery_task.abort();
-    tracing::info!(agent = %prep.agent_name, "Spawned A2A agent shut down");
+    discovery_task.abort();
+    if let Some(t) = mdns_intake_task {
+        t.abort();
+    }
+    tracing::info!(agent = %agent_name, "Spawned A2A agent shut down");
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -250,8 +250,13 @@ pub struct TuiArgs {
     #[arg(long)]
     pub a2a_port: Option<u16>,
 
-    /// A2A bind hostname. 127.0.0.1 (default) is loopback-only; mDNS over
-    /// loopback still finds peers on the same host. Use 0.0.0.0 for LAN.
+    /// A2A bind hostname. 127.0.0.1 (default) is loopback-only and SAFE
+    /// (the peer is unreachable from outside the host) but mDNS multicast
+    /// does NOT traverse the Linux `lo` interface, so same-host peers
+    /// cannot find each other via mDNS at this binding. Use 0.0.0.0 to
+    /// make peers reachable on the LAN AND to enable mDNS auto-discovery
+    /// between same-host agents (multicast loops back through the real
+    /// interface).
     #[arg(long, default_value = "127.0.0.1")]
     pub a2a_hostname: String,
 
@@ -482,9 +487,12 @@ pub struct SpawnArgs {
     #[arg(short, long)]
     pub name: Option<String>,
 
-    /// Hostname to bind. 127.0.0.1 (default) is loopback-only — peers on
-    /// the same host still find each other via mDNS over loopback. Use
-    /// 0.0.0.0 to be reachable across the LAN.
+    /// Hostname to bind. 127.0.0.1 (default) is loopback-only and SAFE
+    /// (the peer is unreachable from outside the host) but mDNS multicast
+    /// does NOT traverse the Linux `lo` interface, so same-host peers
+    /// cannot find each other via mDNS at this binding. Use 0.0.0.0 to
+    /// be reachable on the LAN AND to enable mDNS auto-discovery between
+    /// same-host agents (multicast loops back through the real interface).
     #[arg(long, default_value = "127.0.0.1")]
     pub hostname: String,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -238,24 +238,28 @@ pub struct TuiArgs {
     #[arg(long)]
     pub allow_network: bool,
 
-    /// Bind an A2A peer endpoint on this port alongside the TUI.
-    /// When set, the TUI process exposes /.well-known/agent.json and
-    /// JSON-RPC at http://<a2a-hostname>:<a2a-port>/ and runs peer
-    /// discovery against `--a2a-peer` seeds. Inbound `message/send`
-    /// requests are handled by a fresh background session — they do not
-    /// route into the TUI's interactive session. See docs/a2a-spawn.md.
+    /// Disable the built-in A2A peer endpoint. By default the TUI binds an
+    /// A2A peer with auto-port, auto-name, and mDNS-based peer discovery —
+    /// other CodeTether processes on the same host or LAN find each other
+    /// without flags. Pass `--no-a2a` for purely interactive mode.
+    #[arg(long = "no-a2a", action = clap::ArgAction::SetFalse, default_value_t = true)]
+    pub a2a: bool,
+
+    /// Override the auto-picked A2A port. By default the OS assigns one
+    /// (port 0). Specify a port for stable curl-able URLs.
     #[arg(long)]
     pub a2a_port: Option<u16>,
 
-    /// Hostname to bind the A2A peer endpoint. Use 0.0.0.0 for off-box.
+    /// A2A bind hostname. 127.0.0.1 (default) is loopback-only; mDNS over
+    /// loopback still finds peers on the same host. Use 0.0.0.0 for LAN.
     #[arg(long, default_value = "127.0.0.1")]
     pub a2a_hostname: String,
 
-    /// Public URL published in the agent card (defaults to http://<hostname>:<port>).
+    /// Public URL published in the agent card.
     #[arg(long)]
     pub a2a_public_url: Option<String>,
 
-    /// Agent name for the A2A card. Defaults to "tui-agent-<pid>".
+    /// Override the auto-picked agent name (default: <host>-<repo>-<pid>).
     #[arg(long)]
     pub a2a_name: Option<String>,
 
@@ -263,17 +267,24 @@ pub struct TuiArgs {
     #[arg(long)]
     pub a2a_description: Option<String>,
 
-    /// Peer seed URLs (repeat or comma-separate).
+    /// Explicit peer seed URLs (in addition to mDNS-discovered peers).
+    /// Useful for cross-host setups where mDNS isn't routable.
     #[arg(long, value_delimiter = ',', env = "CODETETHER_A2A_PEERS")]
     pub a2a_peer: Vec<String>,
 
-    /// Discovery interval in seconds (clamped to ≥ 5).
+    /// Discovery interval for explicit --a2a-peer seeds, in seconds.
+    /// Clamped to ≥ 5. (mDNS is event-driven, not polled.)
     #[arg(long, default_value = "15")]
     pub a2a_discovery_interval_secs: u64,
 
     /// Disable auto-intro to newly discovered peers.
     #[arg(long = "a2a-no-auto-introduce", action = clap::ArgAction::SetFalse, default_value_t = true)]
     pub a2a_auto_introduce: bool,
+
+    /// Disable mDNS-based peer discovery. Without mDNS, only explicit
+    /// --a2a-peer seeds are discovered. mDNS is on by default for true P2P.
+    #[arg(long = "a2a-no-mdns", action = clap::ArgAction::SetFalse, default_value_t = true)]
+    pub a2a_mdns: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -467,19 +478,22 @@ pub struct GitCredentialHelperArgs {
 
 #[derive(Parser, Debug, Clone)]
 pub struct SpawnArgs {
-    /// Agent name
+    /// Agent name. Defaults to <host>-<repo>-<short-pid>.
     #[arg(short, long)]
     pub name: Option<String>,
 
-    /// Hostname to bind the spawned A2A agent
+    /// Hostname to bind. 127.0.0.1 (default) is loopback-only — peers on
+    /// the same host still find each other via mDNS over loopback. Use
+    /// 0.0.0.0 to be reachable across the LAN.
     #[arg(long, default_value = "127.0.0.1")]
     pub hostname: String,
 
-    /// Port to bind the spawned A2A agent
-    #[arg(short, long, default_value = "4097")]
+    /// Port to bind. 0 (default) lets the OS pick an available port.
+    /// Specify a port if you need a stable URL for curl scripts.
+    #[arg(short, long, default_value = "0")]
     pub port: u16,
 
-    /// Public URL published in the agent card (defaults to http://<hostname>:<port>)
+    /// Public URL published in the agent card (defaults to http://<hostname>:<port>).
     #[arg(long)]
     pub public_url: Option<String>,
 
@@ -487,17 +501,24 @@ pub struct SpawnArgs {
     #[arg(short, long)]
     pub description: Option<String>,
 
-    /// Peer seed URLs to discover and talk to (repeat flag or comma-separated)
+    /// Explicit peer seed URLs (in addition to mDNS-discovered peers).
+    /// Useful for cross-host setups where mDNS isn't routable.
     #[arg(long, value_delimiter = ',', env = "CODETETHER_A2A_PEERS")]
     pub peer: Vec<String>,
 
-    /// Discovery interval in seconds
+    /// Discovery interval for explicit --peer seeds, in seconds. Clamped
+    /// to ≥ 5. (mDNS discovery is event-driven, not polled.)
     #[arg(long, default_value = "15")]
     pub discovery_interval_secs: u64,
 
     /// Disable sending an automatic intro message to newly discovered peers
     #[arg(long = "no-auto-introduce", action = clap::ArgAction::SetFalse, default_value_t = true)]
     pub auto_introduce: bool,
+
+    /// Disable mDNS announce + browse. Without mDNS, only explicit
+    /// --peer seeds are discovered. mDNS is on by default for true P2P.
+    #[arg(long = "no-mdns", action = clap::ArgAction::SetFalse, default_value_t = true)]
+    pub mdns: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -550,19 +550,25 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Some(Command::Tui(args)) => {
             let allow_network = args.allow_network;
-            let a2a_options = args.a2a_port.map(|port| crate::a2a::spawn::SpawnOptions {
-                name: args
-                    .a2a_name
-                    .clone()
-                    .unwrap_or_else(|| format!("tui-agent-{}", std::process::id())),
-                hostname: args.a2a_hostname.clone(),
-                port,
-                public_url: args.a2a_public_url.clone(),
-                description: args.a2a_description.clone(),
-                peer: args.a2a_peer.clone(),
-                discovery_interval_secs: args.a2a_discovery_interval_secs,
-                auto_introduce: args.a2a_auto_introduce,
-            });
+            // A2A peer is on by default. `--no-a2a` opts out entirely.
+            // When on, every field auto-picks a sensible default unless the
+            // user supplied an explicit override (--a2a-port / --a2a-name /
+            // --a2a-peer, etc.).
+            let a2a_options = if args.a2a {
+                Some(crate::a2a::spawn::SpawnOptions {
+                    name: args.a2a_name.clone(),
+                    hostname: args.a2a_hostname.clone(),
+                    port: args.a2a_port.unwrap_or(0),
+                    public_url: args.a2a_public_url.clone(),
+                    description: args.a2a_description.clone(),
+                    peer: args.a2a_peer.clone(),
+                    discovery_interval_secs: args.a2a_discovery_interval_secs,
+                    auto_introduce: args.a2a_auto_introduce,
+                    mdns: args.a2a_mdns,
+                })
+            } else {
+                None
+            };
             let project = args.project.or(cli.project);
             tui::run(project, allow_network, a2a_options).await
         }
@@ -1852,9 +1858,10 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         None => {
-            // Default: launch TUI without an A2A peer endpoint.
+            // Default: launch TUI with auto-everything A2A peer enabled.
+            // Same defaults as `codetether tui` with no flags.
             let project = cli.project;
-            tui::run(project, false, None).await
+            tui::run(project, false, Some(crate::a2a::spawn::SpawnOptions::auto())).await
         }
     }
 }


### PR DESCRIPTION
**Replaces #115** — that PR was merged into the now-deleted intermediate branch \`feature/tui-a2a-peer\` instead of \`main\` (because GitHub honored the original stacked-PR base) and so its content never landed on \`main\`. This PR re-targets \`main\` directly.

## What's in it

Same content as #115. Two cherry-picked commits, both signed with Riley's GPG key (\`B932D8080A95F13B\`, \`gpg: Good signature\`):

- \`12597da\` feat(a2a): zero-config peer discovery via mDNS, default-on in TUI
- \`7ad94b2\` fix(a2a): address PR #115 review — mdns robustness, sanitize_hostname

## Summary

Makes A2A peer discovery default by default — no flags, no seed list, no central broker. Two CodeTether processes on the same host or LAN find each other and auto-introduce within seconds, purely peer-to-peer.

### Auto-everything
- **Auto port** (\`--port 0\` → OS-assigned).
- **Auto name** (\`<short-host>-<cwd-basename>-<short-pid>\`, sanitized to a valid DNS label).
- **Auto-pick public_url**: when binding \`0.0.0.0\`, the published card URL substitutes the first non-loopback IPv4 (via \`if-addrs\`).

### Discovery via mDNS / DNS-SD
- New \`src/a2a/mdns.rs\` (uses pure-Rust \`mdns-sd\`, no system deps).
- Service type: \`_codetether-a2a._tcp.local.\`
- Each agent **announces** itself and **browses** the same service type.
- Resolved peers stream into \`mdns_intake_loop\` in \`spawn.rs\`.
- Per-peer task spawning + 5 s timeout — slow peers don't block the queue.
- Dedup by card name — multi-homed peers trigger one log line, one auto-intro.
- mDNS is event-driven (no polling). Legacy explicit-seed polling loop retained additively for cross-host setups.

### CLI
- **\`codetether spawn\`** defaults: \`--port 0\`, name auto-derived, mDNS on. New \`--no-mdns\` opt-out. \`--peer\` seeds are additive to mDNS.
- **\`codetether tui\`** defaults: A2A peer **ON** with all the same auto-picks. New \`--no-a2a\` opt-out. \`--a2a-port\` becomes an override rather than the on/off gate.
- Bare \`codetether\` launches the TUI with \`SpawnOptions::auto()\`.

### Review feedback addressed (in second commit)
- \`sanitize_hostname\` produces valid DNS labels (lowercase, trim leading/trailing \`-\`, ≤63 chars, fall back to \`agent\`).
- mDNS \`bound_addrs\` matches HTTP server reachability — loopback only when \`127.0.0.1\`, \`enable_addr_auto\` only when \`0.0.0.0\`.
- \`mdns_intake_loop\` spawns per-peer tasks with 5 s timeout — slow peer no longer freezes discovery.
- \`DiscoveredPeer.urls: Vec<String>\` — multi-homed peers' addresses tried in order.
- \`gethostname = "1"\` (was \`"0.5"\`, deduped against transitive).
- CLI help honest about \`lo\` not multicasting on Linux.
- \`mdns.rs\` module docs updated to match.

### New deps

\`\`\`
mdns-sd = "0.13"
gethostname = "1"
if-addrs = "0.13"
\`\`\`

All pure-Rust, no system deps.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo build\` (debug) clean
- [x] \`cargo test --lib a2a\` — 22/22 pass (was 18/22 before; new \`sanitize_hostname_*\` tests cover lowercase, trim-dashes, truncate-to-63, fall-back-to-agent)
- [x] Headless spawn smoke test (alice + bob, two repos, \`--hostname 0.0.0.0\`, no other flags) — both sides log exactly one \`Discovered A2A peer\` and one \`Auto-intro message sent\` per peer
- [x] \`codetether spawn --help\` and \`codetether tui --help\` show all new flags with correct descriptions and defaults

## Why a v2 PR exists

Merging #115 deleted \`feature/tui-a2a-peer\` (which it was based on) and the merge commit landed on the deleted branch, not on \`main\`. The history of the original PR is preserved in the GitHub merge commit \`36fc290b\` for reference.