### PR TITLE
--- Begin pasted text #2 (43 lines, 5890 bytes) ---
│  ┌─ text

### DIFF
--- a/src/tool/voice_input/stderr_guard.rs
+++ b/src/tool/voice_input/stderr_guard.rs
@@ -1,22 +1,21 @@
 //! RAII guard for temporarily redirecting stderr to `/dev/null` on Linux.
 
-use std::os::fd::RawFd;
-
 /// Guard that restores the original stderr file descriptor on drop.
 ///
 /// On creation, duplicates the current stderr fd, then redirects stderr
 /// to `/dev/null`. When dropped (including during unwinding), the original
 /// stderr is restored and the backup fd is closed.
+#[cfg(target_os = "linux")]
 pub(crate) struct StderrRedirectGuard {
-    saved_stderr: RawFd,
+    saved_stderr: std::os::fd::RawFd,
 }
 
+#[cfg(target_os = "linux")]
 impl StderrRedirectGuard {
     /// Create a new guard that silences stderr until dropped.
     ///
     /// Returns `None` if either `dup` or `dup2` fails, in which case
     /// stderr is left unchanged.
-    #[cfg(target_os = "linux")]
     pub(crate) fn new() -> Option<Self> {
         use std::fs::OpenOptions;
         use std::os::fd::AsRawFd;
@@ -36,6 +35,7 @@ impl StderrRedirectGuard {
     }
 }
 
+#[cfg(target_os = "linux")]
 impl Drop for StderrRedirectGuard {
     fn drop(&mut self) {
         unsafe {


### PR DESCRIPTION
**Prompt:** 

--- Begin pasted text #2 (43 lines, 5890 bytes) ---
│  ┌─ text Code ───────────────────────────────────────────────────────────────────────────────          │
│  │ 2026-04-28 00:42  19.68 MB  18.4s  1080x1920                                                        │
│  │ /home/riley/spotlessbinco/out/offers/brand-editor-media-library/brand-media-library-gemini31-tts.mp4│
│  └─────────────────────────────────────────────────────────────────────────────────────────────────    │
│                                                                                                        │
│────────────────────────────────────────────────────────────                                            │
│[13:44:24] ▸ user                                                                                       │
│  i told the agent about a mascot on windows can you find in the most recent sesion with like 400       │
│  messges                                                                                               │
│                                                                                                        │
│────────────────────────────────────────────────────────────                                            │
│[13:44:30] ◆ assistant                                                                                  │
│  I’ll search the recent session history for the Windows mascot discussion and pull out the             │
│  relevant file paths/details.                                                                          │
│                                                                                                        │
│────────────────────────────────────────────────────────────                                            │
│[13:44:30] ▣ tools 2 • 1-6 / 22                                                                         │
││ 🔧 session_recall                                                                                     │
││   {"limit":10,"query":"most recent long session around 400 messages mascot on Windows video up…       │
││ ✅ session_recall • success • 60276ms                                                                 │
││   Recalled from 10 session(s): Hello from ubuntu-dev-a2a-server-mcp-0f1b (http... (1c170997-5e…       │
││   (RLM: 133524 → 3242 tokens, 10 iterations)                                                          │
││                                                                                                       │
│└ preview scroll 1                                                                                      │
│                                                                                                        │
│[13:45:41] ◆ assistant                                                                                  │
│  The recall pulled mostly the current YouTube thread, not the older Windows/mascot detail. I’ll        │
│  browse the raw session turns and search session archives directly for “Windows”/“mascot” so I         │
│  don’t miss the 400-message session.                                                                   │
│                                                                                                        │
│····························································                                            │
│[13:45:41] ▣ tools 4 • 1-6 / 44                                                                         │
││ 🔧 context_browse                                                                                     │
││   {"action":"list"}                                                                                   │
││ ✅ context_browse • success • 22ms                                                                    │
││   /home/riley/spotlessbinco/.codetether-agent/history/1c170997-5e43-4b63-ad82-f5f90a4063ce/tur…       │
││   /home/riley/spotlessbinco/.codetether-agent/history/1c170997-5e43-4b63-ad82-f5f90a4063ce/tur…       │
││   /home/riley/spotlessbinco/.codetether-agent/history/1c170997-5e43-4b63-ad82-f5f90a4063ce/tur…       │
│└ preview scroll 1                                                                                      │
└────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌ Message (Processing — Enter to queue steering)─────────────────────────────────────────────────────────┐
│Killed                                                                                                  │
riley@ubuntu-dev:~/spotlessbinco$ ──
--- End pasted text #2 ---