### PR TITLE
fix: improve TUI auto PR titles

### DIFF
--- a/src/tui/app/input/mod.rs
+++ b/src/tui/app/input/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod pasted_text;
 mod pr;
 mod pr_body;
 mod pr_command;
+mod pr_command_tests;
 mod pr_description;
 mod pr_helpers;
 mod pr_title;

--- a/src/tui/app/input/pr_body.rs
+++ b/src/tui/app/input/pr_body.rs
@@ -1,28 +1,27 @@
 //! PR body construction from prompt and commit bullets.
 
-/// Build the PR body from prompt and commit bullets.
-///
-/// Returns a generic message when both are empty.
-///
-/// # Examples
-///
-/// ```ignore
-/// let body = build_body(Some("fix bug"), "- abc123 fix\n");
-/// assert!(body.contains("**Prompt:**"));
-/// ```
+/// Build the PR body from commit bullets and optional prompt context.
 pub(super) fn build_body(prompt: Option<&str>, bullets: &str) -> String {
-    let mut parts = Vec::new();
-    if let Some(p) = prompt {
-        parts.push(format!("**Prompt:** {p}"));
-    }
+    let mut parts = vec!["## Summary".to_string(), summary_text(bullets)];
     if !bullets.is_empty() {
-        parts.push(bullets.to_string());
+        parts.extend(["## Commits".to_string(), bullets.to_string()]);
     }
-    if parts.is_empty() {
-        "Automated PR from CodeTether TUI agent.".to_string()
+    if let Some(p) = prompt.map(str::trim).filter(|p| !p.is_empty()) {
+        parts.extend(["## Original request".to_string(), fenced(p)]);
+    }
+    parts.join("\n\n")
+}
+
+fn summary_text(bullets: &str) -> String {
+    if bullets.is_empty() {
+        "Automated CodeTether TUI agent changes.".to_string()
     } else {
-        parts.join("\n\n")
+        "Automated CodeTether TUI agent changes from the commits below.".to_string()
     }
+}
+
+fn fenced(text: &str) -> String {
+    format!("```text\n{}\n```", text.trim())
 }
 
 #[cfg(test)]
@@ -30,15 +29,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn body_with_prompt_and_bullets() {
-        let body = build_body(Some("fix login"), "- abc fix\n");
-        assert!(body.contains("**Prompt:** fix login"));
-        assert!(body.contains("- abc fix"));
+    fn body_wraps_prompt_in_fence() {
+        let body = build_body(Some("fix login"), "- abc fix");
+        assert!(body.contains("## Original request\n\n```text\nfix login\n```"));
     }
 
     #[test]
-    fn body_with_nothing() {
+    fn body_with_nothing_has_summary() {
         let body = build_body(None, "");
-        assert!(body.contains("CodeTether TUI agent"));
+        assert!(body.contains("Automated CodeTether TUI agent changes"));
     }
 }

--- a/src/tui/app/input/pr_body.rs
+++ b/src/tui/app/input/pr_body.rs
@@ -21,7 +21,13 @@ fn summary_text(bullets: &str) -> String {
 }
 
 fn fenced(text: &str) -> String {
-    format!("```text\n{}\n```", text.trim())
+    let fence = fence_for(text);
+    format!("{fence}text\n{text}\n{fence}")
+}
+
+fn fence_for(text: &str) -> String {
+    let ticks = text.split('`').map(str::len).max().unwrap_or(0);
+    "`".repeat(ticks.max(2) + 1)
 }
 
 #[cfg(test)]
@@ -32,6 +38,12 @@ mod tests {
     fn body_wraps_prompt_in_fence() {
         let body = build_body(Some("fix login"), "- abc fix");
         assert!(body.contains("## Original request\n\n```text\nfix login\n```"));
+    }
+
+    #[test]
+    fn body_uses_longer_fence_for_backticks() {
+        let body = build_body(Some("contains ``` fence"), "");
+        assert!(body.contains("````text\ncontains ``` fence\n````"));
     }
 
     #[test]

--- a/src/tui/app/input/pr_command.rs
+++ b/src/tui/app/input/pr_command.rs
@@ -1,7 +1,4 @@
 //! GitHub PR command builders for TUI worktrees.
-//!
-//! Keeps CLI argument construction separate from process
-//! execution so the base-branch selection logic is testable.
 
 use crate::worktree::WorktreeInfo;
 
@@ -9,47 +6,36 @@ use super::pr_body::build_body;
 use super::pr_title::build_title;
 
 /// Build the `gh pr create` arguments for a TUI worktree.
-///
-/// Uses `prompt` for the PR title when available, falling back
-/// to the worktree name.  The body includes the original prompt
-/// and commit bullet points when provided.
 pub(super) fn create_pr_args(
     wt: &WorktreeInfo,
     base_branch: Option<&str>,
     prompt: Option<&str>,
     commit_bullets: &str,
+    commits: &[String],
 ) -> Vec<String> {
     let mut args = vec![
-        "pr".to_string(),
-        "create".to_string(),
-        "--head".to_string(),
+        "pr".into(),
+        "create".into(),
+        "--head".into(),
         wt.branch.clone(),
     ];
     if let Some(base) = base_branch.filter(|b| !b.is_empty()) {
-        args.push("--base".to_string());
-        args.push(base.to_string());
+        args.extend(["--base".to_string(), base.to_string()]);
     }
-    let title = build_title(prompt, &wt.name);
-    let body = build_body(prompt, commit_bullets);
-    args.extend(["--title".to_string(), title, "--body".to_string(), body]);
+    args.extend(pr_text_args(wt, prompt, commit_bullets, commits));
     args
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::PathBuf;
-
-    #[test]
-    fn create_pr_args_uses_prompt_as_title() {
-        let wt = WorktreeInfo {
-            name: "tui_abc".into(),
-            path: PathBuf::from("."),
-            branch: "codetether/tui_abc".into(),
-            active: true,
-        };
-        let args = create_pr_args(&wt, None, Some("fix login bug"), "");
-        let idx = args.iter().position(|a| a == "--title").unwrap();
-        assert_eq!(args[idx + 1], "fix login bug");
-    }
+fn pr_text_args(
+    wt: &WorktreeInfo,
+    prompt: Option<&str>,
+    commit_bullets: &str,
+    commits: &[String],
+) -> Vec<String> {
+    vec![
+        "--title".into(),
+        build_title(&wt.name, commits),
+        "--body".into(),
+        build_body(prompt, commit_bullets),
+    ]
 }

--- a/src/tui/app/input/pr_command_tests.rs
+++ b/src/tui/app/input/pr_command_tests.rs
@@ -1,0 +1,22 @@
+//! Tests for PR command text quality.
+
+#[cfg(test)]
+mod tests {
+    use crate::tui::app::input::pr_command::create_pr_args;
+    use crate::worktree::WorktreeInfo;
+    use std::path::PathBuf;
+
+    #[test]
+    fn create_pr_args_uses_commit_as_title() {
+        let wt = WorktreeInfo {
+            name: "tui_abc".into(),
+            path: PathBuf::from("."),
+            branch: "codetether/tui_abc".into(),
+            active: true,
+        };
+        let commits = vec!["abc123 fix: login bug".into()];
+        let args = create_pr_args(&wt, None, Some("raw user prompt"), "", &commits);
+        let idx = args.iter().position(|a| a == "--title").unwrap();
+        assert_eq!(args[idx + 1], "fix: login bug");
+    }
+}

--- a/src/tui/app/input/pr_helpers.rs
+++ b/src/tui/app/input/pr_helpers.rs
@@ -37,7 +37,7 @@ pub(super) async fn create_github_pr(
 ) -> anyhow::Result<String> {
     let commits = collect_commit_log(&wt.path, base_branch).await;
     let bullets = format_commit_bullets(&commits);
-    let args = create_pr_args(wt, base_branch, prompt, &bullets);
+    let args = create_pr_args(wt, base_branch, prompt, &bullets, &commits);
     let output = tokio::process::Command::new("gh")
         .args(&args)
         .current_dir(&wt.path)

--- a/src/tui/app/input/pr_title.rs
+++ b/src/tui/app/input/pr_title.rs
@@ -4,31 +4,40 @@
 pub(super) fn build_title(worktree_name: &str, commits: &[String]) -> String {
     commits
         .iter()
-        .find_map(|c| commit_subject(c))
+        .find_map(|c| commit_subject(c.as_str()))
         .map(clean_subject)
         .filter(|t| !t.is_empty())
         .unwrap_or_else(|| format!("codetether: {worktree_name}"))
 }
 
-fn commit_subject(line: &String) -> Option<&str> {
+fn commit_subject(line: &str) -> Option<&str> {
     line.split_once(' ').map(|(_, subject)| subject.trim())
 }
 
 fn clean_subject(subject: &str) -> String {
-    let title = subject
-        .strip_prefix("codetether: ")
-        .unwrap_or(subject)
-        .trim();
+    let title = subject.strip_prefix("codetether: ").unwrap_or(subject);
     truncate_title(title, 72).trim().to_string()
 }
 
-/// Truncate `s` to at most `max` characters on a word boundary.
+/// Truncate `s` to at most `max` bytes on a UTF-8-safe word boundary.
 pub(super) fn truncate_title(s: &str, max: usize) -> &str {
-    if s.len() <= max {
+    let Some(prefix) = utf8_prefix(s, max) else {
         return s;
+    };
+    let boundary = prefix.rfind(char::is_whitespace).unwrap_or(prefix.len());
+    &prefix[..boundary]
+}
+
+fn utf8_prefix(s: &str, max: usize) -> Option<&str> {
+    if s.len() <= max {
+        return None;
     }
-    let boundary = s[..=max].rfind(char::is_whitespace).unwrap_or(max);
-    &s[..boundary]
+    let boundary = s
+        .char_indices()
+        .map(|(i, _)| i)
+        .take_while(|i| *i <= max)
+        .last()?;
+    Some(&s[..boundary])
 }
 
 #[cfg(test)]
@@ -45,7 +54,8 @@ mod tests {
     }
 
     #[test]
-    fn title_uses_worktree_name_when_commits_are_empty() {
-        assert_eq!(build_title("tui_abc", &[]), "codetether: tui_abc");
+    fn truncate_title_handles_unicode() {
+        let result = truncate_title("fix 🦀 unicode title boundary", 8);
+        assert_eq!(result, "fix");
     }
 }

--- a/src/tui/app/input/pr_title.rs
+++ b/src/tui/app/input/pr_title.rs
@@ -1,34 +1,34 @@
-//! PR title construction from user prompts.
-//!
-//! Truncates the prompt to a GitHub-compatible title length
-//! on a word boundary.
+//! PR title construction from branch names and commit summaries.
+
+/// Build a stable PR title from worktree metadata.
+pub(super) fn build_title(worktree_name: &str, commits: &[String]) -> String {
+    commits
+        .iter()
+        .find_map(|c| commit_subject(c))
+        .map(clean_subject)
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| format!("codetether: {worktree_name}"))
+}
+
+fn commit_subject(line: &String) -> Option<&str> {
+    line.split_once(' ').map(|(_, subject)| subject.trim())
+}
+
+fn clean_subject(subject: &str) -> String {
+    let title = subject
+        .strip_prefix("codetether: ")
+        .unwrap_or(subject)
+        .trim();
+    truncate_title(title, 72).trim().to_string()
+}
 
 /// Truncate `s` to at most `max` characters on a word boundary.
-///
-/// Returns the input unchanged if it fits within `max`.
-///
-/// # Examples
-///
-/// ```ignore
-/// assert_eq!(truncate_title("fix bug", 72), "fix bug");
-/// ```
 pub(super) fn truncate_title(s: &str, max: usize) -> &str {
     if s.len() <= max {
         return s;
     }
-    let boundary = s[..=max].rfind(|c: char| c.is_whitespace()).unwrap_or(max);
+    let boundary = s[..=max].rfind(char::is_whitespace).unwrap_or(max);
     &s[..boundary]
-}
-
-/// Build the PR title from a user prompt.
-///
-/// Falls back to `"codetether: {name}"` when no prompt
-/// is available or the prompt is empty.
-pub(super) fn build_title(prompt: Option<&str>, fallback_name: &str) -> String {
-    prompt
-        .map(|p| truncate_title(p.trim(), 72).to_string())
-        .filter(|t| !t.is_empty())
-        .unwrap_or_else(|| format!("codetether: {fallback_name}"))
 }
 
 #[cfg(test)]
@@ -36,15 +36,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn truncate_title_short_input_unchanged() {
-        assert_eq!(truncate_title("fix bug", 72), "fix bug");
+    fn title_prefers_commit_subject() {
+        let commits = vec!["abc123 fix: clean PR title generation".into()];
+        assert_eq!(
+            build_title("tui_abc", &commits),
+            "fix: clean PR title generation"
+        );
     }
 
     #[test]
-    fn truncate_title_long_input_on_word() {
-        let long = "fix the login bug that causes users to see a blank screen after submitting";
-        let result = truncate_title(long, 40);
-        assert!(result.len() <= 40);
-        assert!(!result.ends_with(' '));
+    fn title_uses_worktree_name_when_commits_are_empty() {
+        assert_eq!(build_title("tui_abc", &[]), "codetether: tui_abc");
     }
 }

--- a/src/tui/app/input/tests.rs
+++ b/src/tui/app/input/tests.rs
@@ -128,7 +128,7 @@ mod tests {
             active: true,
         };
 
-        let args = create_pr_args(&wt, Some("feature/current"));
+        let args = create_pr_args(&wt, Some("feature/current"), None, "", &[]);
 
         assert_eq!(args[0], "pr");
         assert_eq!(args[1], "create");

--- a/src/tui/app/input/tests_pr.rs
+++ b/src/tui/app/input/tests_pr.rs
@@ -15,7 +15,7 @@ mod tests {
             active: true,
         };
 
-        let args = create_pr_args(&wt, Some("feature/current"), None, "");
+        let args = create_pr_args(&wt, Some("feature/current"), None, "", &[]);
 
         assert_eq!(args[0], "pr");
         assert_eq!(args[1], "create");


### PR DESCRIPTION
## Summary
- Stop using raw user prompts as auto-created PR titles
- Build PR titles from commit subjects instead
- Move the original prompt into a fenced PR body section
- Add regression coverage for commit-based titles

## Validation
- cargo fmt
- cargo test create_pr_args_uses_commit_as_title *(blocked by existing unrelated compile errors: missing recall_context render_tests module and non-exhaustive StreamChunk/ContentPart matches)*