### PR TITLE
fix: require explicit PR requests from TUI worktrees

### DIFF
--- a/src/session/helper/mod.rs
+++ b/src/session/helper/mod.rs
@@ -32,6 +32,7 @@ pub mod stream;
 pub mod text;
 pub mod token;
 pub mod validation;
+mod workspace_tools;
 
 #[cfg(test)]
 mod prompt_events_test_provider;

--- a/src/session/helper/request_state.rs
+++ b/src/session/helper/request_state.rs
@@ -7,6 +7,7 @@ use crate::tool::ToolRegistry;
 use super::bootstrap::{inject_tool_prompt, list_tools_bootstrap_definition};
 use super::provider::{prefers_temperature_one, temperature_is_deprecated};
 use super::runtime::{is_interactive_tool, is_local_cuda_provider, local_cuda_light_system_prompt};
+use super::workspace_tools::registry_for_cwd;
 
 pub(crate) struct ProviderStepState {
     pub tool_registry: Arc<ToolRegistry>,
@@ -23,7 +24,7 @@ pub(crate) fn build_provider_step_state(
     model: &str,
     cwd: &Path,
 ) -> ProviderStepState {
-    let tool_registry = ToolRegistry::with_provider_arc(provider, model.to_string());
+    let tool_registry = registry_for_cwd(provider, model, cwd);
     let tool_definitions: Vec<_> = tool_registry
         .definitions()
         .into_iter()

--- a/src/session/helper/workspace_tools.rs
+++ b/src/session/helper/workspace_tools.rs
@@ -3,8 +3,8 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::provider::Provider;
-use crate::tool::{ToolRegistry, bash, lsp};
+use crate::provider::{Provider, ProviderRegistry};
+use crate::tool::{ToolRegistry, bash, batch, lsp, search_router};
 
 /// Build a provider registry whose shell/LSP tools target `cwd`.
 pub(crate) fn registry_for_cwd(
@@ -12,11 +12,44 @@ pub(crate) fn registry_for_cwd(
     model: &str,
     cwd: &Path,
 ) -> Arc<ToolRegistry> {
-    let mut registry = ToolRegistry::with_provider(provider, model.to_string());
+    let mut registry = ToolRegistry::with_provider(Arc::clone(&provider), model.to_string());
     registry.register(Arc::new(bash::BashTool::with_cwd(cwd.to_path_buf())));
-    registry.register(Arc::new(lsp::LspTool::with_root(format!(
-        "file://{}",
-        cwd.display()
+    registry.register(Arc::new(lsp::LspTool::with_root(file_uri(cwd))));
+    register_search(&mut registry, provider);
+    with_batch(registry)
+}
+
+fn register_search(registry: &mut ToolRegistry, provider: Arc<dyn Provider>) {
+    let mut providers = ProviderRegistry::new();
+    providers.register(provider);
+    registry.register(Arc::new(search_router::SearchTool::new(Arc::new(
+        providers,
     ))));
-    Arc::new(registry)
+}
+
+fn with_batch(mut registry: ToolRegistry) -> Arc<ToolRegistry> {
+    let batch_tool = Arc::new(batch::BatchTool::new());
+    registry.register(batch_tool.clone());
+    let registry = Arc::new(registry);
+    batch_tool.set_registry(Arc::downgrade(&registry));
+    registry
+}
+
+fn file_uri(path: &Path) -> String {
+    let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let raw = path.to_string_lossy().replace('\\', "/");
+    format!("file://{}", encode_path(&raw))
+}
+
+fn encode_path(path: &str) -> String {
+    path.bytes().map(encode_byte).collect()
+}
+
+fn encode_byte(byte: u8) -> String {
+    match byte {
+        b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'/' | b'-' | b'_' | b'.' | b'~' => {
+            (byte as char).to_string()
+        }
+        _ => format!("%{byte:02X}"),
+    }
 }

--- a/src/session/helper/workspace_tools.rs
+++ b/src/session/helper/workspace_tools.rs
@@ -1,0 +1,22 @@
+//! Workspace-scoped tool registry construction.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::provider::Provider;
+use crate::tool::{ToolRegistry, bash, lsp};
+
+/// Build a provider registry whose shell/LSP tools target `cwd`.
+pub(crate) fn registry_for_cwd(
+    provider: Arc<dyn Provider>,
+    model: &str,
+    cwd: &Path,
+) -> Arc<ToolRegistry> {
+    let mut registry = ToolRegistry::with_provider(provider, model.to_string());
+    registry.register(Arc::new(bash::BashTool::with_cwd(cwd.to_path_buf())));
+    registry.register(Arc::new(lsp::LspTool::with_root(format!(
+        "file://{}",
+        cwd.display()
+    ))));
+    Arc::new(registry)
+}

--- a/src/tool/bash.rs
+++ b/src/tool/bash.rs
@@ -597,6 +597,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bash_with_default_cwd_runs_there() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::with_cwd(dir.path().to_path_buf());
+        let result = tool.execute(json!({ "command": "pwd" })).await.unwrap();
+        assert!(result.output.contains(&dir.path().display().to_string()));
+    }
+
+    #[tokio::test]
     async fn unsandboxed_bash_timeout_reports_unsafe_metadata() {
         let tool = BashTool {
             timeout_secs: 1,

--- a/src/tool/bash.rs
+++ b/src/tool/bash.rs
@@ -600,8 +600,12 @@ mod tests {
     async fn bash_with_default_cwd_runs_there() {
         let dir = tempfile::tempdir().unwrap();
         let tool = BashTool::with_cwd(dir.path().to_path_buf());
-        let result = tool.execute(json!({ "command": "pwd" })).await.unwrap();
-        assert!(result.output.contains(&dir.path().display().to_string()));
+        let result = tool.execute(json!({ "command": "pwd -P" })).await.unwrap();
+        let expected = std::fs::canonicalize(dir.path()).unwrap();
+        assert_eq!(
+            std::path::Path::new(result.output.trim()),
+            expected.as_path()
+        );
     }
 
     #[tokio::test]

--- a/src/tui/app/input/merge.rs
+++ b/src/tui/app/input/merge.rs
@@ -26,13 +26,13 @@ pub(super) async fn push_or_merge(
         }
         Err(e) => {
             tracing::warn!(error = %e, "PR creation failed, attempting local merge");
-            recover_with_local_merge(mgr, wt).await;
+            merge_locally(mgr, wt).await;
         }
     }
 }
 
 /// Attempt a local git merge as a recovery path.
-async fn recover_with_local_merge(mgr: &WorktreeManager, wt: &WorktreeInfo) {
+pub(super) async fn merge_locally(mgr: &WorktreeManager, wt: &WorktreeInfo) {
     match mgr.merge(&wt.name).await {
         Ok(mr) if mr.success => {
             tracing::info!(

--- a/src/tui/app/input/mod.rs
+++ b/src/tui/app/input/mod.rs
@@ -26,6 +26,7 @@ mod pr_body;
 mod pr_command;
 mod pr_description;
 mod pr_helpers;
+mod pr_request;
 mod pr_title;
 mod sessions;
 mod tests_enter;

--- a/src/tui/app/input/pr_request.rs
+++ b/src/tui/app/input/pr_request.rs
@@ -1,0 +1,31 @@
+//! Detect explicit user intent to publish a pull request.
+
+const PR_PHRASES: [&str; 6] = [
+    "create a pr",
+    "create pr",
+    "open a pr",
+    "open pr",
+    "create a pull request",
+    "open a pull request",
+];
+
+/// Return true when the prompt explicitly asks to publish a PR.
+pub(super) fn wants_pr(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    PR_PHRASES.iter().any(|phrase| lower.contains(phrase))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_explicit_pr_request() {
+        assert!(wants_pr("commit this and create a PR"));
+    }
+
+    #[test]
+    fn ignores_regular_work_request() {
+        assert!(!wants_pr("fix the failing tests"));
+    }
+}

--- a/src/tui/app/input/pr_request.rs
+++ b/src/tui/app/input/pr_request.rs
@@ -12,7 +12,20 @@ const PR_PHRASES: [&str; 6] = [
 /// Return true when the prompt explicitly asks to publish a PR.
 pub(super) fn wants_pr(prompt: &str) -> bool {
     let lower = prompt.to_ascii_lowercase();
-    PR_PHRASES.iter().any(|phrase| lower.contains(phrase))
+    PR_PHRASES
+        .iter()
+        .any(|phrase| contains_phrase(&lower, phrase))
+}
+
+fn contains_phrase(text: &str, phrase: &str) -> bool {
+    text.match_indices(phrase)
+        .any(|(idx, _)| has_boundaries(text, phrase, idx))
+}
+
+fn has_boundaries(text: &str, phrase: &str, idx: usize) -> bool {
+    let before = text[..idx].chars().next_back();
+    let after = text[idx + phrase.len()..].chars().next();
+    !before.is_some_and(char::is_alphanumeric) && !after.is_some_and(char::is_alphanumeric)
 }
 
 #[cfg(test)]
@@ -25,7 +38,8 @@ mod tests {
     }
 
     #[test]
-    fn ignores_regular_work_request() {
-        assert!(!wants_pr("fix the failing tests"));
+    fn rejects_substring_matches() {
+        assert!(!wants_pr("create a program"));
+        assert!(!wants_pr("open product notes"));
     }
 }

--- a/src/tui/app/input/worktree_result.rs
+++ b/src/tui/app/input/worktree_result.rs
@@ -11,7 +11,8 @@ use tokio::sync::mpsc;
 use crate::provider::ProviderRegistry;
 use crate::session::{ImageAttachment, Session, SessionEvent};
 
-use super::merge::push_or_merge;
+use super::merge::{merge_locally, push_or_merge};
+use super::pr_request::wants_pr;
 use super::worktree::WorktreeState;
 
 /// Run the prompt against the provider and restore the
@@ -46,7 +47,10 @@ pub(super) async fn handle_worktree_result(
         return;
     };
     if result.is_ok() {
-        push_or_merge(&mgr, &wt, base_branch.as_deref(), prompt).await;
+        match prompt.filter(|p| wants_pr(p)) {
+            Some(p) => push_or_merge(&mgr, &wt, base_branch.as_deref(), Some(p)).await,
+            None => merge_locally(&mgr, &wt).await,
+        }
     }
     if let Err(e) = mgr.cleanup(&wt.name).await {
         tracing::warn!(error = %e, "Failed to cleanup TUI worktree");

--- a/src/tui/app/input/worktree_result.rs
+++ b/src/tui/app/input/worktree_result.rs
@@ -34,10 +34,10 @@ pub(super) async fn run_prompt(
         })
 }
 
-/// Handle worktree merge/PR and cleanup after prompt.
+/// Handle worktree publishing or local merge after a prompt.
 ///
-/// Pushes a PR on success, recovers with local merge on PR
-/// failure, and always cleans up the worktree.
+/// Creates a PR only when the prompt explicitly asks for one;
+/// otherwise merges the successful worktree locally and cleans up.
 pub(super) async fn handle_worktree_result(
     result: &anyhow::Result<Session>,
     worktree: Option<WorktreeState>,


### PR DESCRIPTION
## Summary
- Stop auto-creating GitHub PRs after every successful TUI worktree run
- Only publish a PR when the user prompt explicitly asks for one
- Otherwise merge the isolated worktree locally and clean it up
- Scope bash and LSP tools to the session/worktree cwd so commands run inside the active worktree by default

## Validation
- cargo fmt
- cargo test wants_pr *(blocked by existing unrelated compile errors on main: missing recall_context render_tests module and non-exhaustive StreamChunk/ContentPart matches)*

Depends on/related to #159, which improves PR title/body quality when PR creation is explicitly requested.