### PR TITLE
--- Begin pasted text #1 (237 lines, 9586 bytes) ---








### DIFF
--- a/src/a2a/server.rs
+++ b/src/a2a/server.rs
@@ -137,13 +137,24 @@ async fn get_agent_card(State(server): State<A2AServer>) -> Json<AgentCard> {
     Json(server.agent_card.clone())
 }
 
-
 fn emit_a2a_inbound(server: &A2AServer, task_id: &str, message: &Message) {
-    emit_a2a_message(server, task_id, "remote-a2a", &server.agent_card.name, message);
+    emit_a2a_message(
+        server,
+        task_id,
+        "remote-a2a",
+        &server.agent_card.name,
+        message,
+    );
 }
 
 fn emit_a2a_outbound(server: &A2AServer, task_id: &str, message: &Message) {
-    emit_a2a_message(server, task_id, &server.agent_card.name, "remote-a2a", message);
+    emit_a2a_message(
+        server,
+        task_id,
+        &server.agent_card.name,
+        "remote-a2a",
+        message,
+    );
 }
 
 fn emit_a2a_message(server: &A2AServer, task_id: &str, from: &str, to: &str, message: &Message) {

--- a/src/provider/deepseek/convert.rs
+++ b/src/provider/deepseek/convert.rs
@@ -33,10 +33,7 @@ fn assistant_msg(m: &Message) -> Value {
     let txt = convert_helpers::collect_text(m);
     let calls = convert_helpers::collect_calls(m);
     let reason = convert_helpers::collect_thinking(m);
-    tracing::debug!(
-        tool_calls = calls.len(),
-        "DeepSeek convert assistant msg"
-    );
+    tracing::debug!(tool_calls = calls.len(), "DeepSeek convert assistant msg");
     if calls.is_empty() {
         let mut val = json!({"role": "assistant", "content": txt});
         if !reason.is_empty() {

--- a/src/provider/deepseek/convert_helpers.rs
+++ b/src/provider/deepseek/convert_helpers.rs
@@ -31,7 +31,10 @@ pub(super) fn collect_calls(m: &Message) -> Vec<Value> {
         .iter()
         .filter_map(|p| match p {
             ContentPart::ToolCall {
-                id, name, arguments, ..
+                id,
+                name,
+                arguments,
+                ..
             } => Some(json!({
                 "id": id,
                 "type": "function",

--- a/src/provider/deepseek/stream.rs
+++ b/src/provider/deepseek/stream.rs
@@ -26,7 +26,12 @@ pub(crate) async fn exec(
             ContentPart::Thinking { text } => {
                 chunks.push(StreamChunk::Thinking(text.clone()));
             }
-            ContentPart::ToolCall { id, name, arguments, .. } => {
+            ContentPart::ToolCall {
+                id,
+                name,
+                arguments,
+                ..
+            } => {
                 chunks.push(StreamChunk::ToolCallStart {
                     id: id.clone(),
                     name: name.clone(),
@@ -37,6 +42,9 @@ pub(crate) async fn exec(
                 });
                 chunks.push(StreamChunk::ToolCallEnd { id: id.clone() });
             }
+            ContentPart::Image { .. }
+            | ContentPart::File { .. }
+            | ContentPart::ToolResult { .. } => {}
         }
     }
 

--- a/src/provider/limits.rs
+++ b/src/provider/limits.rs
@@ -52,7 +52,11 @@ pub fn context_window_for_model(model: &str) -> usize {
         131_072
     } else if m.contains("deepseek-v4") {
         1_048_576
-    } else if m.contains("deepseek-r1") || m.contains("deepseek-v3") || m.contains("deepseek-chat") || m.contains("deepseek-reasoner") {
+    } else if m.contains("deepseek-r1")
+        || m.contains("deepseek-v3")
+        || m.contains("deepseek-chat")
+        || m.contains("deepseek-reasoner")
+    {
         128_000
     } else if m.contains("llama-4") || m.contains("llama4") {
         256_000

--- a/src/provider/openai_codex.rs
+++ b/src/provider/openai_codex.rs
@@ -1654,7 +1654,7 @@ impl OpenAiCodexProvider {
 
         while let Some(chunk) = stream.next().await {
             match chunk {
-                StreamChunk::Text(delta) => text.push_str(&delta),
+                StreamChunk::Text(delta) | StreamChunk::Thinking(delta) => text.push_str(&delta),
                 StreamChunk::ToolCallStart { id, name } => {
                     let next_idx = tools.len();
                     let idx = *tool_index_by_id.entry(id.clone()).or_insert(next_idx);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1862,7 +1862,8 @@ async fn openai_chat_completions(
 
             while let Some(chunk) = provider_stream.next().await {
                 match chunk {
-                    crate::provider::StreamChunk::Text(text) => {
+                    crate::provider::StreamChunk::Text(text)
+                    | crate::provider::StreamChunk::Thinking(text) => {
                         if text.is_empty() {
                             continue;
                         }

--- a/src/session/helper/recall_context/flatten.rs
+++ b/src/session/helper/recall_context/flatten.rs
@@ -1,8 +1,8 @@
 //! Budget-aware session flattening for recall.
 
+use super::render::render_part;
 use crate::provider::Message;
 use crate::rlm::RlmChunker;
-use super::render::render_part;
 
 /// Maximum estimated tokens per session for recall.
 const RECALL_TOKEN_BUDGET: usize = 30_000;
@@ -13,10 +13,7 @@ pub fn flatten_messages(messages: &[Message]) -> (String, bool) {
 }
 
 /// Budget-aware flattening with a running token count (O(N), not O(N²)).
-pub fn flatten_messages_with_budget(
-    messages: &[Message],
-    budget: usize,
-) -> (String, bool) {
+pub fn flatten_messages_with_budget(messages: &[Message], budget: usize) -> (String, bool) {
     let mut out = String::with_capacity(budget * 4);
     let mut tokens = 0usize;
     let mut truncated = false;
@@ -30,7 +27,10 @@ pub fn flatten_messages_with_budget(
         let hdr = format!("[{idx} {role}]\n");
         let hdr_tok = RlmChunker::estimate_tokens(&hdr);
 
-        if tokens + hdr_tok > budget { truncated = true; break; }
+        if tokens + hdr_tok > budget {
+            truncated = true;
+            break;
+        }
         out.push_str(&hdr);
         tokens += hdr_tok;
 
@@ -38,7 +38,10 @@ pub fn flatten_messages_with_budget(
             let seg = render_part(part);
             let seg_tok = RlmChunker::estimate_tokens(&seg);
             if tokens + seg_tok > budget {
-                if tokens + marker_tok <= budget { out.push_str(marker); tokens += marker_tok; }
+                if tokens + marker_tok <= budget {
+                    out.push_str(marker);
+                    tokens += marker_tok;
+                }
                 truncated = true;
                 break;
             }
@@ -46,7 +49,10 @@ pub fn flatten_messages_with_budget(
             tokens += seg_tok;
         }
 
-        if tokens + sep_tok > budget { truncated = true; break; }
+        if tokens + sep_tok > budget {
+            truncated = true;
+            break;
+        }
         out.push_str(sep);
         tokens += sep_tok;
     }

--- a/src/session/helper/recall_context/render.rs
+++ b/src/session/helper/recall_context/render.rs
@@ -13,7 +13,10 @@ pub fn render_part(part: &ContentPart) -> String {
         ContentPart::Text { text } => format!("{text}\n"),
         ContentPart::Thinking { .. } => String::new(),
         ContentPart::ToolCall {
-            id, name, arguments, ..
+            id,
+            name,
+            arguments,
+            ..
         } => {
             let args = truncate_bytes(arguments, MAX_FIELD_BYTES);
             format!("[ToolCall id={id} name={name}]\nargs: {args}\n")
@@ -23,7 +26,11 @@ pub fn render_part(part: &ContentPart) -> String {
             content,
         } => {
             let preview = truncate_bytes(content, MAX_FIELD_BYTES);
-            let tail = if content.len() > MAX_FIELD_BYTES { " [...truncated]" } else { "" };
+            let tail = if content.len() > MAX_FIELD_BYTES {
+                " [...truncated]"
+            } else {
+                ""
+            };
             format!("[ToolResult id={tool_call_id}]\n{preview}{tail}\n")
         }
         ContentPart::Image { mime_type, url } => {
@@ -39,7 +46,9 @@ pub fn render_part(part: &ContentPart) -> String {
 
 /// Truncate to `max_len` bytes, respecting char boundaries.
 pub(crate) fn truncate_bytes(s: &str, max_len: usize) -> &str {
-    if s.len() <= max_len { return s; }
+    if s.len() <= max_len {
+        return s;
+    }
     let mut end = max_len;
     while !s.is_char_boundary(end) && end > 0 {
         end -= 1;

--- a/src/session/helper/recall_context/render_tests.rs
+++ b/src/session/helper/recall_context/render_tests.rs
@@ -5,7 +5,9 @@ use super::*;
 #[test]
 fn skips_thinking() {
     use crate::provider::ContentPart;
-    let part = ContentPart::Thinking { text: "reasoning".into() };
+    let part = ContentPart::Thinking {
+        text: "reasoning".into(),
+    };
     assert!(render_part(&part).is_empty());
 }
 
@@ -13,7 +15,10 @@ fn skips_thinking() {
 fn truncates_tool_result() {
     use crate::provider::ContentPart;
     let big = "x".repeat(5000);
-    let part = ContentPart::ToolResult { tool_call_id: "c1".into(), content: big };
+    let part = ContentPart::ToolResult {
+        tool_call_id: "c1".into(),
+        content: big,
+    };
     assert!(render_part(&part).contains("[...truncated]"));
 }
 

--- a/src/session/helper/recall_context/tests.rs
+++ b/src/session/helper/recall_context/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for budget-aware message flattening.
 
-use crate::provider::{ContentPart, Message, Role};
 use super::flatten::flatten_messages_with_budget;
+use crate::provider::{ContentPart, Message, Role};
 
 #[test]
 fn respects_token_budget() {

--- a/src/session/helper/stream.rs
+++ b/src/session/helper/stream.rs
@@ -92,7 +92,7 @@ pub async fn collect_stream_completion_with_events(
 
     while let Some(chunk) = stream.next().await {
         match chunk {
-            StreamChunk::Text(delta) => {
+            StreamChunk::Text(delta) | StreamChunk::Thinking(delta) => {
                 if delta.is_empty() {
                     continue;
                 }

--- a/src/tool/session_recall/context.rs
+++ b/src/tool/session_recall/context.rs
@@ -20,11 +20,7 @@ pub async fn build_recall_context(
     let mut ctx = String::new();
     let mut sources = Vec::with_capacity(sessions.len());
     for s in &sessions {
-        let label = format!(
-            "{} ({})",
-            s.title.as_deref().unwrap_or("<untitled>"),
-            &s.id
-        );
+        let label = format!("{} ({})", s.title.as_deref().unwrap_or("<untitled>"), &s.id);
         sources.push(label.clone());
         ctx.push_str(&format!(
             "\n===== SESSION {label} — updated {} =====\n",

--- a/src/tool/session_recall/faults.rs
+++ b/src/tool/session_recall/faults.rs
@@ -13,7 +13,9 @@ pub fn fault_from_error(err: &anyhow::Error) -> Fault {
     {
         Fault::NoMatch
     } else {
-        Fault::BackendError { reason: err.to_string() }
+        Fault::BackendError {
+            reason: err.to_string(),
+        }
     }
 }
 

--- a/src/tool/session_recall/rlm_run.rs
+++ b/src/tool/session_recall/rlm_run.rs
@@ -10,17 +10,25 @@ use std::sync::Arc;
 
 /// Run RLM processing against the flattened recall context.
 pub async fn run_recall(
-    context: &str, sources: &[String], query: &str,
-    provider: Arc<dyn Provider>, model: &str, config: &RlmConfig,
+    context: &str,
+    sources: &[String],
+    query: &str,
+    provider: Arc<dyn Provider>,
+    model: &str,
+    config: &RlmConfig,
 ) -> Result<ToolResult> {
     let auto_ctx = AutoProcessContext {
         tool_id: "session_recall",
         tool_args: json!({ "query": query }),
         session_id: "session-recall-tool",
-        abort: None, on_progress: None,
-        provider, model: model.to_string(),
-        bus: None, trace_id: None,
-        subcall_provider: None, subcall_model: None,
+        abort: None,
+        on_progress: None,
+        provider,
+        model: model.to_string(),
+        bus: None,
+        trace_id: None,
+        subcall_provider: None,
+        subcall_model: None,
     };
     let framed = format!(
         "Recall task: {query}\n\nUse the session transcript below \
@@ -30,12 +38,17 @@ pub async fn run_recall(
     match RlmRouter::auto_process(&framed, auto_ctx, config).await {
         Ok(result) => Ok(ToolResult::success(format!(
             "Recalled from {} session(s): {}\n(RLM: {} → {} tokens, {} iterations)\n\n{}",
-            sources.len(), sources.join(", "),
-            result.stats.input_tokens, result.stats.output_tokens,
-            result.stats.iterations, result.processed,
+            sources.len(),
+            sources.join(", "),
+            result.stats.input_tokens,
+            result.stats.output_tokens,
+            result.stats.iterations,
+            result.processed,
         ))),
         Err(e) => Ok(super::faults::fault_result(
-            crate::session::Fault::BackendError { reason: e.to_string() },
+            crate::session::Fault::BackendError {
+                reason: e.to_string(),
+            },
             format!("RLM recall failed: {e}"),
         )),
     }

--- a/src/tool/session_recall/tool_struct.rs
+++ b/src/tool/session_recall/tool_struct.rs
@@ -27,16 +27,28 @@ pub struct SessionRecallTool {
 
 impl SessionRecallTool {
     pub fn new(provider: Arc<dyn Provider>, model: String, config: RlmConfig) -> Self {
-        Self { provider, model, config }
+        Self {
+            provider,
+            model,
+            config,
+        }
     }
 }
 
 #[async_trait]
 impl Tool for SessionRecallTool {
-    fn id(&self) -> &str { "session_recall" }
-    fn name(&self) -> &str { "SessionRecall" }
-    fn description(&self) -> &str { DESCRIPTION }
-    fn parameters(&self) -> serde_json::Value { super::schema::parameters() }
+    fn id(&self) -> &str {
+        "session_recall"
+    }
+    fn name(&self) -> &str {
+        "SessionRecall"
+    }
+    fn description(&self) -> &str {
+        DESCRIPTION
+    }
+    fn parameters(&self) -> serde_json::Value {
+        super::schema::parameters()
+    }
 
     async fn execute(&self, args: serde_json::Value) -> Result<ToolResult> {
         let query = match args["query"].as_str() {
@@ -44,17 +56,35 @@ impl Tool for SessionRecallTool {
             _ => return Ok(ToolResult::error("query is required")),
         };
         let sid = args["session_id"].as_str().map(str::to_string);
-        let limit = args["limit"].as_u64().map(|n| n as usize)
-            .unwrap_or(DEFAULT_SESSION_LIMIT).clamp(1, MAX_SESSION_LIMIT);
+        let limit = args["limit"]
+            .as_u64()
+            .map(|n| n as usize)
+            .unwrap_or(DEFAULT_SESSION_LIMIT)
+            .clamp(1, MAX_SESSION_LIMIT);
 
         let (ctx, sources) = match super::context::build_recall_context(sid, limit).await {
             Ok(ok) => ok,
-            Err(e) => return Ok(super::faults::fault_result(
-                super::faults::fault_from_error(&e), format!("recall load failed: {e}"))),
+            Err(e) => {
+                return Ok(super::faults::fault_result(
+                    super::faults::fault_from_error(&e),
+                    format!("recall load failed: {e}"),
+                ));
+            }
         };
-        if ctx.trim().is_empty() { return Ok(super::faults::fault_result(
-            crate::session::Fault::NoMatch, "No prior session history found.")); }
-        super::rlm_run::run_recall(&ctx, &sources, &query,
-            Arc::clone(&self.provider), &self.model, &self.config).await
+        if ctx.trim().is_empty() {
+            return Ok(super::faults::fault_result(
+                crate::session::Fault::NoMatch,
+                "No prior session history found.",
+            ));
+        }
+        super::rlm_run::run_recall(
+            &ctx,
+            &sources,
+            &query,
+            Arc::clone(&self.provider),
+            &self.model,
+            &self.config,
+        )
+        .await
     }
 }

--- a/src/tui/bus_log.rs
+++ b/src/tui/bus_log.rs
@@ -159,7 +159,11 @@ impl BusLogEntry {
                     if is_a2a { "A2A•PEER" } else { "BEAT" }.to_string(),
                     format!("{agent_id} [{status}]"),
                     format!("Agent: {agent_id}\nStatus: {status}"),
-                    if is_a2a { Color::LightCyan } else { Color::DarkGray },
+                    if is_a2a {
+                        Color::LightCyan
+                    } else {
+                        Color::DarkGray
+                    },
                 )
             }
             BusMessage::RalphLearning {


### PR DESCRIPTION
**Prompt:** 

--- Begin pasted text #1 (237 lines, 9586 bytes) ---







riley@ubuntu-dev:~/A2A-Server-MCP/codetether-agent$ cargo install --path .
  Installing codetether-agent v4.7.0 (/home/riley/A2A-Server-MCP/codetether-agent)
    Updating crates.io index
    Updating git repository `https://github.com/kiln-rs/kiln.git`
warning: patch `candle-kernels v0.9.2 (/home/riley/A2A-Server-MCP/codetether-agent/vendor/candle-kernels)` was not used in the crate graph
help: Check that the patched package version and available features are compatible
      with the dependency requirements. If the patch has a different version from
      what is locked in the Cargo.lock file, run `cargo update` to use the new
      version. This may also occur with an optional dependency that is not enabled.
     Locking 688 packages to latest Rust 1.95.0 compatible versions
      Adding async-openai v0.32.4 (available: v0.36.1)
      Adding candle-core v0.9.2 (available: v0.10.2)
      Adding candle-transformers v0.9.2 (available: v0.10.2)
      Adding cpal v0.15.3 (available: v0.17.3)
      Adding generic-array v0.14.7 (available: v0.14.9)
      Adding hmac v0.12.1 (available: v0.13.0)
      Adding if-addrs v0.13.4 (available: v0.15.0)
      Adding jsonwebtoken v9.3.1 (available: v10.3.0)
      Adding matchit v0.8.4 (available: v0.8.6)
      Adding mdns-sd v0.13.11 (available: v0.19.1)
      Adding minio v0.3.0 (available: v0.4.0)
      Adding sha2 v0.10.9 (available: v0.11.0)
      Adding similar v2.7.0 (available: v3.1.0)
      Adding tokenizers v0.22.2 (available: v0.23.1)
      Adding tokio-tungstenite v0.28.0 (available: v0.29.0)
      Adding toml v0.9.12+spec-1.1.0 (available: v1.1.2+spec-1.1.0)
      Adding tree-sitter v0.24.7 (available: v0.26.8)
      Adding tree-sitter-rust v0.23.3 (available: v0.24.2)
      Adding vaultrs v0.7.4 (available: v0.8.0)
   Compiling codetether-agent v4.7.0 (/home/riley/A2A-Server-MCP/codetether-agent)
warning: unused import: `MAX_CACHED_SUMMARIES`
  --> src/session/index/cache.rs:10:20
   |
10 | use super::types::{MAX_CACHED_SUMMARIES, SummaryNode, SummaryRange};
   |                    ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: unused import: `super::super::index::types::SummaryRange`
  --> src/session/index_produce/build_context.rs:21:9
   |
21 |     use super::super::index::types::SummaryRange;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `std::sync::Arc`
  --> src/session/index_produce/mod.rs:10:5
   |
10 | use std::sync::Arc;
   |     ^^^^^^^^^^^^^^

warning: unused import: `Result`
  --> src/session/index_produce/mod.rs:12:28
   |
12 | use anyhow::{Context as _, Result};
   |                            ^^^^^^

warning: unused import: `tracing::info`
  --> src/session/index_produce/mod.rs:13:5
   |
13 | use tracing::info;
   |     ^^^^^^^^^^^^^

warning: unused imports: `Granularity`, `SummaryNode`, and `SummaryRange`
  --> src/session/index_produce/mod.rs:15:27
   |
15 | use super::index::types::{Granularity, SummaryNode, SummaryRange};
   |                           ^^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^

warning: unused import: `Message`
  --> src/session/index_produce/mod.rs:16:23
   |
16 | use crate::provider::{Message, Provider};
   |                       ^^^^^^^

warning: unused import: `crate::rlm::RlmConfig`
  --> src/session/index_produce/mod.rs:17:5
   |
17 | use crate::rlm::RlmConfig;
   |     ^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `crate::session::eval::PolicyRunResult`
  --> src/session/oracle_replay.rs:10:5
   |
10 | use crate::session::eval::PolicyRunResult;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `anyhow::Result`
 --> src/tool/context_summarize/logic.rs:5:5
  |
5 | use anyhow::Result;
  |     ^^^^^^^^^^^^^^

error[E0004]: non-exhaustive patterns: `provider::types::StreamChunk::Thinking(_)` not covered
   --> src/session/helper/stream.rs:94:15
    |
 94 |         match chunk {
    |               ^^^^^ pattern `provider::types::StreamChunk::Thinking(_)` not covered
    |
note: `provider::types::StreamChunk` defined here
   --> src/provider/types.rs:208:10
    |
208 | pub enum StreamChunk {
    |          ^^^^^^^^^^^
...
212 |     Thinking(String),
    |     -------- not covered
    = note: the matched value is of type `provider::types::StreamChunk`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
148 ~             StreamChunk::Error(message) => anyhow::bail!(message),
149 ~             provider::types::StreamChunk::Thinking(_) => todo!(),
    |

error[E0004]: non-exhaustive patterns: `&provider::types::ContentPart::Image { .. }`, `&provider::types::ContentPart::File { .. }` and `&provider::types::ContentPart::ToolResult { .. }` not covered
  --> src/provider/deepseek/stream.rs:22:15
   |
22 |         match part {
   |               ^^^^ patterns `&provider::types::ContentPart::Image { .. }`, `&provider::types::ContentPart::File { .. }` and `&provider::types::ContentPart::ToolResult { .. }` not covered
   |
note: `provider::types::ContentPart` defined here
  --> src/provider/types.rs:68:10
   |
68 | pub enum ContentPart {
   |          ^^^^^^^^^^^
...
72 |     Image {
   |     ----- not covered
...
77 |     File {
   |     ---- not covered
...
91 |     ToolResult {
   |     ---------- not covered
   = note: the matched value is of type `&provider::types::ContentPart`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
   |
39 ~             },
40 +             &provider::types::ContentPart::Image { .. } | &provider::types::ContentPart::File { .. } | &provider::types::ContentPart::ToolResult { .. } => todo!()
   |

error[E0004]: non-exhaustive patterns: `provider::types::StreamChunk::Thinking(_)` not covered
    --> src/provider/openai_codex.rs:1656:19
     |
1656 |             match chunk {
     |                   ^^^^^ pattern `provider::types::StreamChunk::Thinking(_)` not covered
     |
note: `provider::types::StreamChunk` defined here
    --> src/provider/types.rs:208:10
     |
 208 | pub enum StreamChunk {
     |          ^^^^^^^^^^^
...
 212 |     Thinking(String),
     |     -------- not covered
     = note: the matched value is of type `provider::types::StreamChunk`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
     |
1693 ~                 StreamChunk::Error(message) => anyhow::bail!(message),
1694 ~                 provider::types::StreamChunk::Thinking(_) => todo!(),
     |

error[E0004]: non-exhaustive patterns: `provider::types::StreamChunk::Thinking(_)` not covered
    --> src/server/mod.rs:1864:23
     |
1864 |                 match chunk {
     |                       ^^^^^ pattern `provider::types::StreamChunk::Thinking(_)` not covered
     |
note: `provider::types::StreamChunk` defined here
    --> src/provider/types.rs:208:10
     |
 208 | pub enum StreamChunk {
     |          ^^^^^^^^^^^
...
 212 |     Thinking(String),
     |     -------- not covered
     = note: the matched value is of type `provider::types::StreamChunk`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
     |
1946 ~                     },
1947 +                     provider::types::StreamChunk::Thinking(_) => todo!()
     |

warning: variable does not need to be mutable
    --> src/server/mod.rs:1832:13
     |
1832 |         let mut provider_stream =
     |             ----^^^^^^^^^^^^^^^
     |             |
     |             help: remove this `mut`
     |
     = note: `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default

warning: unused import: `Provider`
  --> src/session/index_produce/mod.rs:16:32
   |
16 | use crate::provider::{Message, Provider};
   |                                ^^^^^^^^

warning: unused import: `Context`
  --> src/session/index_produce/mod.rs:12:14
   |
12 | use anyhow::{Context as _, Result};
   |              ^^^^^^^

warning: unused variable: `provider_stream`
    --> src/server/mod.rs:1832:13
     |
1832 |         let mut provider_stream =
     |             ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_provider_stream`
     |
     = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

warning: unused variable: `stream_id`
    --> src/server/mod.rs:1846:13
     |
1846 |         let stream_id = chat_id.clone();
     |             ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_stream_id`

warning: unused variable: `stream_model`
    --> src/server/mod.rs:1847:13
     |
1847 |         let stream_model = openai_model.clone();
     |             ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_stream_model`

For more information about this error, try `rustc --explain E0004`.
warning: `codetether-agent` (lib) generated 16 warnings
error: could not compile `codetether-agent` (lib) due to 4 previous errors; 16 warnings emitted
error: failed to compile `codetether-agent v4.7.0 (/home/riley/A2A-Server-MCP/codetether-agent)`, intermediate artifacts can be found at `/home/riley/A2A-Server-MCP/codetether-agent/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.
riley@ubuntu-dev:~/A2A-Server-MCP/codetether-agent$ 
--- End pasted text #1 ---

- 21cbe69 codetether: TUI agent work (tui_21f2793b86ba43ffbaeb33cbe6a93771)