### PR TITLE
fix: S3 sink panic on pre-epoch system clock

### DIFF
--- a/src/event_stream/s3_sink.rs
+++ b/src/event_stream/s3_sink.rs
@@ -288,19 +288,12 @@ impl S3Sink {
             return Ok(url);
         }
 
-        use std::time::{SystemTime, UNIX_EPOCH};
-
         let endpoint = self.endpoint_url();
         let path = format!("/{}", s3_key);
 
         // Generate AWS Signature V4 headers
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default();
-        let date = chrono::DateTime::from_timestamp(now.as_secs() as i64, 0)
-            .map(|dt| dt.format("%Y%m%dT%H%M%SZ").to_string())
-            .unwrap_or_default();
-        let _date_only = &date[..8];
+        let now = chrono::Utc::now();
+        let date = now.format("%Y%m%dT%H%M%SZ").to_string();
 
         let content_hash = sha256_hex_bytes(data);
 

--- a/src/event_stream/s3_sink.rs
+++ b/src/event_stream/s3_sink.rs
@@ -294,7 +294,9 @@ impl S3Sink {
         let path = format!("/{}", s3_key);
 
         // Generate AWS Signature V4 headers
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
         let date = chrono::DateTime::from_timestamp(now.as_secs() as i64, 0)
             .map(|dt| dt.format("%Y%m%dT%H%M%SZ").to_string())
             .unwrap_or_default();


### PR DESCRIPTION
## Summary
Replaces `.unwrap()` with `.unwrap_or_default()` on `SystemTime::now().duration_since(UNIX_EPOCH)` in S3 sink upload path.

## Problem
The `.unwrap()` panics if the system clock is before the Unix epoch (misconfigured VMs, embedded systems without RTC).

## Fix
```rust
// Before
let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();

// After  
let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
```

Closes #171