### PR TITLE
fix: prevent auction NaN panic in swarm marketplace

### DIFF
--- a/src/marketplace/auction.rs
+++ b/src/marketplace/auction.rs
@@ -28,10 +28,11 @@ pub fn resolve_auction(auction: &mut KrAuction) -> Option<String> {
     if auction.bids.is_empty() {
         return None;
     }
-    let winner = auction
-        .bids
-        .iter()
-        .max_by(|a, b| a.expected_value().partial_cmp(&b.expected_value()).unwrap())?;
+    let winner = auction.bids.iter().max_by(|a, b| {
+        a.expected_value()
+            .partial_cmp(&b.expected_value())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })?;
     auction.status = AuctionStatus::Awarded;
     Some(winner.agent_id.clone())
 }

--- a/src/marketplace/auction.rs
+++ b/src/marketplace/auction.rs
@@ -24,15 +24,22 @@ pub enum AuctionStatus {
 }
 
 /// Resolve an auction — pick the best bid by expected value.
+///
+/// Bids with NaN expected values are excluded to prevent nondeterministic
+/// winner selection via `partial_cmp` returning `None`.
 pub fn resolve_auction(auction: &mut KrAuction) -> Option<String> {
     if auction.bids.is_empty() {
         return None;
     }
-    let winner = auction.bids.iter().max_by(|a, b| {
-        a.expected_value()
-            .partial_cmp(&b.expected_value())
-            .unwrap_or(std::cmp::Ordering::Equal)
-    })?;
+    let winner = auction
+        .bids
+        .iter()
+        .filter(|b| !b.expected_value().is_nan())
+        .max_by(|a, b| {
+            a.expected_value()
+                .partial_cmp(&b.expected_value())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })?;
     auction.status = AuctionStatus::Awarded;
     Some(winner.agent_id.clone())
 }


### PR DESCRIPTION
## Summary
Replaces `.partial_cmp().unwrap()` with `.partial_cmp().unwrap_or(Ordering::Equal)` in auction resolution.

## Problem
`partial_cmp()` returns `None` when comparing `NaN` floats, causing `.unwrap()` to panic. This can happen if any bid has a `NaN` expected value (e.g., from division by zero).

## Fix
```rust
// Before
.max_by(|a, b| a.expected_value().partial_cmp(&b.expected_value()).unwrap())

// After
.max_by(|a, b| {
    a.expected_value()
        .partial_cmp(&b.expected_value())
        .unwrap_or(std::cmp::Ordering::Equal)
})
```

Closes #172