### PR TITLE
fix: stop leaking moltbook API key to stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1398,11 +1398,14 @@ async fn main() -> anyhow::Result<()> {
 
                     println!("✅ Registered successfully!\n");
                     println!("   Agent:             {}", reg.name);
-                    println!("   API Key:           {}", result.agent.api_key);
                     println!("   Claim URL:         {}", result.agent.claim_url);
                     println!("   Verification Code: {}", result.agent.verification_code);
                     println!("\n🔗 Send the claim URL to your human to verify ownership.");
-                    println!("🔐 API key has been saved to Vault (codetether/moltbook).");
+                    if result.vault_saved {
+                        println!("🔐 API key has been saved to Vault (codetether/moltbook).");
+                    } else {
+                        println!("⚠️  Could not save API key to Vault. Check VAULT_ADDR/VAULT_TOKEN and save it manually.");
+                    }
                     Ok(())
                 }
                 MoltbookCommand::Status => {

--- a/src/moltbook/mod.rs
+++ b/src/moltbook/mod.rs
@@ -204,12 +204,7 @@ impl MoltbookClient {
 
         // Persist the key in Vault automatically
         if let Err(e) = Self::save_key_to_vault(&parsed.agent.api_key).await {
-            tracing::warn!("Could not auto-save key to Vault: {e}");
-            eprintln!(
-                "\n⚠️  Could not save API key to Vault. Store it manually:\n   \
-                 MOLTBOOK_API_KEY={}\n",
-                parsed.agent.api_key
-            );
+            tracing::error!("Could not auto-save API key to Vault: {e}. Run `codetether config vault` to check Vault connectivity and store the key manually.");
         }
 
         Ok(parsed)

--- a/src/moltbook/mod.rs
+++ b/src/moltbook/mod.rs
@@ -25,6 +25,9 @@ const VAULT_PROVIDER_ID: &str = "moltbook";
 pub struct RegisterResponse {
     pub agent: RegisteredAgent,
     pub important: Option<String>,
+    /// Whether the API key was persisted to HashiCorp Vault.
+    #[serde(default)]
+    pub vault_saved: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,11 +206,24 @@ impl MoltbookClient {
             serde_json::from_str(&body).context("Failed to parse registration response")?;
 
         // Persist the key in Vault automatically
-        if let Err(e) = Self::save_key_to_vault(&parsed.agent.api_key).await {
-            tracing::error!("Could not auto-save API key to Vault: {e}. Run `codetether config vault` to check Vault connectivity and store the key manually.");
-        }
+        let vault_saved = match Self::save_key_to_vault(&parsed.agent.api_key).await {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    "Could not auto-save API key to Vault. \
+                     Set VAULT_ADDR and VAULT_TOKEN, then store the key manually \
+                     at codetether/moltbook."
+                );
+                false
+            }
+        };
 
-        Ok(parsed)
+        Ok(RegisterResponse {
+            agent: parsed.agent,
+            important: parsed.important,
+            vault_saved,
+        })
     }
 
     // ------- profile --------------------------------------------------------


### PR DESCRIPTION
## Summary
Removes the `eprintln!` that prints the raw API key to stderr when Vault save fails. Replaced with `tracing::error!` that directs users to check Vault configuration.

## Problem
When Vault save fails, the API key was printed verbatim to stderr:
```
MOLTBOOK_API_KEY=sk-actual-key-here
```

This can be captured in logs, CI output, terminal history, or container aggregation.

## Fix
```rust
// Before
eprintln!("\n⚠️  ... MOLTBOOK_API_KEY={}\n", parsed.agent.api_key);

// After
tracing::error!("... Run `codetether config vault` to check Vault connectivity...");
```

Closes #182