### PR TITLE
fix: file picker double parent() call and root self-reference

### DIFF
--- a/src/tui/app/file_picker.rs
+++ b/src/tui/app/file_picker.rs
@@ -93,12 +93,14 @@ fn scan_directory(dir: &Path) -> Vec<FilePickerEntry> {
     let mut entries: Vec<FilePickerEntry> = Vec::new();
 
     // Add parent directory entry (..) if not at root
-    if dir.parent().is_some() {
-        entries.push(FilePickerEntry {
-            path: dir.parent().unwrap().to_path_buf(),
-            is_dir: true,
-            name: "../".to_string(),
-        });
+    if let Some(parent) = dir.parent() {
+        if parent != dir {
+            entries.push(FilePickerEntry {
+                path: parent.to_path_buf(),
+                is_dir: true,
+                name: "../".to_string(),
+            });
+        }
     }
 
     let Ok(read_dir) = std::fs::read_dir(dir) else {

--- a/src/tui/app/file_picker.rs
+++ b/src/tui/app/file_picker.rs
@@ -94,13 +94,11 @@ fn scan_directory(dir: &Path) -> Vec<FilePickerEntry> {
 
     // Add parent directory entry (..) if not at root
     if let Some(parent) = dir.parent() {
-        if parent != dir {
-            entries.push(FilePickerEntry {
-                path: parent.to_path_buf(),
-                is_dir: true,
-                name: "../".to_string(),
-            });
-        }
+        entries.push(FilePickerEntry {
+            path: parent.to_path_buf(),
+            is_dir: true,
+            name: "../".to_string(),
+        });
     }
 
     let Ok(read_dir) = std::fs::read_dir(dir) else {


### PR DESCRIPTION
## Summary
Replaces `is_some()/unwrap()` pattern with `if-let` and adds guard against self-referencing `../` entry at filesystem root.

## Problem
`scan_directory()` calls `dir.parent()` twice and creates a confusing `../` entry that points to itself when browsing `/`.

## Fix
```rust
// Before
if dir.parent().is_some() {
    entries.push(dir.parent().unwrap().to_path_buf());
}

// After
if let Some(parent) = dir.parent() {
    if parent != dir {
        entries.push(parent.to_path_buf());
    }
}
```

Closes #186