### PR TITLE
fix: preserve parent workspace for sub-agent sessions

### DIFF
--- a/script/verify_pr.sh
+++ b/script/verify_pr.sh
@@ -13,7 +13,23 @@ TOTAL=0
 SIGNED=0
 UNSIGNED=0
 
+is_github_pr_merge_commit() {
+    local commit="$1"
+    local parent_count
+    parent_count=$(git show -s --format="%P" "$commit" | wc -w | tr -d ' ')
+    [ "$parent_count" = "2" ] || return 1
+
+    local subject
+    subject=$(git log -1 --format="%s" "$commit")
+    echo "$subject" | grep -Eq '^Merge [0-9a-f]{40} into [0-9a-f]{40}$'
+}
+
 for COMMIT in $COMMITS; do
+    if is_github_pr_merge_commit "$COMMIT"; then
+        echo "  ⏭️  $COMMIT — skipping GitHub pull-request merge commit"
+        continue
+    fi
+
     TOTAL=$((TOTAL + 1))
     BODY=$(git log -1 --format="%b" "$COMMIT")
     if echo "$BODY" | grep -qi "^CodeTether-Provenance-ID:"; then

--- a/src/session/helper/runtime/context.rs
+++ b/src/session/helper/runtime/context.rs
@@ -22,6 +22,7 @@ use std::path::Path;
 ///
 /// assert_eq!(enriched["path"], "/workspace/src/lib.rs");
 /// assert_eq!(enriched["__ct_session_id"], "session-1");
+/// assert_eq!(enriched["__ct_parent_workspace"], "/workspace");
 /// ```
 pub fn enrich_tool_input_with_runtime_context(
     tool_input: &Value,
@@ -41,9 +42,17 @@ pub fn enrich_tool_input_with_runtime_context(
         if let Some(provenance) = provenance {
             insert_provenance_fields(obj, provenance);
         }
+        insert_parent_workspace(obj, workspace_dir);
         normalize_workspace_paths(obj, workspace_dir);
     }
     enriched
+}
+
+fn insert_parent_workspace(obj: &mut Map<String, Value>, parent_workspace: &Path) {
+    obj.insert(
+        "__ct_parent_workspace".to_string(),
+        json!(parent_workspace.display().to_string()),
+    );
 }
 
 /// Insert a string field into a JSON object only when the value is present.

--- a/src/tool/agent/params.rs
+++ b/src/tool/agent/params.rs
@@ -12,6 +12,7 @@
 //! ```
 
 use serde::Deserialize;
+use std::path::PathBuf;
 
 /// Parsed input payload for the sub-agent management tool.
 ///
@@ -36,4 +37,6 @@ pub(super) struct Params {
     pub model: Option<String>,
     #[serde(default, rename = "__ct_current_model")]
     pub _current_model: Option<String>,
+    #[serde(default, rename = "__ct_parent_workspace")]
+    pub parent_workspace: Option<PathBuf>,
 }

--- a/src/tool/agent/session_factory.rs
+++ b/src/tool/agent/session_factory.rs
@@ -27,21 +27,24 @@
 use crate::provider::{ContentPart, Message, Role};
 use crate::session::Session;
 use anyhow::{Context, Result};
+use std::path::PathBuf;
 
 /// Create a fresh [`Session`] for a spawned sub-agent.
 ///
 /// The session is initialized with:
 /// - `agent_name` set to `name` (used by the TUI / bus for message routing),
 /// - `metadata.model` set to `model` (independent of the parent's model),
+/// - `metadata.directory` set to the parent's workspace/worktree when provided,
 /// - a single system message built by [`build_system_message`] that embeds the
-///   parent process's current working directory plus explicit guidance not to
-///   spend turns on workspace discovery.
+///   same workspace plus explicit guidance not to spend turns on workspace
+///   discovery.
 ///
 /// # Arguments
 ///
 /// * `name` — Sub-agent identifier, e.g. `"reviewer"`. Referenced by users as `@reviewer`.
 /// * `instructions` — Free-form task description merged into the system prompt.
 /// * `model` — Provider model id, e.g. `"zai/glm-5.1"`.
+/// * `parent_workspace` — Workspace/worktree inherited from the parent session.
 ///
 /// # Returns
 ///
@@ -64,6 +67,7 @@ use anyhow::{Context, Result};
 /// //     "tui-cache-fix",
 /// //     "Apply the cache-clone fix in src/tui/app/state.rs and verify cargo check.",
 /// //     "zai/glm-5.1",
+/// //     Some(std::path::PathBuf::from("/workspace/project")),
 /// // ).await?;
 /// // assert_eq!(session.metadata.model.as_deref(), Some("zai/glm-5.1"));
 /// # Ok(()) }
@@ -73,15 +77,18 @@ pub(super) async fn create_agent_session(
     name: &str,
     instructions: &str,
     model: &str,
+    parent_workspace: Option<PathBuf>,
 ) -> Result<Session> {
     let mut session = Session::new().await.context("Failed to create session")?;
+    let workspace = parent_workspace.or_else(|| session.metadata.directory.clone());
     session.set_agent_name(name.to_string());
     session.metadata.model = Some(model.to_string());
+    session.metadata.directory = workspace.clone();
     session.bus = crate::bus::global();
     session.add_message(Message {
         role: Role::System,
         content: vec![ContentPart::Text {
-            text: build_system_message(name, instructions),
+            text: build_system_message(name, instructions, workspace),
         }],
     });
     Ok(session)
@@ -89,27 +96,29 @@ pub(super) async fn create_agent_session(
 
 /// Build the system prompt injected into every spawned sub-agent.
 ///
-/// The prompt embeds the *parent* process's current working directory so the
-/// sub-agent can resolve relative paths immediately, and includes explicit
+/// The prompt embeds the same workspace stored on the spawned child session so
+/// the sub-agent can resolve relative paths immediately, and includes explicit
 /// directives to avoid workspace-discovery tool calls (`pwd`, `ls`, `glob`)
 /// that were observed burning 4–6 turns before any real edit.
 ///
-/// The directory is read from [`std::env::current_dir`] at spawn time and
-/// falls back to the literal string `"<unknown>"` on failure (e.g. the cwd
-/// was deleted). This never panics.
+/// If no workspace was passed from the parent, the directory falls back to
+/// [`std::env::current_dir`] and then the literal string `"<unknown>"`. This
+/// never panics.
 ///
 /// # Arguments
 ///
 /// * `name` — Sub-agent identifier injected as `@{name}`.
 /// * `instructions` — Task description appended to the role preamble.
+/// * `workspace` — Resolved parent workspace/worktree.
 ///
 /// # Returns
 ///
 /// A multi-line system prompt string.
-fn build_system_message(name: &str, instructions: &str) -> String {
-    let cwd = std::env::current_dir()
+fn build_system_message(name: &str, instructions: &str, workspace: Option<PathBuf>) -> String {
+    let cwd = workspace
+        .or_else(|| std::env::current_dir().ok())
         .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| "<unknown>".to_string());
+        .unwrap_or_else(|| "<unknown>".to_string());
     format!(
         "You are @{name}, a specialized sub-agent. {instructions}\n\n\
          Workspace cwd: {cwd}\n\
@@ -121,30 +130,4 @@ fn build_system_message(name: &str, instructions: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::build_system_message;
-
-    #[test]
-    fn includes_agent_name_and_instructions() {
-        let msg = build_system_message("reviewer", "Audit the PR");
-        assert!(msg.contains("@reviewer"));
-        assert!(msg.contains("Audit the PR"));
-    }
-
-    #[test]
-    fn embeds_current_working_directory() {
-        let msg = build_system_message("x", "do the thing");
-        let cwd = std::env::current_dir().unwrap().display().to_string();
-        assert!(
-            msg.contains(&cwd),
-            "system prompt should embed cwd: {cwd}\nmsg: {msg}"
-        );
-    }
-
-    #[test]
-    fn warns_against_discovery_tool_calls() {
-        let msg = build_system_message("x", "y");
-        assert!(msg.contains("Do NOT waste turns discovering the workspace"));
-        assert!(msg.contains("no pwd/ls/glob"));
-    }
-}
+mod tests;

--- a/src/tool/agent/session_factory/tests.rs
+++ b/src/tool/agent/session_factory/tests.rs
@@ -1,0 +1,46 @@
+use super::{build_system_message, create_agent_session};
+use crate::provider::ContentPart;
+use std::path::PathBuf;
+
+#[test]
+fn includes_agent_name_and_instructions() {
+    let msg = build_system_message("reviewer", "Audit the PR", None);
+    assert!(msg.contains("@reviewer"));
+    assert!(msg.contains("Audit the PR"));
+}
+
+#[test]
+fn embeds_current_working_directory() {
+    let msg = build_system_message("x", "do the thing", None);
+    let cwd = std::env::current_dir().unwrap().display().to_string();
+    assert!(
+        msg.contains(&cwd),
+        "system prompt should embed cwd: {cwd}\nmsg: {msg}"
+    );
+}
+
+#[test]
+fn warns_against_discovery_tool_calls() {
+    let msg = build_system_message("x", "y", None);
+    assert!(msg.contains("Do NOT waste turns discovering the workspace"));
+    assert!(msg.contains("no pwd/ls/glob"));
+}
+
+#[tokio::test]
+async fn child_session_uses_parent_workspace_not_process_cwd() {
+    let parent_workspace = PathBuf::from("/tmp/codetether-parent-worktree");
+    let session = create_agent_session(
+        "child",
+        "work in the parent repo",
+        "example/model",
+        Some(parent_workspace.clone()),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(session.metadata.directory, Some(parent_workspace.clone()));
+    let ContentPart::Text { text } = &session.messages[0].content[0] else {
+        panic!("expected system prompt text");
+    };
+    assert!(text.contains(&parent_workspace.display().to_string()));
+}

--- a/src/tool/agent/spawn.rs
+++ b/src/tool/agent/spawn.rs
@@ -31,9 +31,13 @@ pub(super) async fn handle_spawn(params: &Params) -> Result<ToolResult> {
     if let Err(result) = spawn_validation::validate_spawn_request(&request).await {
         return Ok(result);
     }
-    let session =
-        session_factory::create_agent_session(request.name, request.instructions, request.model)
-            .await?;
+    let session = session_factory::create_agent_session(
+        request.name,
+        request.instructions,
+        request.model,
+        request.parent_workspace.clone(),
+    )
+    .await?;
     spawn_store::persist_spawned_agent(request.name, request.instructions, session).await;
     tracing::info!(agent = %request.name, model = %request.model, "Sub-agent spawned");
     Ok(ToolResult::success(success_message(&request)))

--- a/src/tool/agent/spawn_request.rs
+++ b/src/tool/agent/spawn_request.rs
@@ -13,8 +13,9 @@
 
 use super::params::Params;
 use anyhow::{Context, Result};
+use std::path::PathBuf;
 
-/// Borrowed spawn request fields extracted from tool params.
+/// Borrowed spawn request fields plus the runtime-owned parent workspace.
 ///
 /// This avoids cloning large strings while spawn validation and session
 /// creation run.
@@ -28,6 +29,7 @@ pub(super) struct SpawnRequest<'a> {
     pub name: &'a str,
     pub instructions: &'a str,
     pub model: &'a str,
+    pub parent_workspace: Option<PathBuf>,
 }
 
 impl<'a> SpawnRequest<'a> {
@@ -49,6 +51,7 @@ impl<'a> SpawnRequest<'a> {
                 .model
                 .as_deref()
                 .context("model required for spawn")?,
+            parent_workspace: params.parent_workspace.clone(),
         })
     }
 }

--- a/src/tui/app/test_modules.rs
+++ b/src/tui/app/test_modules.rs
@@ -1,0 +1,1 @@
+//! Test-only module namespace.


### PR DESCRIPTION
Fixes #190

Summary:
- Thread the parent workspace through runtime-enriched agent tool input.
- Store the inherited workspace on spawned child sessions and use it in the child system prompt.
- Add regression coverage for child sessions created from a parent workspace that differs from process cwd.
- Make provenance verification ignore GitHub synthetic PR merge commits and add the missing test-only TUI module file needed by clean checkouts.

Review follow-up:
- `__ct_parent_workspace` is now overwritten from runtime context instead of preserving model-supplied input.
- Moved session factory tests into a child test module so `./check_file_limits.sh` passes.
- Removed the `Cargo.lock` version change from the PR.
- Updated `SpawnRequest` docs to reflect the owned parent workspace field.

Validation:
- cargo test child_session_uses_parent_workspace_not_process_cwd -- --nocapture
- ./script/verify_pr.sh origin/main..HEAD
- ./check_file_limits.sh
- git diff --check

CodeTether provenance:
- Issue: #190
- Branch: codetether/issue-190
- Commit: 498b2f5d76e534347c721edd3d7ee079ce83e487
