### PR TITLE
feat: surface TUI context health

### DIFF
--- a/src/session/index_produce/summary_text.rs
+++ b/src/session/index_produce/summary_text.rs
@@ -32,7 +32,10 @@ pub fn clamp_tokens(text: &str, target_tokens: usize) -> String {
     }
     let marker = "\n[summary clamped to requested token budget]";
     let keep = limit.saturating_sub(marker.len());
-    let end = text.floor_char_boundary(keep);
+    let end = (0..=keep)
+        .rev()
+        .find(|index| text.is_char_boundary(*index))
+        .unwrap_or(0);
     format!("{}{}", text[..end].trim_end(), marker)
 }
 

--- a/src/tool/computer_use/platform.rs
+++ b/src/tool/computer_use/platform.rs
@@ -1,6 +1,9 @@
 //! Platform-specific computer use implementations.
 
-use crate::tool::computer_use::{input::ComputerUseInput, response};
+use crate::tool::computer_use::input::ComputerUseInput;
+
+#[cfg(not(target_os = "windows"))]
+use crate::tool::computer_use::response;
 
 #[cfg(target_os = "windows")]
 mod windows;

--- a/src/tui/app/bus_reply.rs
+++ b/src/tui/app/bus_reply.rs
@@ -1,6 +1,5 @@
 //! Emit a bus reply to `from_agent` after a remote task completes.
 
-use crate::bus::BusMessage;
 use crate::tui::app::state::App;
 
 pub fn emit(app: &mut App, status: &str, error: Option<String>) {

--- a/src/tui/app/commands.rs
+++ b/src/tui/app/commands.rs
@@ -207,18 +207,6 @@ async fn handle_mcp_command(app: &mut App, raw: &str) {
 /// - `/goal done [reason]` — clear the goal.
 /// - `/goal reaffirm <note>` — record progress.
 /// - `/goal show` (or bare `/goal`) — print goal + open tasks.
-
-fn handle_context_command(app: &mut App, rest: &str) {
-    match rest.trim() {
-        "" | "status" => {
-            let body = crate::tui::app::context_status::render(&app.state);
-            push_system_message(app, body);
-            app.state.status = "Context status".to_string();
-        }
-        _ => app.state.status = "Usage: /context [status]".to_string(),
-    }
-}
-
 async fn handle_goal_command(app: &mut App, session: &Session, rest: &str) {
     use crate::session::tasks::{TaskEvent, TaskLog, TaskState, governance_block};
     use chrono::Utc;
@@ -300,6 +288,18 @@ async fn handle_goal_command(app: &mut App, session: &Session, rest: &str) {
         Err(e) => {
             app.state.status = format!("/goal write failed: {e}");
         }
+    }
+}
+
+/// Dispatch a `/context ...` command for context/RLM health status.
+fn handle_context_command(app: &mut App, rest: &str) {
+    match rest.trim() {
+        "" | "status" => {
+            let body = crate::tui::app::context_status::render(&app.state);
+            push_system_message(app, body);
+            app.state.status = "Context status".to_string();
+        }
+        _ => app.state.status = "Usage: /context [status]".to_string(),
     }
 }
 

--- a/src/tui/app/commands.rs
+++ b/src/tui/app/commands.rs
@@ -207,6 +207,18 @@ async fn handle_mcp_command(app: &mut App, raw: &str) {
 /// - `/goal done [reason]` — clear the goal.
 /// - `/goal reaffirm <note>` — record progress.
 /// - `/goal show` (or bare `/goal`) — print goal + open tasks.
+
+fn handle_context_command(app: &mut App, rest: &str) {
+    match rest.trim() {
+        "" | "status" => {
+            let body = crate::tui::app::context_status::render(&app.state);
+            push_system_message(app, body);
+            app.state.status = "Context status".to_string();
+        }
+        _ => app.state.status = "Usage: /context [status]".to_string(),
+    }
+}
+
 async fn handle_goal_command(app: &mut App, session: &Session, rest: &str) {
     use crate::session::tasks::{TaskEvent, TaskLog, TaskState, governance_block};
     use chrono::Utc;
@@ -819,6 +831,11 @@ pub async fn handle_slash_command(
         return;
     }
 
+    if let Some(rest) = command_with_optional_args(&normalized, "/context") {
+        handle_context_command(app, rest);
+        return;
+    }
+
     if let Some(rest) = command_with_optional_args(&normalized, "/mcp") {
         handle_mcp_command(app, rest).await;
         return;
@@ -894,8 +911,7 @@ pub async fn handle_slash_command(
         }
         "/git" => {
             let cwd = std::path::PathBuf::from(&app.state.cwd_display);
-            app.state.git =
-                crate::tui::git_capture::capture_git_state(&cwd);
+            app.state.git = crate::tui::git_capture::capture_git_state(&cwd);
             app.state.set_view_mode(ViewMode::Git);
             app.state.status = "Git status".to_string();
         }
@@ -959,17 +975,19 @@ pub async fn handle_slash_command(
             }
         }
         "/recall" => {
-            let beliefs = crate::memory::palace::load_project_beliefs(Path::new(
-                &app.state.cwd_display,
-            ));
+            let beliefs =
+                crate::memory::palace::load_project_beliefs(Path::new(&app.state.cwd_display));
             if beliefs.is_empty() {
                 push_system_message(
                     app,
                     "No project memories found. Memories accumulate as you work.",
                 );
             } else {
-                let active: Vec<&crate::cognition::beliefs::Belief> =
-                    beliefs.iter().filter(|b| b.confidence >= 0.5).take(30).collect();
+                let active: Vec<&crate::cognition::beliefs::Belief> = beliefs
+                    .iter()
+                    .filter(|b| b.confidence >= 0.5)
+                    .take(30)
+                    .collect();
                 let mut lines = vec![format!(
                     "🏰 Project Memory Palace ({} beliefs, {} active)",
                     beliefs.len(),
@@ -987,7 +1005,7 @@ pub async fn handle_slash_command(
         }
         "/keys" => {
             app.state.status =
-                "Protocol-first commands: /protocol /bus /file /autoapply /network /autocomplete /mcp /model /sessions /import-codex /swarm /ralph /latency /symbols /settings /lsp /rlm /chat /new /undo /fork /spawn /kill /agents /agent /audit /git\nEasy aliases: /add /talk /list /remove /focus /home /say /ls /rm /main"
+                "Protocol-first commands: /protocol /bus /context /file /autoapply /network /autocomplete /mcp /model /sessions /import-codex /swarm /ralph /latency /symbols /settings /lsp /rlm /chat /new /undo /fork /spawn /kill /agents /agent /audit /git\nEasy aliases: /add /talk /list /remove /focus /home /say /ls /rm /main"
                     .to_string();
         }
         _ => {}
@@ -1048,6 +1066,7 @@ pub async fn handle_slash_command(
             | "/network"
             | "/autocomplete"
             | "/mcp"
+            | "/context"
             | "/spawn"
             | "/kill"
             | "/agents"

--- a/src/tui/app/context_status.rs
+++ b/src/tui/app/context_status.rs
@@ -1,0 +1,55 @@
+//! Render context/RLM status for slash commands.
+
+use crate::tui::app::state::AppState;
+
+pub fn render(state: &AppState) -> String {
+    [
+        usage_line(state),
+        compaction_line(state),
+        rlm_line(state),
+        truncation_line(state),
+    ]
+    .join("\n")
+}
+
+fn usage_line(state: &AppState) -> String {
+    match (state.context_used, state.context_budget) {
+        (Some(used), Some(budget)) if budget > 0 => {
+            format!(
+                "Context: {used}/{budget} tokens ({:.1}%)",
+                used as f64 * 100.0 / budget as f64
+            )
+        }
+        (Some(used), _) => format!("Context: {used} tokens (budget unknown)"),
+        _ => "Context: no estimate yet".to_string(),
+    }
+}
+
+fn compaction_line(state: &AppState) -> String {
+    format!(
+        "Last compaction: {}",
+        state
+            .context_health
+            .last_compaction
+            .as_deref()
+            .unwrap_or("none")
+    )
+}
+
+fn rlm_line(state: &AppState) -> String {
+    format!(
+        "Last RLM: {}",
+        state.context_health.last_rlm.as_deref().unwrap_or("none")
+    )
+}
+
+fn truncation_line(state: &AppState) -> String {
+    format!(
+        "Last truncation: {}",
+        state
+            .context_health
+            .last_truncation
+            .as_deref()
+            .unwrap_or("none")
+    )
+}

--- a/src/tui/app/context_status_tests.rs
+++ b/src/tui/app/context_status_tests.rs
@@ -1,0 +1,20 @@
+//! Tests for `/context status` rendering.
+
+#[cfg(test)]
+mod tests {
+    use crate::tui::app::context_status::render;
+    use crate::tui::app::state::AppState;
+
+    #[test]
+    fn render_includes_usage_and_recent_events() {
+        let mut state = AppState {
+            context_used: Some(50),
+            context_budget: Some(100),
+            ..Default::default()
+        };
+        state.context_health.last_rlm = Some("done".to_string());
+        let body = render(&state);
+        assert!(body.contains("50.0%"));
+        assert!(body.contains("Last RLM: done"));
+    }
+}

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -6,6 +6,9 @@ pub mod bus_ingest;
 pub mod bus_reply;
 pub mod codex_sessions;
 pub mod commands;
+pub mod context_status;
+#[cfg(test)]
+mod context_status_tests;
 #[path = "event_handlers/mod.rs"]
 pub mod event_handlers;
 #[path = "event_loop/mod.rs"]

--- a/src/tui/app/session_events.rs
+++ b/src/tui/app/session_events.rs
@@ -217,29 +217,69 @@ pub async fn handle_session_event(
             app.state.context_budget = Some(est.budget);
         }
         SessionEvent::ContextTruncated(t) => {
-            app.state.messages.push(ChatMessage::new(
-                MessageType::System,
-                format!("⚠ Context truncated — dropped {} tokens", t.dropped_tokens),
-            ));
-        }
-        SessionEvent::CompactionStarted(_) => {
-            app.state.status = "Compacting context…".to_string();
-        }
-        SessionEvent::CompactionCompleted(o) => {
-            app.state.context_used = Some(o.after_tokens);
+            app.state.context_health.note_truncation(&t);
             app.state.messages.push(ChatMessage::new(
                 MessageType::System,
                 format!(
-                    "Context compacted ({}): {} → {} tokens",
-                    o.strategy.as_str(),
-                    o.before_tokens,
-                    o.after_tokens
+                    "⚠ Context truncated — dropped {} tokens, kept {} messages",
+                    t.dropped_tokens, t.kept_messages
+                ),
+            ));
+        }
+        SessionEvent::CompactionStarted(start) => {
+            app.state.status = format!(
+                "Compacting context… {} tokens over {} budget",
+                start.before_tokens, start.budget
+            );
+        }
+        SessionEvent::CompactionCompleted(outcome) => {
+            app.state.context_used = Some(outcome.after_tokens);
+            app.state.context_health.note_compaction(&outcome);
+            app.state.messages.push(ChatMessage::new(
+                MessageType::System,
+                format!(
+                    "Context compacted ({}): {} → {} tokens ({:.0}% reduction, kept {} messages)",
+                    outcome.strategy.as_str(),
+                    outcome.before_tokens,
+                    outcome.after_tokens,
+                    outcome.reduction() * 100.0,
+                    outcome.kept_messages
                 ),
             ));
             app.state.status = "Ready".to_string();
         }
-        // Other non-exhaustive variants (TokenUsage, RlmProgress,
-        // RlmComplete, CompactionFailed, RlmSubcallFallback) are consumed
+        SessionEvent::CompactionFailed(failure) => {
+            app.state.status = "Context compaction failed".to_string();
+            app.state.messages.push(ChatMessage::new(
+                MessageType::Error,
+                format!(
+                    "Context compaction failed: {} ({} / {} tokens)",
+                    failure.reason, failure.after_tokens, failure.budget
+                ),
+            ));
+        }
+        SessionEvent::RlmProgress(progress) => {
+            app.state.context_health.note_rlm_progress(&progress);
+            app.state.status = format!(
+                "RLM {} {}/{}",
+                progress.status, progress.iteration, progress.max_iterations
+            );
+        }
+        SessionEvent::RlmComplete(done) => {
+            app.state.context_health.note_rlm_complete(&done);
+            app.state.messages.push(ChatMessage::new(
+                MessageType::System,
+                format!(
+                    "RLM {:?}: {} → {} tokens, {} iterations, {} ms",
+                    done.outcome,
+                    done.input_tokens,
+                    done.output_tokens,
+                    done.iterations,
+                    done.elapsed_ms
+                ),
+            ));
+        }
+        // Other non-exhaustive variants (TokenUsage, RlmSubcallFallback) are consumed
         // by dedicated SessionBus subscribers, not this legacy mpsc handler.
         _ => {}
     }

--- a/src/tui/app/session_events.rs
+++ b/src/tui/app/session_events.rs
@@ -267,6 +267,7 @@ pub async fn handle_session_event(
         }
         SessionEvent::RlmComplete(done) => {
             app.state.context_health.note_rlm_complete(&done);
+            app.state.status = format!("RLM complete: {:?}", done.outcome);
             app.state.messages.push(ChatMessage::new(
                 MessageType::System,
                 format!(

--- a/src/tui/app/state/context_health.rs
+++ b/src/tui/app/state/context_health.rs
@@ -12,7 +12,7 @@ pub struct ContextHealthState {
 impl ContextHealthState {
     pub fn note_compaction(&mut self, event: &CompactionOutcome) {
         self.last_compaction = Some(format!(
-            "{}: {} → {} tokens ({:.0}% reduction, kept {} msgs)",
+            "{}: {} → {} tokens ({:.0}% reduction, kept {} messages)",
             event.strategy.as_str(),
             event.before_tokens,
             event.after_tokens,
@@ -33,7 +33,7 @@ impl ContextHealthState {
 
     pub fn note_rlm_complete(&mut self, event: &RlmCompletion) {
         self.last_rlm = Some(format!(
-            "{:?}: {} → {} tokens, {} iter, {} ms",
+            "{:?}: {} → {} tokens, {} iterations, {} ms",
             event.outcome,
             event.input_tokens,
             event.output_tokens,
@@ -44,7 +44,7 @@ impl ContextHealthState {
 
     pub fn note_truncation(&mut self, event: &ContextTruncation) {
         self.last_truncation = Some(format!(
-            "dropped {} tokens, kept {} msgs",
+            "dropped {} tokens, kept {} messages",
             event.dropped_tokens, event.kept_messages
         ));
     }

--- a/src/tui/app/state/context_health.rs
+++ b/src/tui/app/state/context_health.rs
@@ -1,0 +1,51 @@
+//! Context/RLM health snapshot stored by the TUI.
+
+use crate::session::{CompactionOutcome, ContextTruncation, RlmCompletion, RlmProgressEvent};
+
+#[derive(Debug, Clone, Default)]
+pub struct ContextHealthState {
+    pub last_compaction: Option<String>,
+    pub last_rlm: Option<String>,
+    pub last_truncation: Option<String>,
+}
+
+impl ContextHealthState {
+    pub fn note_compaction(&mut self, event: &CompactionOutcome) {
+        self.last_compaction = Some(format!(
+            "{}: {} → {} tokens ({:.0}% reduction, kept {} msgs)",
+            event.strategy.as_str(),
+            event.before_tokens,
+            event.after_tokens,
+            event.reduction() * 100.0,
+            event.kept_messages
+        ));
+    }
+
+    pub fn note_rlm_progress(&mut self, event: &RlmProgressEvent) {
+        self.last_rlm = Some(format!(
+            "running {}/{} ({:.0}%): {}",
+            event.iteration,
+            event.max_iterations,
+            event.fraction() * 100.0,
+            event.status
+        ));
+    }
+
+    pub fn note_rlm_complete(&mut self, event: &RlmCompletion) {
+        self.last_rlm = Some(format!(
+            "{:?}: {} → {} tokens, {} iter, {} ms",
+            event.outcome,
+            event.input_tokens,
+            event.output_tokens,
+            event.iterations,
+            event.elapsed_ms
+        ));
+    }
+
+    pub fn note_truncation(&mut self, event: &ContextTruncation) {
+        self.last_truncation = Some(format!(
+            "dropped {} tokens, kept {} msgs",
+            event.dropped_tokens, event.kept_messages
+        ));
+    }
+}

--- a/src/tui/app/state/default_impl.rs
+++ b/src/tui/app/state/default_impl.rs
@@ -69,6 +69,7 @@ impl Default for super::AppState {
             last_completion_output_tokens: None,
             context_used: None,
             context_budget: None,
+            context_health: Default::default(),
             last_tool_name: None,
             last_tool_latency_ms: None,
             last_tool_success: None,

--- a/src/tui/app/state/mod.rs
+++ b/src/tui/app/state/mod.rs
@@ -21,6 +21,7 @@
 pub mod agent_profile;
 #[path = "latency/chat.rs"]
 pub mod chat_latency;
+pub mod context_health;
 pub mod default_impl;
 pub mod git_state;
 pub mod history;
@@ -138,6 +139,7 @@ pub struct AppState {
     pub context_used: Option<usize>,
     /// Usable token budget paired with [`AppState::context_used`].
     pub context_budget: Option<usize>,
+    pub context_health: context_health::ContextHealthState,
     pub last_tool_name: Option<String>,
     pub last_tool_latency_ms: Option<u64>,
     pub last_tool_success: Option<bool>,

--- a/src/tui/app/test_modules.rs
+++ b/src/tui/app/test_modules.rs
@@ -1,0 +1,1 @@
+//! Test-only module aggregator for TUI app tests.


### PR DESCRIPTION
## Summary
- Adds a TUI context/RLM health sidecar state.
- Adds `/context status` to show current context estimate, last compaction, last RLM run, and last truncation.
- Surfaces compaction, truncation, RLM progress, RLM completion, and compaction failures in chat/status.
- Adds focused context status test and missing test module shim.

Closes #234

## Validation
- `cargo test --lib context_status -- --nocapture`
- `git diff --check` for touched files

## Notes
This implements the first vertical slice of the full TUI audit roadmap. Larger refactors of `commands.rs`, `session_events.rs`, formatter, state nesting, command palette, task drawer, and health strip should continue in follow-up PRs.
