### PR TITLE
perf: reuse TUI worker stream HTTP client

### DIFF
--- a/src/tui/worker_bridge.rs
+++ b/src/tui/worker_bridge.rs
@@ -164,7 +164,7 @@ impl TuiWorkerBridge {
                     let server = server.clone();
                     let token = token.clone();
                     let worker_id = worker_id.clone();
-                    let worker_name = worker_name.clone(); let client = client.clone();
+                    let (worker_name, client) = (worker_name.clone(), client.clone());
                     async move {
                         loop {
                             let url = format!(

--- a/src/tui/worker_bridge.rs
+++ b/src/tui/worker_bridge.rs
@@ -164,7 +164,7 @@ impl TuiWorkerBridge {
                     let server = server.clone();
                     let token = token.clone();
                     let worker_id = worker_id.clone();
-                    let worker_name = worker_name.clone();
+                    let worker_name = worker_name.clone(); let client = client.clone();
                     async move {
                         loop {
                             let url = format!(
@@ -174,7 +174,7 @@ impl TuiWorkerBridge {
                                 urlencoding::encode(&worker_id)
                             );
 
-                            let req = Client::new()
+                            let req = client
                                 .get(&url)
                                 .header("Accept", "text/event-stream")
                                 .header("X-Worker-ID", &worker_id)


### PR DESCRIPTION
## Summary
- reuse the existing TUI worker bridge reqwest client for task SSE reconnects
- preserve connection pooling/TLS config instead of constructing a fresh client each reconnect

## Validation
- ./check_file_limits.sh src/tui/worker_bridge.rs

Note: per repo instructions, did not run cargo build/check.