### PR TITLE
perf: reuse shared HTTP client for Moltbook

### DIFF
--- a/src/moltbook/mod.rs
+++ b/src/moltbook/mod.rs
@@ -126,7 +126,7 @@ impl MoltbookClient {
     /// Build a client from a known API key.
     pub fn new(api_key: String) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            http: crate::provider::shared_http::shared_client().clone(),
             api_key,
         }
     }
@@ -183,7 +183,7 @@ impl MoltbookClient {
     pub async fn register(name: &str, extra_description: Option<&str>) -> Result<RegisterResponse> {
         let description = build_codetether_description(name, extra_description);
 
-        let http = reqwest::Client::new();
+        let http = crate::provider::shared_http::shared_client();
         let resp = http
             .post(format!("{}/agents/register", API_BASE))
             .header("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- use the process-wide shared reqwest client for Moltbook authenticated clients
- use the same shared client for registration calls
- avoids rebuilding TLS/root-store state and duplicate connection pools for Moltbook operations

## Validation
- ./check_file_limits.sh src/moltbook/mod.rs

Note: per repo instructions, did not run cargo build/check.