### PR TITLE
perf: reuse shared HTTP client for Ralph verification

### DIFF
--- a/src/ralph/verification.rs
+++ b/src/ralph/verification.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 pub async fn run_story_verification(root: &Path, story: &UserStory) -> Result<()> {
     let mut failures = Vec::new();
-    let client = reqwest::Client::new();
+    let client = crate::provider::shared_http::shared_client();
     for (index, item) in story.verification_steps.iter().enumerate() {
         if let Err(error) = step::run(root, item, &client).await {
             failures.push(format!("step {}: {error}", index + 1));


### PR DESCRIPTION
## Summary
- use the process-wide shared reqwest client for Ralph URL verification steps
- avoids creating a fresh TLS config and connection pool for every story verification run

## Validation
- ./check_file_limits.sh src/ralph/verification.rs

Note: per repo instructions, did not run cargo build/check.