### PR TITLE
perf: reuse shared HTTP client for Morph backend

### DIFF
--- a/src/tool/morph_backend.rs
+++ b/src/tool/morph_backend.rs
@@ -139,7 +139,7 @@ async fn apply_with_direct_openrouter(prompt: &str, base_url: &str) -> Result<St
         }]
     });
 
-    let client = reqwest::Client::new();
+    let client = crate::provider::shared_http::shared_client();
     let resp = client
         .post(format!("{base_url}/chat/completions"))
         .header("Authorization", format!("Bearer {api_key}"))


### PR DESCRIPTION
## Summary
- use the process-wide shared reqwest client for direct OpenRouter Morph backend calls
- avoids rebuilding TLS/root-store state and a separate connection pool for each direct Morph edit

## Validation
- ./check_file_limits.sh src/tool/morph_backend.rs

Note: per repo instructions, did not run cargo build/check.