### PR TITLE
perf: reuse shared HTTP client for A2A client

### DIFF
--- a/src/a2a/client.rs
+++ b/src/a2a/client.rs
@@ -16,7 +16,7 @@ impl A2AClient {
     /// Create a new A2A client
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
-            client: Client::new(),
+            client: crate::provider::shared_http::shared_client().clone(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
             auth: None,
         }


### PR DESCRIPTION
## Summary
- initialize A2AClient with the process-wide shared reqwest client
- lets A2A RPC calls share TLS setup and connection pooling with other HTTP users

## Validation
- ./check_file_limits.sh src/a2a/client.rs

Note: per repo instructions, did not run cargo build/check.