### PR TITLE
perf: reuse shared HTTP client for CLI server commands

### DIFF
--- a/src/cli/ob_login.rs
+++ b/src/cli/ob_login.rs
@@ -6,7 +6,6 @@ use crate::cli::auth::{
 };
 use crate::cli::onboard::{DEFAULT_SERVER, prompt_line};
 use anyhow::Result;
-use reqwest::Client;
 
 pub async fn login_interactive() -> Result<Option<SavedCredentials>> {
     let email = prompt_line("Email: ")?;
@@ -19,7 +18,7 @@ pub async fn login_interactive() -> Result<Option<SavedCredentials>> {
     }
 
     println!("Logging in...");
-    let client = Client::new();
+    let client = crate::provider::shared_http::shared_client().clone();
     let login = login_with_password(&client, DEFAULT_SERVER, &email, &password).await?;
     write_saved_credentials(DEFAULT_SERVER, &email, &login)?;
     println!("Logged in as {email}.\n");

--- a/src/cli/ob_register.rs
+++ b/src/cli/ob_register.rs
@@ -6,7 +6,6 @@ use crate::cli::auth::{
 };
 use crate::cli::onboard::{DEFAULT_SERVER, prompt_line};
 use anyhow::{Context, Result};
-use reqwest::Client;
 use serde_json::json;
 
 pub async fn register_and_login() -> Result<Option<SavedCredentials>> {
@@ -24,7 +23,7 @@ pub async fn register_and_login() -> Result<Option<SavedCredentials>> {
     }
 
     println!("Creating your account...");
-    let client = Client::new();
+    let client = crate::provider::shared_http::shared_client().clone();
     let resp = client
         .post(format!("{DEFAULT_SERVER}/v1/users/register"))
         .header("Content-Type", "application/json")

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -1,7 +1,6 @@
 use super::TaskArgs;
 use crate::cli::auth::load_saved_credentials;
 use anyhow::{Context, Result};
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -46,7 +45,7 @@ pub async fn execute(
     global_project: Option<PathBuf>,
 ) -> Result<()> {
     let (server, token) = resolve_server_and_token(default_server, default_token)?;
-    let client = Client::new();
+    let client = crate::provider::shared_http::shared_client().clone();
 
     let workspace_id = match args.workspace_id.clone() {
         Some(workspace_id) => workspace_id,


### PR DESCRIPTION
## Summary
- reuse the process-wide reqwest client for onboarding login/register flows
- reuse it for the task trigger command
- removes one-off client construction while keeping call behavior unchanged

## Validation
- ./check_file_limits.sh src/cli/ob_login.rs src/cli/ob_register.rs src/cli/task.rs

Note: per repo instructions, did not run cargo build/check.