### PR TITLE
fix: capacity-guarding global allocator to prevent OOM aborts

### DIFF
--- a/src/crash.rs
+++ b/src/crash.rs
@@ -200,11 +200,12 @@ pub async fn initialize(config: &Config) {
     let settings = CrashReporterSettings::from_config(config);
     install_panic_hook(settings.clone());
 
-    // Spawn the RSS watchdog alongside the panic hook. The watchdog itself
-    // is idempotent; calling `initialize` twice is a no-op for it. It writes
-    // pre-OOM breadcrumbs into the same spool the crash-report flusher
-    // already drains on next startup.
-    crate::telemetry::rss_watchdog::spawn(settings.report_dir.clone());
+    // Arm the memory guards next to the panic hook: the capacity-guarding
+    // allocator (clean abort + spooled report on a runaway allocation) and
+    // the RSS watchdog (pre-OOM breadcrumbs). Both write into the same spool
+    // the crash-report flusher already drains on next startup, and both are
+    // idempotent, so calling `initialize` twice is harmless.
+    crate::telemetry::install_memory_guards(settings.report_dir.clone());
 
     if !settings.enabled {
         return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,14 @@
 //! A Rust implementation of an AI coding agent with first-class support for
 //! the A2A (Agent-to-Agent) protocol and the CodeTether ecosystem.
 
+/// Process-wide capacity-guarding allocator. Catches a single runaway
+/// allocation (a corrupted capacity hint reserving tens of GiB) and aborts
+/// cleanly with a spooled crash report rather than letting the OS OOM-kill
+/// the process. See [`telemetry::alloc_guard`]. The guard is inert until
+/// [`telemetry::alloc_guard_config::configure`] arms it at startup.
+#[global_allocator]
+static GLOBAL_ALLOC: telemetry::alloc_guard::GuardAlloc = telemetry::alloc_guard::GuardAlloc;
+
 pub mod a2a;
 pub mod agent;
 pub mod audit;

--- a/src/session/helper/recall_context/flatten.rs
+++ b/src/session/helper/recall_context/flatten.rs
@@ -14,7 +14,9 @@ pub fn flatten_messages(messages: &[Message]) -> (String, bool) {
 
 /// Budget-aware flattening with a running token count (O(N), not O(N²)).
 pub fn flatten_messages_with_budget(messages: &[Message], budget: usize) -> (String, bool) {
-    let mut out = String::with_capacity(budget * 4);
+    // Reserve a sane amount up front (the string still grows as needed). A
+    // bogus `budget` must never turn this hint into a multi-GiB reservation.
+    let mut out = String::with_capacity(budget.saturating_mul(4).min(1024 * 1024));
     let mut tokens = 0usize;
     let mut truncated = false;
     let sep = "\n---\n\n";

--- a/src/telemetry/alloc_guard.rs
+++ b/src/telemetry/alloc_guard.rs
@@ -1,0 +1,63 @@
+//! Capacity-guarding global allocator.
+//!
+//! Wraps the system allocator and trips on any *single* allocation request
+//! larger than a configured ceiling — far above any legitimate working set
+//! for this agent. A corrupted capacity computation that tries to reserve
+//! tens of gigabytes (the `memory allocation of N bytes failed` class of
+//! crash) is caught here: the [`report`](super::alloc_guard_report) module
+//! captures a backtrace, spools a crash report, and aborts cleanly instead
+//! of leaving the OS OOM-killer to `SIGKILL` the process with no clue why.
+//!
+//! The hot path is a single relaxed atomic load plus a compare. The ceiling
+//! is `0` (disabled) until
+//! [`configure`](super::alloc_guard_config::configure) runs at startup, so
+//! allocations made before configuration always pass straight through.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Per-allocation hard ceiling in bytes. `0` means "not yet configured".
+pub(crate) static CEILING: AtomicUsize = AtomicUsize::new(0);
+
+/// Crash-report spool directory, recorded at configuration time so the trip
+/// handler can write without re-deriving platform paths under duress.
+pub(crate) static SPOOL_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// The installed global allocator. Delegates every request to [`System`],
+/// guarding only the requested size.
+pub struct GuardAlloc;
+
+#[inline]
+fn check(size: usize) {
+    let ceiling = CEILING.load(Ordering::Relaxed);
+    if ceiling != 0 && size > ceiling {
+        super::alloc_guard_report::trip(size, ceiling);
+    }
+}
+
+unsafe impl GlobalAlloc for GuardAlloc {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        check(layout.size());
+        unsafe { System.alloc(layout) }
+    }
+
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        check(layout.size());
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        check(new_size);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}

--- a/src/telemetry/alloc_guard_command.rs
+++ b/src/telemetry/alloc_guard_command.rs
@@ -1,0 +1,19 @@
+//! Command-line capture for allocator crash reports.
+
+use std::ffi::OsString;
+
+/// Return the current command line without panicking on invalid Unicode.
+pub(crate) fn command_line() -> String {
+    command_line_from(std::env::args_os())
+}
+
+/// Join command-line arguments using lossy UTF-8 conversion.
+pub(crate) fn command_line_from<I>(args: I) -> String
+where
+    I: IntoIterator<Item = OsString>,
+{
+    args.into_iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/src/telemetry/alloc_guard_config.rs
+++ b/src/telemetry/alloc_guard_config.rs
@@ -1,0 +1,63 @@
+//! Startup configuration for the
+//! [capacity-guarding allocator](super::alloc_guard).
+//!
+//! Resolves the per-allocation ceiling from physical RAM (default 75%) with
+//! env overrides, then records the crash-report spool directory so the trip
+//! handler can write a breadcrumb.
+
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+
+use super::alloc_guard::{CEILING, SPOOL_DIR};
+
+/// Absolute ceiling override, in MiB. Wins over the RAM-percent path.
+const ENV_CEILING_MIB: &str = "CODETETHER_ALLOC_CEILING_MIB";
+/// Ceiling as a percent of physical RAM (default 75, clamped to 10..=95).
+const ENV_CEILING_RAM_PCT: &str = "CODETETHER_ALLOC_CEILING_RAM_PCT";
+
+/// Floor so the guard never trips on modest legitimate allocations, even on
+/// small machines or when RAM detection fails.
+const MIN_CEILING_BYTES: usize = 2 * 1024 * 1024 * 1024;
+/// Assumed RAM when detection is unavailable (e.g. non-Unix) and no
+/// override is set — keeps the guard armed at a sane level everywhere.
+const FALLBACK_RAM_BYTES: usize = 16 * 1024 * 1024 * 1024;
+
+/// Arm the allocator guard. Call once, early in process startup. Idempotent
+/// for the spool dir; the ceiling is simply restored on repeat calls.
+pub fn configure(spool_dir: PathBuf) {
+    let _ = SPOOL_DIR.set(spool_dir);
+    CEILING.store(resolve_ceiling(), Ordering::Relaxed);
+}
+
+fn resolve_ceiling() -> usize {
+    if let Some(mib) = env_usize(ENV_CEILING_MIB) {
+        return mib.saturating_mul(1024 * 1024).max(MIN_CEILING_BYTES);
+    }
+    let pct = env_usize(ENV_CEILING_RAM_PCT).unwrap_or(75).clamp(10, 95);
+    let ram = match total_ram_bytes() {
+        0 => FALLBACK_RAM_BYTES,
+        n => n,
+    };
+    (ram / 100).saturating_mul(pct).max(MIN_CEILING_BYTES)
+}
+
+fn env_usize(var: &str) -> Option<usize> {
+    std::env::var(var).ok()?.trim().parse().ok()
+}
+
+#[cfg(unix)]
+fn total_ram_bytes() -> usize {
+    // SAFETY: `sysconf` takes a constant name and is always valid to call.
+    let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if pages > 0 && page > 0 {
+        (pages as usize).saturating_mul(page as usize)
+    } else {
+        0
+    }
+}
+
+#[cfg(not(unix))]
+fn total_ram_bytes() -> usize {
+    0
+}

--- a/src/telemetry/alloc_guard_report.rs
+++ b/src/telemetry/alloc_guard_report.rs
@@ -1,0 +1,64 @@
+//! Trip handler for the [capacity-guarding allocator](super::alloc_guard).
+//!
+//! Runs only when a single allocation exceeds the ceiling — never on a
+//! healthy process. It captures a backtrace and spools a crash report in the
+//! same JSON shape the panic flusher already drains, then aborts. Because we
+//! are about to abort anyway, the small allocations made here (backtrace,
+//! JSON) are fine: they are far below the ceiling and pass straight through.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use chrono::Utc;
+use serde_json::json;
+
+use super::alloc_guard::SPOOL_DIR;
+use super::memory::MemorySnapshot;
+
+/// Handle an over-ceiling allocation: diagnose, spool, and abort. Marked
+/// cold and never-inline so it stays entirely off the allocator hot path.
+#[cold]
+#[inline(never)]
+pub(crate) fn trip(size: usize, ceiling: usize) -> ! {
+    // Guard against re-entrancy: if spooling itself tripped the guard, just
+    // abort rather than recursing.
+    static IN_TRIP: AtomicBool = AtomicBool::new(false);
+    if IN_TRIP.swap(true, Ordering::SeqCst) {
+        std::process::abort();
+    }
+
+    let backtrace = std::backtrace::Backtrace::force_capture().to_string();
+    eprintln!(
+        "\nFATAL: single allocation of {size} bytes exceeds the {ceiling}-byte alloc \
+         guard ceiling.\nThis is a runaway capacity computation, not real data — \
+         aborting cleanly with a crash report instead of risking an OS OOM kill.\n\n{backtrace}"
+    );
+    if let Some(dir) = SPOOL_DIR.get() {
+        let _ = write_report(dir, size, ceiling, &backtrace);
+    }
+    std::process::abort();
+}
+
+fn write_report(dir: &Path, size: usize, ceiling: usize, backtrace: &str) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    let report_id = uuid::Uuid::new_v4().to_string();
+    let report = json!({
+        "report_version": 1,
+        "report_id": report_id,
+        "occurred_at": Utc::now().to_rfc3339(),
+        "app_version": env!("CARGO_PKG_VERSION"),
+        "command_line": std::env::args().collect::<Vec<_>>().join(" "),
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "process_id": std::process::id(),
+        "thread_name": std::thread::current().name().unwrap_or("unnamed"),
+        "panic_message": format!(
+            "alloc_guard: single allocation of {size} bytes exceeds ceiling {ceiling} bytes"
+        ),
+        "panic_location": null,
+        "backtrace": backtrace,
+        "memory": MemorySnapshot::capture(),
+    });
+    let bytes = serde_json::to_vec_pretty(&report).map_err(std::io::Error::other)?;
+    std::fs::write(dir.join(format!("alloc-guard-{report_id}.json")), bytes)
+}

--- a/src/telemetry/alloc_guard_report.rs
+++ b/src/telemetry/alloc_guard_report.rs
@@ -13,6 +13,7 @@ use chrono::Utc;
 use serde_json::json;
 
 use super::alloc_guard::SPOOL_DIR;
+use super::alloc_guard_command::command_line;
 use super::memory::MemorySnapshot;
 
 /// Handle an over-ceiling allocation: diagnose, spool, and abort. Marked
@@ -47,7 +48,7 @@ fn write_report(dir: &Path, size: usize, ceiling: usize, backtrace: &str) -> std
         "report_id": report_id,
         "occurred_at": Utc::now().to_rfc3339(),
         "app_version": env!("CARGO_PKG_VERSION"),
-        "command_line": std::env::args().collect::<Vec<_>>().join(" "),
+        "command_line": command_line(),
         "os": std::env::consts::OS,
         "arch": std::env::consts::ARCH,
         "process_id": std::process::id(),

--- a/src/telemetry/alloc_guard_tests.rs
+++ b/src/telemetry/alloc_guard_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the capacity-guarding allocator.
 
 use super::alloc_guard::CEILING;
+use std::ffi::OsString;
 use std::sync::atomic::Ordering;
 
 /// `configure` must resolve a non-zero ceiling, floor a too-small override,
@@ -32,4 +33,23 @@ fn configure_arms_guard_and_floors_tiny_override() {
     CEILING.store(0, Ordering::Relaxed);
     // SAFETY: single-threaded test teardown.
     unsafe { std::env::remove_var("CODETETHER_ALLOC_CEILING_MIB") };
+}
+
+#[test]
+fn command_line_tolerates_invalid_unicode() {
+    let args = [OsString::from("codetether"), invalid_os_string()];
+    let command_line = super::alloc_guard_command::command_line_from(args);
+    assert!(command_line.starts_with("codetether "));
+    assert!(command_line.contains('\u{fffd}'));
+}
+
+#[cfg(unix)]
+fn invalid_os_string() -> OsString {
+    use std::os::unix::ffi::OsStringExt;
+    OsString::from_vec(vec![0xff])
+}
+
+#[cfg(not(unix))]
+fn invalid_os_string() -> OsString {
+    OsString::from("�")
 }

--- a/src/telemetry/alloc_guard_tests.rs
+++ b/src/telemetry/alloc_guard_tests.rs
@@ -1,0 +1,35 @@
+//! Tests for the capacity-guarding allocator.
+
+use super::alloc_guard::CEILING;
+use std::sync::atomic::Ordering;
+
+/// `configure` must resolve a non-zero ceiling, floor a too-small override,
+/// and leave ordinary allocations (far below the ceiling) untouched.
+///
+/// Both cases live in one test so they run sequentially: the allocator and
+/// its ceiling are process-global, so concurrent `configure` calls would
+/// race.
+#[test]
+fn configure_arms_guard_and_floors_tiny_override() {
+    // Deterministic absolute ceiling via env override.
+    // SAFETY: single-threaded test setup; no other thread reads the var.
+    unsafe { std::env::set_var("CODETETHER_ALLOC_CEILING_MIB", "4096") };
+    super::alloc_guard_config::configure(std::env::temp_dir().join("ct-alloc-guard-test"));
+    assert_eq!(CEILING.load(Ordering::Relaxed), 4096 * 1024 * 1024);
+
+    // A normal allocation well under the ceiling succeeds verbatim.
+    let v: Vec<u8> = Vec::with_capacity(8 * 1024 * 1024);
+    assert_eq!(v.capacity(), 8 * 1024 * 1024);
+
+    // A tiny override is floored to the 2 GiB minimum so the guard never
+    // trips on modest legitimate allocations.
+    // SAFETY: single-threaded test.
+    unsafe { std::env::set_var("CODETETHER_ALLOC_CEILING_MIB", "1") };
+    super::alloc_guard_config::configure(std::env::temp_dir().join("ct-alloc-guard-test"));
+    assert!(CEILING.load(Ordering::Relaxed) >= 2 * 1024 * 1024 * 1024);
+
+    // Restore the inert state so the rest of the suite is unaffected.
+    CEILING.store(0, Ordering::Relaxed);
+    // SAFETY: single-threaded test teardown.
+    unsafe { std::env::remove_var("CODETETHER_ALLOC_CEILING_MIB") };
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -62,6 +62,11 @@
 //! ```
 
 pub mod a2a;
+pub mod alloc_guard;
+pub mod alloc_guard_config;
+pub mod alloc_guard_report;
+#[cfg(test)]
+mod alloc_guard_tests;
 pub mod context;
 pub mod cost;
 pub mod globals;
@@ -88,3 +93,11 @@ pub use tokens::{
     AtomicTokenCounter, GlobalTokenSnapshot, TokenCounts, TokenTotals, TokenUsageSnapshot,
 };
 pub use tools::{AtomicToolCounter, FileChange, ToolExecution};
+
+/// Arm both memory guards using `report_dir` as the crash-report spool:
+/// the capacity-guarding global allocator and the RSS watchdog. Both are
+/// idempotent and write into the same spool the flusher drains on startup.
+pub fn install_memory_guards(report_dir: std::path::PathBuf) {
+    alloc_guard_config::configure(report_dir.clone());
+    rss_watchdog::spawn(report_dir);
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -63,6 +63,7 @@
 
 pub mod a2a;
 pub mod alloc_guard;
+pub(crate) mod alloc_guard_command;
 pub mod alloc_guard_config;
 pub mod alloc_guard_report;
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Sessions were dying with `memory allocation of N bytes failed` — a single allocation of **48 GiB** (`51539607552` = exactly `3 × 2³⁴`, the fingerprint of a corrupted/wrapped capacity computation, not real data), seen after RLM context compaction.

Rust's infallible allocators turn an oversized request into an **immediate process abort** that bypasses the panic flusher — so no backtrace and no crash report is ever produced. That's why this kept recurring undiagnosed. A static audit of every plausible 48 GiB site (streaming accumulators, session load, thinker `Vec<u32>`, the RLM compaction/chunker path, Bedrock eventstream, embeddings) found **none that can reach 48 GiB on legitimate input** — it's a data-dependent bug path with no breadcrumb.

## Fix

Install a **capacity-guarding global allocator** that wraps the system allocator and trips on any *single* allocation above a fraction-of-RAM ceiling:

- **Ceiling:** default 75% of physical RAM (via `libc::sysconf`), floored at 2 GiB, overridable with `CODETETHER_ALLOC_CEILING_MIB` / `CODETETHER_ALLOC_CEILING_RAM_PCT`.
- **On trip:** capture a backtrace, spool a crash report in the existing schema (so the flusher ships it on next startup), then abort cleanly — converting an opaque OOM / silent OS OOM-kill into a controlled, **diagnosable** event.
- **Hot path:** one relaxed atomic load + a compare per allocation; inert until armed at startup in `crash::initialize`.

Also clamps the recall `flatten()` `with_capacity(budget * 4)` hint so a bogus budget can never become a multi-GiB reservation.

## Why this approach

A genuine 48 GiB request cannot be satisfied, so the only robust options are (a) bound the inputs and (b) fail cleanly with diagnostics. This does both, and the **next** occurrence will pin the exact culprit line via `crash-reports/alloc-guard-*.json` — which static analysis alone could not.

## Files

- `src/telemetry/alloc_guard.rs` — `GuardAlloc` wrapper + `GlobalAlloc` impl
- `src/telemetry/alloc_guard_config.rs` — RAM detection + ceiling resolution
- `src/telemetry/alloc_guard_report.rs` — trip handler (backtrace + spooled report + abort)
- `src/telemetry/alloc_guard_tests.rs` — arms-guard / floors-override test
- `src/lib.rs` — `#[global_allocator]`
- `src/crash.rs`, `src/telemetry/mod.rs` — wiring via `install_memory_guards`
- `src/session/helper/recall_context/flatten.rs` — capacity-hint clamp

## Test

`cargo test --lib telemetry::alloc_guard` passes; full lib test target compiles clean. New files respect the file-line ratchet; provenance trailer present.