### PR TITLE
fix: address PR 281 MiniMax-M3 feedback

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -29,9 +29,8 @@ const AUTOCHAT_QUICK_DEMO_TASK: &str = crate::autochat::AUTOCHAT_QUICK_DEMO_TASK
 const AUTOCHAT_RLM_THRESHOLD_CHARS: usize = crate::autochat::AUTOCHAT_RLM_THRESHOLD_CHARS;
 const AUTOCHAT_RLM_FALLBACK_CHARS: usize = crate::autochat::AUTOCHAT_RLM_FALLBACK_CHARS;
 const AUTOCHAT_RLM_HANDOFF_QUERY: &str = crate::autochat::AUTOCHAT_RLM_HANDOFF_QUERY;
-// Easy-go defaults should be fast and cheap. We use the dedicated
-// minimax-credits provider and the highspeed variant by default.
-const GO_DEFAULT_MODEL: &str = "minimax-credits/MiniMax-M2.5-highspeed";
+// Easy-go defaults align with the TUI /go rotation model.
+const GO_DEFAULT_MODEL: &str = "minimax/MiniMax-M3";
 
 /// Guarded UUID parse that logs warnings on invalid input instead of returning NIL UUID.
 /// Returns None for invalid UUIDs, allowing callers to skip operations rather than corrupt data.
@@ -1621,7 +1620,7 @@ mod tests {
     fn easy_go_defaults_to_minimax_when_model_not_set() {
         assert_eq!(
             resolve_autochat_model(None, None, Some("zai/glm-5"), true),
-            "minimax-credits/MiniMax-M2.5-highspeed"
+            "minimax/MiniMax-M3"
         );
     }
 

--- a/src/provider/limits.rs
+++ b/src/provider/limits.rs
@@ -47,7 +47,7 @@ pub fn context_window_for_model(model: &str) -> usize {
     } else if m.contains("gemini") {
         1_000_000
     // ── MiniMax: most specific patterns first ────────────────────────
-    } else if m.contains("minimax") && m.contains("m3") {
+    } else if m.contains("minimax-m3") || m.contains("minimaxm3") || m.contains("minimax/m3") {
         1_000_000
     } else if m.contains("minimax") || m.contains("m2.5") {
         256_000

--- a/src/provider/limits.rs
+++ b/src/provider/limits.rs
@@ -47,7 +47,7 @@ pub fn context_window_for_model(model: &str) -> usize {
     } else if m.contains("gemini") {
         1_000_000
     // ── MiniMax: most specific patterns first ────────────────────────
-    } else if m.contains("minimax-m3") || m.contains("minimaxm3") {
+    } else if m.contains("minimax") && m.contains("m3") {
         1_000_000
     } else if m.contains("minimax") || m.contains("m2.5") {
         256_000
@@ -98,8 +98,8 @@ mod tests {
         assert_eq!(context_window_for_model("gpt-4o-mini"), 128_000);
         assert_eq!(context_window_for_model("gemini-2.0-flash"), 1_000_000);
         assert_eq!(context_window_for_model("gemini-1.5-pro"), 1_000_000);
+        assert_eq!(context_window_for_model("minimax/m3"), 1_000_000);
         assert_eq!(context_window_for_model("minimax-m2.5"), 256_000);
-        assert_eq!(context_window_for_model("MiniMax-M3"), 1_000_000);
         assert_eq!(context_window_for_model("qwen-2.5-coder"), 131_072);
         assert_eq!(context_window_for_model("deepseek-v4-flash"), 1_048_576);
         assert_eq!(context_window_for_model("deepseek-chat"), 128_000);

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -289,22 +289,10 @@ mod tests {
 
     #[test]
     fn next_go_model_toggles_between_glm_and_minimax() {
-        assert_eq!(
-            next_go_model(Some("zai/glm-5")),
-            "minimax-credits/MiniMax-M2.5-highspeed"
-        );
-        assert_eq!(
-            next_go_model(Some("z-ai/glm-5")),
-            "minimax-credits/MiniMax-M2.5-highspeed"
-        );
-        assert_eq!(
-            next_go_model(Some("minimax-credits/MiniMax-M2.5-highspeed")),
-            "zai/glm-5"
-        );
-        assert_eq!(
-            next_go_model(Some("unknown/model")),
-            "minimax-credits/MiniMax-M2.5-highspeed"
-        );
+        assert_eq!(next_go_model(Some("zai/glm-5")), "minimax/MiniMax-M3");
+        assert_eq!(next_go_model(Some("z-ai/glm-5")), "minimax/MiniMax-M3");
+        assert_eq!(next_go_model(Some("minimax/MiniMax-M3")), "zai/glm-5");
+        assert_eq!(next_go_model(Some("unknown/model")), "minimax/MiniMax-M3");
     }
 
     #[test]

--- a/tests/minimax_context_limits.rs
+++ b/tests/minimax_context_limits.rs
@@ -1,0 +1,14 @@
+use codetether_agent::provider::limits::context_window_for_model;
+
+#[test]
+fn minimax_m3_formats_get_million_token_context() {
+    assert_eq!(context_window_for_model("minimax/m3"), 1_000_000);
+    assert_eq!(context_window_for_model("MiniMax-M3"), 1_000_000);
+    assert_eq!(context_window_for_model("minimaxm3"), 1_000_000);
+}
+
+#[test]
+fn other_minimax_three_models_keep_minimax_default() {
+    assert_eq!(context_window_for_model("minimax/llama3"), 256_000);
+    assert_eq!(context_window_for_model("minimax/glm3"), 256_000);
+}

--- a/tests/minimax_provider_metadata.rs
+++ b/tests/minimax_provider_metadata.rs
@@ -1,0 +1,21 @@
+use codetether_agent::provider::Provider;
+use codetether_agent::provider::anthropic::AnthropicProvider;
+
+#[tokio::test]
+async fn minimax_models_include_m3_metadata() {
+    let provider =
+        AnthropicProvider::with_base_url("test-key".into(), "https://x".into(), "minimax")
+            .expect("provider should construct");
+    let models = provider.list_models().await.expect("models should list");
+    let m3 = models.iter().find(|m| m.id == "MiniMax-M3").unwrap();
+
+    assert_eq!(
+        (m3.context_window, m3.max_output_tokens),
+        (1_000_000, Some(128_000))
+    );
+    assert!(m3.supports_vision && m3.supports_tools && m3.supports_streaming);
+    assert_eq!(
+        (m3.input_cost_per_million, m3.output_cost_per_million),
+        (Some(0.3), Some(1.2))
+    );
+}


### PR DESCRIPTION
## Summary
- make MiniMax-M3 context-window detection robust across alternate formats like minimax/m3
- align CLI /go default with the TUI MiniMax-M3 rotation
- add MiniMax-M3 provider metadata coverage

## Validation
- focused CI-like: cargo test minimax --lib
- focused CI-like: cargo test minimax_models_include_m3_metadata --test minimax_provider_metadata
- static/local: ./check_file_limits.sh