### PR TITLE
fix: add runtime context to alloc crash reports

### DIFF
--- a/src/telemetry/alloc_guard_payload.rs
+++ b/src/telemetry/alloc_guard_payload.rs
@@ -1,0 +1,28 @@
+//! JSON payload builder for allocator crash reports.
+
+use chrono::Utc;
+use serde_json::{Value, json};
+
+use super::alloc_guard_command::command_line;
+use super::memory::MemorySnapshot;
+
+pub(crate) fn build(report_id: &str, size: usize, ceiling: usize, backtrace: &str) -> Value {
+    json!({
+        "report_version": 1,
+        "report_id": report_id,
+        "occurred_at": Utc::now().to_rfc3339(),
+        "app_version": env!("CARGO_PKG_VERSION"),
+        "command_line": command_line(),
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "process_id": std::process::id(),
+        "thread_name": std::thread::current().name().unwrap_or("unnamed"),
+        "panic_message": format!(
+            "alloc_guard: single allocation of {size} bytes exceeds ceiling {ceiling} bytes"
+        ),
+        "panic_location": null,
+        "backtrace": backtrace,
+        "memory": MemorySnapshot::capture(),
+        "runtime_context": super::crash_context::snapshot(),
+    })
+}

--- a/src/telemetry/alloc_guard_report.rs
+++ b/src/telemetry/alloc_guard_report.rs
@@ -9,12 +9,7 @@
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use chrono::Utc;
-use serde_json::json;
-
 use super::alloc_guard::SPOOL_DIR;
-use super::alloc_guard_command::command_line;
-use super::memory::MemorySnapshot;
 
 /// Handle an over-ceiling allocation: diagnose, spool, and abort. Marked
 /// cold and never-inline so it stays entirely off the allocator hot path.
@@ -43,23 +38,7 @@ pub(crate) fn trip(size: usize, ceiling: usize) -> ! {
 fn write_report(dir: &Path, size: usize, ceiling: usize, backtrace: &str) -> std::io::Result<()> {
     std::fs::create_dir_all(dir)?;
     let report_id = uuid::Uuid::new_v4().to_string();
-    let report = json!({
-        "report_version": 1,
-        "report_id": report_id,
-        "occurred_at": Utc::now().to_rfc3339(),
-        "app_version": env!("CARGO_PKG_VERSION"),
-        "command_line": command_line(),
-        "os": std::env::consts::OS,
-        "arch": std::env::consts::ARCH,
-        "process_id": std::process::id(),
-        "thread_name": std::thread::current().name().unwrap_or("unnamed"),
-        "panic_message": format!(
-            "alloc_guard: single allocation of {size} bytes exceeds ceiling {ceiling} bytes"
-        ),
-        "panic_location": null,
-        "backtrace": backtrace,
-        "memory": MemorySnapshot::capture(),
-    });
+    let report = super::alloc_guard_payload::build(&report_id, size, ceiling, backtrace);
     let bytes = serde_json::to_vec_pretty(&report).map_err(std::io::Error::other)?;
     std::fs::write(dir.join(format!("alloc-guard-{report_id}.json")), bytes)
 }

--- a/src/telemetry/crash_context.rs
+++ b/src/telemetry/crash_context.rs
@@ -1,0 +1,45 @@
+//! Best-effort runtime context for crash reports.
+
+use std::path::Path;
+use std::sync::{LazyLock, RwLock};
+
+use serde::Serialize;
+
+static CONTEXT: LazyLock<RwLock<CrashContext>> =
+    LazyLock::new(|| RwLock::new(CrashContext::default()));
+
+/// Runtime facts captured outside the crash path.
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CrashContext {
+    /// Current working directory or session workspace.
+    pub cwd: Option<String>,
+    /// Active session id, when the TUI knows it.
+    pub session_id: Option<String>,
+    /// Active session message count at last draw.
+    pub session_messages: Option<usize>,
+    /// Selected model for the active session.
+    pub session_model: Option<String>,
+    /// Last visible TUI status string.
+    pub tui_status: Option<String>,
+}
+
+/// Record the active TUI session context.
+pub fn record_tui(
+    session_id: &str,
+    messages: usize,
+    model: Option<&str>,
+    cwd: Option<&Path>,
+    status: &str,
+) {
+    let Ok(mut ctx) = CONTEXT.write() else { return };
+    ctx.cwd = cwd.map(|p| p.display().to_string());
+    ctx.session_id = Some(session_id.to_string());
+    ctx.session_messages = Some(messages);
+    ctx.session_model = model.map(str::to_string);
+    ctx.tui_status = Some(status.to_string());
+}
+
+/// Return the latest recorded crash context.
+pub fn snapshot() -> CrashContext {
+    CONTEXT.read().map(|ctx| ctx.clone()).unwrap_or_default()
+}

--- a/src/telemetry/crash_context_tests.rs
+++ b/src/telemetry/crash_context_tests.rs
@@ -1,0 +1,20 @@
+//! Tests for crash-report runtime context.
+
+use std::path::Path;
+
+#[test]
+fn record_tui_updates_snapshot() {
+    super::crash_context::record_tui(
+        "session-123",
+        42,
+        Some("model-x"),
+        Some(Path::new("/tmp/work")),
+        "Streaming reply…",
+    );
+    let snap = super::crash_context::snapshot();
+    assert_eq!(snap.session_id.as_deref(), Some("session-123"));
+    assert_eq!(snap.session_messages, Some(42));
+    assert_eq!(snap.session_model.as_deref(), Some("model-x"));
+    assert_eq!(snap.cwd.as_deref(), Some("/tmp/work"));
+    assert_eq!(snap.tui_status.as_deref(), Some("Streaming reply…"));
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -65,11 +65,15 @@ pub mod a2a;
 pub mod alloc_guard;
 pub(crate) mod alloc_guard_command;
 pub mod alloc_guard_config;
+pub(crate) mod alloc_guard_payload;
 pub mod alloc_guard_report;
 #[cfg(test)]
 mod alloc_guard_tests;
 pub mod context;
 pub mod cost;
+pub mod crash_context;
+#[cfg(test)]
+mod crash_context_tests;
 pub mod globals;
 pub mod memory;
 pub mod metrics;

--- a/src/tui/app/safe_draw.rs
+++ b/src/tui/app/safe_draw.rs
@@ -1,12 +1,13 @@
 //! Guarded TUI drawing.
 
-use ratatui::{Terminal, backend::CrosstermBackend, layout::Size};
+use ratatui::{Terminal, backend::CrosstermBackend};
+
+#[path = "safe_draw_size.rs"]
+mod safe_draw_size;
 
 use crate::session::Session;
 use crate::tui::{app::state::App, ui::main::ui};
-
-const MAX_RENDER_CELLS: u32 = 500_000;
-const MAX_RENDER_DIMENSION: u16 = 1_000;
+use safe_draw_size::{rect_for, safe_size};
 
 /// Draw one TUI frame when the reported terminal size is sane.
 pub fn draw_ui(
@@ -14,38 +15,32 @@ pub fn draw_ui(
     app: &mut App,
     session: &Session,
 ) -> anyhow::Result<()> {
+    record_context(app, session);
     let size = terminal.size()?;
     if !safe_size(size) {
-        tracing::warn!(
-            width = size.width,
-            height = size.height,
-            cells = size.width as u32 * size.height as u32,
-            "skipping TUI draw because terminal reported an invalid size"
-        );
+        log_skipped_size(size);
         return Ok(());
     }
+    terminal.resize(rect_for(size))?;
     terminal.draw(|f| ui(f, app, session))?;
     Ok(())
 }
 
-fn safe_size(size: Size) -> bool {
-    let cells = size.width as u32 * size.height as u32;
-    size.width > 0
-        && size.height > 0
-        && size.width <= MAX_RENDER_DIMENSION
-        && size.height <= MAX_RENDER_DIMENSION
-        && cells <= MAX_RENDER_CELLS
+fn record_context(app: &App, session: &Session) {
+    crate::telemetry::crash_context::record_tui(
+        &session.id,
+        session.messages.len(),
+        session.metadata.model.as_deref(),
+        session.metadata.directory.as_deref(),
+        &app.state.status,
+    );
 }
 
-#[cfg(test)]
-mod tests {
-    use super::safe_size;
-    use ratatui::layout::Size;
-
-    #[test]
-    fn rejects_absurd_terminal_sizes() {
-        assert!(safe_size(Size::new(120, 40)));
-        assert!(!safe_size(Size::new(0, 40)));
-        assert!(!safe_size(Size::new(u16::MAX, u16::MAX)));
-    }
+fn log_skipped_size(size: ratatui::layout::Size) {
+    tracing::warn!(
+        width = size.width,
+        height = size.height,
+        cells = size.width as u32 * size.height as u32,
+        "skipping TUI draw because terminal reported an invalid size"
+    );
 }

--- a/src/tui/app/safe_draw_size.rs
+++ b/src/tui/app/safe_draw_size.rs
@@ -1,0 +1,30 @@
+use ratatui::layout::{Rect, Size};
+
+const MAX_RENDER_CELLS: u32 = 500_000;
+const MAX_RENDER_DIMENSION: u16 = 1_000;
+
+pub fn safe_size(size: Size) -> bool {
+    let cells = size.width as u32 * size.height as u32;
+    size.width > 0
+        && size.height > 0
+        && size.width <= MAX_RENDER_DIMENSION
+        && size.height <= MAX_RENDER_DIMENSION
+        && cells <= MAX_RENDER_CELLS
+}
+
+pub const fn rect_for(size: Size) -> Rect {
+    Rect::new(0, 0, size.width, size.height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::safe_size;
+    use ratatui::layout::Size;
+
+    #[test]
+    fn rejects_absurd_terminal_sizes() {
+        assert!(safe_size(Size::new(120, 40)));
+        assert!(!safe_size(Size::new(0, 40)));
+        assert!(!safe_size(Size::new(u16::MAX, u16::MAX)));
+    }
+}


### PR DESCRIPTION
## Summary
- add best-effort TUI/session runtime context to allocator crash report JSON
- record active session id, message count, model, workspace, and visible TUI status before draws
- keep the terminal-size guard effective by resizing ratatui buffers after validating sane dimensions

## Validation
- focused CI-like: `cargo test crash_context --lib`
- static/local: `./check_file_limits.sh src/tui/app/safe_draw.rs src/tui/app/safe_draw_size.rs src/telemetry/crash_context.rs src/telemetry/alloc_guard_payload.rs src/telemetry/alloc_guard_report.rs src/telemetry/crash_context_tests.rs`