### PR TITLE
feat: add OpenRouter-style /models endpoint with rich model metadata

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,6 +3,7 @@
 //! Main API server for the CodeTether Agent
 
 pub mod auth;
+mod models_catalog;
 pub mod policy;
 mod policy_user;
 mod tool_contract;
@@ -38,7 +39,7 @@ use axum::{
     response::{IntoResponse, Json, Response},
     routing::{get, post},
 };
-use futures::{StreamExt, future::join_all, stream};
+use futures::{StreamExt, stream};
 use http::HeaderValue;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -295,6 +296,11 @@ const POLICY_RULES: &[PolicyRule] = &[
         permission: "",
     },
     // OpenAI-compatible model discovery and chat completions
+    PolicyRule {
+        pattern: "/models",
+        methods: Some(&["GET"]),
+        permission: "agent:read",
+    },
     PolicyRule {
         pattern: "/v1/models",
         methods: Some(&["GET"]),
@@ -747,7 +753,8 @@ pub async fn serve(args: ServeArgs) -> Result<()> {
         .route("/api/provider", get(list_providers))
         .route("/api/agent", get(list_agents))
         // OpenAI-compatible APIs
-        .route("/v1/models", get(list_openai_models))
+        .route("/models", get(models_catalog::list_models))
+        .route("/v1/models", get(models_catalog::list_models))
         .route("/v1/chat/completions", post(openai_chat_completions))
         // Perpetual cognition APIs
         .route("/v1/cognition/start", post(start_cognition))
@@ -1301,20 +1308,6 @@ struct OpenAiRequestToolDefinition {
 }
 
 #[derive(Debug, Serialize)]
-struct OpenAiModelsResponse {
-    object: String,
-    data: Vec<OpenAiModel>,
-}
-
-#[derive(Debug, Serialize)]
-struct OpenAiModel {
-    id: String,
-    object: String,
-    created: i64,
-    owned_by: String,
-}
-
-#[derive(Debug, Serialize)]
 struct OpenAiChatCompletionResponse {
     id: String,
     object: String,
@@ -1702,59 +1695,6 @@ fn openai_stream_chunk(
 
 fn openai_stream_event(payload: &serde_json::Value) -> Event {
     Event::default().data(payload.to_string())
-}
-
-async fn list_openai_models() -> OpenAiApiResult<Json<OpenAiModelsResponse>> {
-    let registry = crate::provider::ProviderRegistry::from_vault()
-        .await
-        .map_err(|error| {
-            tracing::error!(error = %error, "Failed to load providers from Vault");
-            openai_internal_error(format!("failed to load providers: {error}"))
-        })?;
-
-    let model_futures = registry.list().into_iter().map(|provider_id| {
-        let provider_id = provider_id.to_string();
-        let provider = registry.get(&provider_id);
-
-        async move {
-            let Some(provider) = provider else {
-                return Vec::new();
-            };
-
-            let now = chrono::Utc::now().timestamp();
-            match provider.list_models().await {
-                Ok(models) => models
-                    .into_iter()
-                    .map(|model| OpenAiModel {
-                        id: make_openai_model_id(&provider_id, &model.id),
-                        object: "model".to_string(),
-                        created: now,
-                        owned_by: canonicalize_provider_name(&provider_id).to_string(),
-                    })
-                    .collect(),
-                Err(error) => {
-                    tracing::warn!(
-                        provider = %provider_id,
-                        error = %error,
-                        "Failed to list models for provider"
-                    );
-                    Vec::new()
-                }
-            }
-        }
-    });
-
-    let mut data: Vec<OpenAiModel> = join_all(model_futures)
-        .await
-        .into_iter()
-        .flatten()
-        .collect();
-    data.sort_by(|a, b| a.owned_by.cmp(&b.owned_by).then(a.id.cmp(&b.id)));
-
-    Ok(Json(OpenAiModelsResponse {
-        object: "list".to_string(),
-        data,
-    }))
 }
 
 async fn openai_chat_completions(
@@ -3216,6 +3156,12 @@ mod tests {
     fn policy_proposal_approval_requires_execute_permission() {
         let permission = match_policy_rule("/v1/cognition/proposals/p1/approve", "POST");
         assert_eq!(permission, Some("agent:execute"));
+    }
+
+    #[test]
+    fn policy_root_models_requires_read_permission() {
+        let permission = match_policy_rule("/models", "GET");
+        assert_eq!(permission, Some("agent:read"));
     }
 
     #[test]

--- a/src/server/models_catalog.rs
+++ b/src/server/models_catalog.rs
@@ -6,6 +6,9 @@ mod ids;
 mod parameters;
 mod pricing;
 mod types;
+mod types_architecture;
+mod types_pricing;
+mod types_top_provider;
 
 use axum::{Json, http::StatusCode};
 
@@ -16,7 +19,8 @@ pub(crate) async fn list_models() -> ModelsResult<Json<types::ModelsResponse>> {
         .await
         .map_err(load_error)?;
 
-    let data = collect::collect_models(&registry).await;
+    let created = chrono::Utc::now().timestamp();
+    let data = collect::collect_models(&registry, created).await;
     Ok(Json(types::ModelsResponse { data }))
 }
 

--- a/src/server/models_catalog.rs
+++ b/src/server/models_catalog.rs
@@ -1,0 +1,35 @@
+//! OpenAI/OpenRouter-compatible model discovery handlers.
+
+mod collect;
+mod convert;
+mod ids;
+mod parameters;
+mod pricing;
+mod types;
+
+use axum::{Json, http::StatusCode};
+
+pub(crate) type ModelsResult<T> = Result<T, (StatusCode, Json<serde_json::Value>)>;
+
+pub(crate) async fn list_models() -> ModelsResult<Json<types::ModelsResponse>> {
+    let registry = crate::provider::ProviderRegistry::from_vault()
+        .await
+        .map_err(load_error)?;
+
+    let data = collect::collect_models(&registry).await;
+    Ok(Json(types::ModelsResponse { data }))
+}
+
+fn load_error(error: anyhow::Error) -> (StatusCode, Json<serde_json::Value>) {
+    tracing::error!(error = %error, "Failed to load providers from Vault");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({
+            "error": {
+                "message": format!("failed to load providers: {error}"),
+                "type": "server_error",
+                "code": "internal_error"
+            }
+        })),
+    )
+}

--- a/src/server/models_catalog/collect.rs
+++ b/src/server/models_catalog/collect.rs
@@ -2,20 +2,25 @@
 
 use super::{convert, types};
 use futures::future::join_all;
+use std::time::Duration;
+
+const PROVIDER_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(crate) async fn collect_models(
     registry: &crate::provider::ProviderRegistry,
+    created: i64,
 ) -> Vec<types::Model> {
     let futures = registry.list().into_iter().map(|provider_id| async move {
         let Some(provider) = registry.get(provider_id) else {
             return Vec::new();
         };
-        match provider.list_models().await {
-            Ok(models) => models
+        match tokio::time::timeout(PROVIDER_TIMEOUT, provider.list_models()).await {
+            Ok(Ok(models)) => models
                 .into_iter()
-                .map(|model| convert::convert_model(provider_id, model))
+                .map(|model| convert::convert_model(provider_id, model, created))
                 .collect(),
-            Err(error) => failed_provider(provider_id, error),
+            Ok(Err(error)) => failed_provider(provider_id, error),
+            Err(_) => failed_provider(provider_id, anyhow::anyhow!("Timeout after 5s")),
         }
     });
     let mut data: Vec<_> = join_all(futures).await.into_iter().flatten().collect();

--- a/src/server/models_catalog/collect.rs
+++ b/src/server/models_catalog/collect.rs
@@ -1,0 +1,29 @@
+//! Provider model collection for model discovery.
+
+use super::{convert, types};
+use futures::future::join_all;
+
+pub(crate) async fn collect_models(
+    registry: &crate::provider::ProviderRegistry,
+) -> Vec<types::Model> {
+    let futures = registry.list().into_iter().map(|provider_id| async move {
+        let Some(provider) = registry.get(provider_id) else {
+            return Vec::new();
+        };
+        match provider.list_models().await {
+            Ok(models) => models
+                .into_iter()
+                .map(|model| convert::convert_model(provider_id, model))
+                .collect(),
+            Err(error) => failed_provider(provider_id, error),
+        }
+    });
+    let mut data: Vec<_> = join_all(futures).await.into_iter().flatten().collect();
+    data.sort_by(|a: &types::Model, b| a.id.cmp(&b.id));
+    data
+}
+
+fn failed_provider(provider_id: &str, error: anyhow::Error) -> Vec<types::Model> {
+    tracing::warn!(provider = %provider_id, error = %error, "Failed to list models");
+    Vec::new()
+}

--- a/src/server/models_catalog/convert.rs
+++ b/src/server/models_catalog/convert.rs
@@ -1,0 +1,48 @@
+//! Convert internal provider model metadata to API models.
+
+use super::{ids, types};
+
+type ModelInfo = crate::provider::ModelInfo;
+
+pub(crate) fn convert_model(provider: &str, model: ModelInfo) -> types::Model {
+    let id = ids::model_id(provider, &model.id);
+    types::Model {
+        id: id.clone(),
+        canonical_slug: id,
+        name: ids::display_name(provider, &model.name),
+        created: 0,
+        description: format!(
+            "{} model served by CodeTether provider {provider}",
+            model.name
+        ),
+        context_length: model.context_window,
+        architecture: architecture(&model),
+        pricing: super::pricing::price(&model),
+        top_provider: top_provider(&model),
+        per_request_limits: None,
+        supported_parameters: super::parameters::supported_parameters(&model),
+    }
+}
+
+fn architecture(model: &ModelInfo) -> types::Architecture {
+    let inputs = if model.supports_vision {
+        vec!["text", "image"]
+    } else {
+        vec!["text"]
+    };
+    types::Architecture {
+        modality: format!("{}->text", inputs.join("+")),
+        input_modalities: inputs.into_iter().map(str::to_string).collect(),
+        output_modalities: vec!["text".to_string()],
+        tokenizer: "Other".to_string(),
+        instruct_type: None,
+    }
+}
+
+fn top_provider(model: &ModelInfo) -> types::TopProvider {
+    types::TopProvider {
+        context_length: model.context_window,
+        max_completion_tokens: model.max_output_tokens,
+        is_moderated: false,
+    }
+}

--- a/src/server/models_catalog/convert.rs
+++ b/src/server/models_catalog/convert.rs
@@ -4,13 +4,13 @@ use super::{ids, types};
 
 type ModelInfo = crate::provider::ModelInfo;
 
-pub(crate) fn convert_model(provider: &str, model: ModelInfo) -> types::Model {
+pub(crate) fn convert_model(provider: &str, model: ModelInfo, created: i64) -> types::Model {
     let id = ids::model_id(provider, &model.id);
     types::Model {
         id: id.clone(),
         canonical_slug: id,
         name: ids::display_name(provider, &model.name),
-        created: 0,
+        created,
         description: format!(
             "{} model served by CodeTether provider {provider}",
             model.name

--- a/src/server/models_catalog/ids.rs
+++ b/src/server/models_catalog/ids.rs
@@ -8,12 +8,14 @@ pub(crate) fn canonical_provider(provider: &str) -> &str {
 }
 
 pub(crate) fn model_id(provider: &str, model_id: &str) -> String {
-    let provider = canonical_provider(provider);
+    let canonical = canonical_provider(provider);
     let trimmed = model_id.trim_start_matches('/');
-    if trimmed.starts_with(&format!("{provider}/")) {
+    if trimmed.starts_with(&format!("{canonical}/")) {
         trimmed.to_string()
+    } else if provider != canonical && trimmed.starts_with(&format!("{provider}/")) {
+        format!("{canonical}/{}", &trimmed[provider.len() + 1..])
     } else {
-        format!("{provider}/{trimmed}")
+        format!("{canonical}/{trimmed}")
     }
 }
 

--- a/src/server/models_catalog/ids.rs
+++ b/src/server/models_catalog/ids.rs
@@ -1,0 +1,23 @@
+//! Model identifier helpers.
+
+pub(crate) fn canonical_provider(provider: &str) -> &str {
+    match provider {
+        "zhipuai" => "zai",
+        other => other,
+    }
+}
+
+pub(crate) fn model_id(provider: &str, model_id: &str) -> String {
+    let provider = canonical_provider(provider);
+    let trimmed = model_id.trim_start_matches('/');
+    if trimmed.starts_with(&format!("{provider}/")) {
+        trimmed.to_string()
+    } else {
+        format!("{provider}/{trimmed}")
+    }
+}
+
+pub(crate) fn display_name(provider: &str, name: &str) -> String {
+    let provider = canonical_provider(provider);
+    format!("{}: {name}", provider.to_uppercase())
+}

--- a/src/server/models_catalog/parameters.rs
+++ b/src/server/models_catalog/parameters.rs
@@ -1,0 +1,13 @@
+//! OpenRouter-style supported parameter names.
+
+pub(crate) fn supported_parameters(model: &crate::provider::ModelInfo) -> Vec<String> {
+    let mut params = base_parameters();
+    if model.supports_tools {
+        params.extend(["tools", "tool_choice"]);
+    }
+    params.into_iter().map(str::to_string).collect()
+}
+
+fn base_parameters() -> Vec<&'static str> {
+    vec!["max_tokens", "temperature", "top_p", "stop"]
+}

--- a/src/server/models_catalog/pricing.rs
+++ b/src/server/models_catalog/pricing.rs
@@ -9,8 +9,8 @@ pub(crate) fn price(model: &crate::provider::ModelInfo) -> super::types::Pricing
 
 fn per_token(cost_per_million: Option<f64>) -> String {
     match cost_per_million {
-        Some(cost) => trim_float(cost / 1_000_000.0),
-        None => "0".to_string(),
+        Some(cost) if cost.is_finite() && cost >= 0.0 => trim_float(cost / 1_000_000.0),
+        _ => "".to_string(),
     }
 }
 

--- a/src/server/models_catalog/pricing.rs
+++ b/src/server/models_catalog/pricing.rs
@@ -1,0 +1,23 @@
+//! Pricing conversion helpers.
+
+pub(crate) fn price(model: &crate::provider::ModelInfo) -> super::types::Pricing {
+    super::types::Pricing {
+        prompt: per_token(model.input_cost_per_million),
+        completion: per_token(model.output_cost_per_million),
+    }
+}
+
+fn per_token(cost_per_million: Option<f64>) -> String {
+    match cost_per_million {
+        Some(cost) => trim_float(cost / 1_000_000.0),
+        None => "0".to_string(),
+    }
+}
+
+fn trim_float(value: f64) -> String {
+    let fixed = format!("{value:.12}");
+    fixed
+        .trim_end_matches('0')
+        .trim_end_matches('.')
+        .to_string()
+}

--- a/src/server/models_catalog/types.rs
+++ b/src/server/models_catalog/types.rs
@@ -1,5 +1,9 @@
 //! Response structs for `/models` and `/v1/models`.
 
+pub(crate) use super::types_architecture::Architecture;
+pub(crate) use super::types_pricing::Pricing;
+pub(crate) use super::types_top_provider::TopProvider;
+
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -18,28 +22,7 @@ pub(crate) struct Model {
     pub(crate) architecture: Architecture,
     pub(crate) pricing: Pricing,
     pub(crate) top_provider: TopProvider,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) per_request_limits: Option<serde_json::Value>,
     pub(crate) supported_parameters: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct Architecture {
-    pub(crate) modality: String,
-    pub(crate) input_modalities: Vec<String>,
-    pub(crate) output_modalities: Vec<String>,
-    pub(crate) tokenizer: String,
-    pub(crate) instruct_type: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct Pricing {
-    pub(crate) prompt: String,
-    pub(crate) completion: String,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct TopProvider {
-    pub(crate) context_length: usize,
-    pub(crate) max_completion_tokens: Option<usize>,
-    pub(crate) is_moderated: bool,
 }

--- a/src/server/models_catalog/types.rs
+++ b/src/server/models_catalog/types.rs
@@ -1,0 +1,45 @@
+//! Response structs for `/models` and `/v1/models`.
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ModelsResponse {
+    pub(crate) data: Vec<Model>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Model {
+    pub(crate) id: String,
+    pub(crate) canonical_slug: String,
+    pub(crate) name: String,
+    pub(crate) created: i64,
+    pub(crate) description: String,
+    pub(crate) context_length: usize,
+    pub(crate) architecture: Architecture,
+    pub(crate) pricing: Pricing,
+    pub(crate) top_provider: TopProvider,
+    pub(crate) per_request_limits: Option<serde_json::Value>,
+    pub(crate) supported_parameters: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Architecture {
+    pub(crate) modality: String,
+    pub(crate) input_modalities: Vec<String>,
+    pub(crate) output_modalities: Vec<String>,
+    pub(crate) tokenizer: String,
+    pub(crate) instruct_type: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Pricing {
+    pub(crate) prompt: String,
+    pub(crate) completion: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TopProvider {
+    pub(crate) context_length: usize,
+    pub(crate) max_completion_tokens: Option<usize>,
+    pub(crate) is_moderated: bool,
+}

--- a/src/server/models_catalog/types_architecture.rs
+++ b/src/server/models_catalog/types_architecture.rs
@@ -1,0 +1,13 @@
+//! Architecture modality structs.
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Architecture {
+    pub(crate) modality: String,
+    pub(crate) input_modalities: Vec<String>,
+    pub(crate) output_modalities: Vec<String>,
+    pub(crate) tokenizer: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) instruct_type: Option<String>,
+}

--- a/src/server/models_catalog/types_pricing.rs
+++ b/src/server/models_catalog/types_pricing.rs
@@ -1,0 +1,9 @@
+//! Pricing response struct.
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Pricing {
+    pub(crate) prompt: String,
+    pub(crate) completion: String,
+}

--- a/src/server/models_catalog/types_top_provider.rs
+++ b/src/server/models_catalog/types_top_provider.rs
@@ -1,0 +1,11 @@
+//! Top-provider response struct.
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TopProvider {
+    pub(crate) context_length: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) max_completion_tokens: Option<usize>,
+    pub(crate) is_moderated: bool,
+}


### PR DESCRIPTION
## Summary

Replaces the minimal OpenAI-compatible `/v1/models` response (only `id`, `object`, `created`, `owned_by`) with an **OpenRouter-style** payload that includes:

| Field | Description |
|---|---|
| `id` / `canonical_slug` | Provider-prefixed model ID (e.g. `anthropic/claude-sonnet-4-20250514`) |
| `name` | Human-readable display name |
| `description` | Short description with provider attribution |
| `context_length` | Context window in tokens |
| `architecture` | Modality string + input/output modalities, tokenizer |
| `pricing` | Per-token prompt/completion cost strings |
| `top_provider` | Context length, max completion tokens, moderation flag |
| `supported_parameters` | e.g. `max_tokens`, `temperature`, `tools`, `tool_choice` |

### Routes

- `GET /models` — new root-level endpoint
- `GET /v1/models` — preserved for backward compat, same handler

### Implementation

All logic extracted into `src/server/models_catalog/` with focused sub-files:

```
models_catalog.rs          — module root + entry handler
models_catalog/collect.rs  — async provider fan-out + sort
models_catalog/convert.rs  — ModelInfo → API Model conversion
models_catalog/ids.rs      — provider name canonicalization + ID helpers
models_catalog/parameters.rs — supported_parameters builder
models_catalog/pricing.rs  — per-token cost string formatting
models_catalog/types.rs    — response structs (ModelsResponse, Model, Architecture, Pricing, TopProvider)
```

Old `OpenAiModelsResponse` / `OpenAiModel` structs and `list_openai_models()` handler removed from `mod.rs`.

### Policy

Both `/models` and `/v1/models` covered by `agent:read` policy rule.

## Checklist

- [x] `cargo fmt`
- [x] `./check_file_limits.sh` passes
- [x] Policy test for new `/models` route
