### PR TITLE
fix(computer_use): include visibility fields in Win32 list_apps

### DIFF
--- a/src/platform/windows/computer_use/windows.rs
+++ b/src/platform/windows/computer_use/windows.rs
@@ -26,30 +26,32 @@ unsafe fn enum_inner() -> anyhow::Result<Vec<Value>> {
 }
 
 unsafe extern "system" fn enum_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
-    let results = &mut *(lparam.0 as *mut Vec<Value>);
-
+    let results = unsafe { &mut *(lparam.0 as *mut Vec<Value>) };
     let mut title_buf = [0u16; 512];
-    let title_len = GetWindowTextW(hwnd, &mut title_buf);
-    if title_len == 0 {
-        return BOOL(1); // continue
+    let title_len = unsafe { GetWindowTextW(hwnd, &mut title_buf) };
+    if title_len <= 0 || title_len as usize > title_buf.len() {
+        return BOOL(1);
     }
     let title = String::from_utf16_lossy(&title_buf[..title_len as usize]);
+    let visible = unsafe { IsWindowVisible(hwnd).as_bool() };
+    let minimized = unsafe { IsIconic(hwnd).as_bool() };
 
-    let mut rect = std::mem::zeroed();
-    let _ = GetWindowRect(hwnd, &mut rect);
-
+    let mut rect = Default::default();
+    let _ = unsafe { GetWindowRect(hwnd, &mut rect) };
     let mut pid: u32 = 0;
-    let _ = GetWindowThreadProcessId(hwnd, Some(&mut pid));
+    let _ = unsafe { GetWindowThreadProcessId(hwnd, Some(&mut pid)) };
 
     results.push(serde_json::json!({
         "hwnd": hwnd.0 as i64,
         "pid": pid,
         "title": title,
+        "visible": visible,
+        "minimized": minimized,
         "left": rect.left,
         "top": rect.top,
         "right": rect.right,
         "bottom": rect.bottom,
     }));
 
-    BOOL(1) // continue enumeration
+    BOOL(1)
 }


### PR DESCRIPTION
## Summary
- populate `visible` and `minimized` in Win32 window enumeration
- fixes `computer_use list_apps` returning `count: 0` because the handler filtered on missing fields
- adds an ignored live Windows smoke test for list_apps

## Validation
- focused CI-like: `cargo test -p codetether-agent --lib live_list_apps_returns_visible_windows -- --ignored --nocapture` returned `count: 11` visible windows and passed
- static/local: `cargo check -p codetether-agent --lib` finished successfully with existing warnings
- static/local: `./check_file_limits.sh` passed
