### PR TITLE
fix(a2a): stop intro storms, add intro short-circuit and RPC bearer auth

### DIFF
--- a/src/a2a/intro/ledger.rs
+++ b/src/a2a/intro/ledger.rs
@@ -3,53 +3,29 @@
 //! The in-memory `discovered` set in the discovery loops forgets on
 //! restart, which caused thousands of duplicate intros. This ledger
 //! persists introduced endpoints to `<data_dir>/a2a/introduced.json`
-//! keyed by endpooint only (peer names embed PIDs and churn per restart).
+//! keyed by endpoint only (peer names embed PIDs and churn per restart).
+//!
+//! Split across:
+//! - [`ledger_path`] — filesystem location
+//! - [`ledger_load`] — read into `HashSet`
+//! - [`ledger_atomic`] — temp-file rename writer
+//! - [`ledger_record`] — atomic append
 
-use std::collections::HashSet;
-use std::path::PathBuf;
+#[path = "ledger_atomic.rs"]
+mod ledger_atomic;
+#[path = "ledger_load.rs"]
+mod ledger_load;
+#[path = "ledger_path.rs"]
+mod ledger_path;
+#[path = "ledger_record.rs"]
+mod ledger_record;
 
-/// Where the ledger lives: `<data_dir>/a2a/introduced.json`.
-fn ledger_path() -> Option<PathBuf> {
-    crate::config::Config::data_dir().map(|d| d.join("a2a").join("introduced.json"))
-}
-
-/// Load the set of endpoints we have already introduced ourselves to.
-pub fn load() -> HashSet<String> {
-    let Some(path) = ledger_path() else {
-        return HashSet::new();
-    };
-    let Ok(raw) = std::fs::read_to_string(&path) else {
-        return HashSet::new();
-    };
-    serde_json::from_str(&raw).unwrap_or_default()
-}
-
-/// Record `endpoint` as introduced. Best-effort; failures only log.
-pub fn record(endpoint: &str) {
-    let Some(path) = ledger_path() else {
-        return;
-    };
-    let mut set = load();
-    if !set.insert(endpoint.trim_end_matches('/').to_string()) {
-        return;
-    }
-    if let Some(parent) = path.parent()
-        && let Err(e) = std::fs::create_dir_all(parent)
-    {
-        tracing::debug!(error = %e, "Failed to create intro ledger dir");
-        return;
-    }
-    match serde_json::to_string(&set) {
-        Ok(json) => {
-            if let Err(e) = std::fs::write(&path, json) {
-                tracing::debug!(error = %e, "Failed to persist intro ledger");
-            }
-        }
-        Err(e) => tracing::debug!(error = %e, "Failed to serialize intro ledger"),
-    }
-}
+pub use ledger_load::load;
+pub use ledger_record::record;
 
 /// Whether `endpoint` was already introduced to (normalized, no trailing `/`).
 pub fn contains(endpoint: &str) -> bool {
-    load().contains(endpoint.trim_end_matches('/'))
+    load()
+        .unwrap_or_default()
+        .contains(endpoint.trim_end_matches('/'))
 }

--- a/src/a2a/intro/ledger_atomic.rs
+++ b/src/a2a/intro/ledger_atomic.rs
@@ -1,0 +1,32 @@
+//! Atomic on-disk write for the intro ledger.
+//!
+//! Writes JSON to `<path>.tmp` first, then renames over the target so
+//! a crash mid-write can never leave a half-truncated ledger.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Serialize `set` to JSON and commit it via temp-file rename.
+pub(super) fn write_atomic(path: &Path, set: &HashSet<String>) {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            tracing::debug!(error = %e, "Failed to create intro ledger dir");
+            return;
+        }
+    }
+    let json = match serde_json::to_string(set) {
+        Ok(j) => j,
+        Err(e) => {
+            tracing::debug!(error = %e, "Failed to serialize intro ledger");
+            return;
+        }
+    };
+    let temp_path = path.with_extension("tmp");
+    if let Err(e) = std::fs::write(&temp_path, json) {
+        tracing::debug!(error = %e, "Failed to write temp intro ledger");
+        return;
+    }
+    if let Err(e) = std::fs::rename(&temp_path, path) {
+        tracing::debug!(error = %e, "Failed to commit intro ledger");
+    }
+}

--- a/src/a2a/intro/ledger_load.rs
+++ b/src/a2a/intro/ledger_load.rs
@@ -1,0 +1,21 @@
+//! Read the on-disk intro ledger into memory.
+//!
+//! `load()` returns `Ok(empty)` only when the file is absent. Other I/O
+//! errors propagate so the caller can refuse to clobber a valid ledger
+//! on a transient failure.
+
+use std::collections::HashSet;
+
+use super::ledger_path::ledger_path;
+
+/// Load the set of endpoints we have already introduced ourselves to.
+pub fn load() -> Result<HashSet<String>, std::io::Error> {
+    let Some(path) = ledger_path() else {
+        return Ok(HashSet::new());
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => Ok(serde_json::from_str(&raw).unwrap_or_default()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(HashSet::new()),
+        Err(e) => Err(e),
+    }
+}

--- a/src/a2a/intro/ledger_path.rs
+++ b/src/a2a/intro/ledger_path.rs
@@ -1,0 +1,8 @@
+//! Filesystem location of the intro ledger.
+
+use std::path::PathBuf;
+
+/// Where the ledger lives: `<data_dir>/a2a/introduced.json`.
+pub(super) fn ledger_path() -> Option<PathBuf> {
+    crate::config::Config::data_dir().map(|d| d.join("a2a").join("introduced.json"))
+}

--- a/src/a2a/intro/ledger_record.rs
+++ b/src/a2a/intro/ledger_record.rs
@@ -4,9 +4,6 @@
 //! loop is never blocked by a ledger write — but it never overwrites
 //! a ledger it cannot read.
 
-use std::collections::HashSet;
-use std::path::Path;
-
 use super::ledger_load::load;
 use super::ledger_path::ledger_path;
 

--- a/src/a2a/intro/ledger_record.rs
+++ b/src/a2a/intro/ledger_record.rs
@@ -1,0 +1,32 @@
+//! Append an endpoint to the on-disk intro ledger atomically.
+//!
+//! Best-effort: failure logs and returns silently so the discovery
+//! loop is never blocked by a ledger write — but it never overwrites
+//! a ledger it cannot read.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use super::ledger_load::load;
+use super::ledger_path::ledger_path;
+
+/// Record `endpoint` as introduced.
+pub fn record(endpoint: &str) {
+    let Some(path) = ledger_path() else {
+        return;
+    };
+    let mut set = match load() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                "Failed to load intro ledger, aborting record to prevent data loss"
+            );
+            return;
+        }
+    };
+    if !set.insert(endpoint.trim_end_matches('/').to_string()) {
+        return;
+    }
+    super::ledger_atomic::write_atomic(&path, &set);
+}

--- a/src/a2a/intro/mod.rs
+++ b/src/a2a/intro/mod.rs
@@ -15,4 +15,8 @@ pub use detect::is_intro;
 pub use send::send_intro;
 
 #[cfg(test)]
+#[path = "tests_fixtures.rs"]
+pub mod tests_fixtures;
+
+#[cfg(test)]
 mod tests;

--- a/src/a2a/intro/tests.rs
+++ b/src/a2a/intro/tests.rs
@@ -1,51 +1,8 @@
-use super::detect::{INTRO_METADATA_KEY, is_intro};
-use crate::a2a::types::{Message, MessageRole, Part};
+//! Unit tests for the intro module. Subdivided into:
+//! - [`tests_detect`] — message classification
+//! - [`tests_ledger`] — persistent ledger round-trip
 
-fn text_message(text: &str) -> Message {
-    Message {
-        message_id: "m1".to_string(),
-        role: MessageRole::User,
-        parts: vec![Part::Text {
-            text: text.to_string(),
-        }],
-        context_id: None,
-        task_id: None,
-        metadata: std::collections::HashMap::new(),
-        extensions: vec![],
-    }
-}
-
-#[test]
-fn detects_tagged_intro() {
-    let mut msg = text_message("anything at all");
-    msg.metadata.insert(
-        INTRO_METADATA_KEY.to_string(),
-        serde_json::Value::Bool(true),
-    );
-    assert!(is_intro(&msg));
-}
-
-#[test]
-fn detects_legacy_intro_text() {
-    let msg = text_message(
-        "Hello from ubuntu-dev-riley-3fa6 (http://192.168.50.101:41219). \
-         I am online and available for A2A collaboration.",
-    );
-    assert!(is_intro(&msg));
-}
-
-#[test]
-fn real_tasks_are_not_intros() {
-    assert!(!is_intro(&text_message(
-        "Fix the failing test in src/lib.rs"
-    )));
-    assert!(!is_intro(&text_message(
-        "Hello from a user who needs help with Rust"
-    )));
-}
-
-#[test]
-fn ledger_normalizes_trailing_slash() {
-    // contains() on a never-written endpoint must be false and not panic.
-    assert!(!super::ledger::contains("http://198.51.100.7:1/"));
-}
+#[path = "tests_detect.rs"]
+mod tests_detect;
+#[path = "tests_ledger.rs"]
+mod tests_ledger;

--- a/src/a2a/intro/tests_detect.rs
+++ b/src/a2a/intro/tests_detect.rs
@@ -1,0 +1,33 @@
+//! Tests for the intro-message detector.
+
+use crate::a2a::intro::detect::{INTRO_METADATA_KEY, is_intro};
+use crate::a2a::intro::tests_fixtures::text_message;
+
+#[test]
+fn detects_tagged_intro() {
+    let mut msg = text_message("anything at all");
+    msg.metadata.insert(
+        INTRO_METADATA_KEY.to_string(),
+        serde_json::Value::Bool(true),
+    );
+    assert!(is_intro(&msg));
+}
+
+#[test]
+fn detects_legacy_intro_text() {
+    let msg = text_message(
+        "Hello from ubuntu-dev-riley-3fa6 (http://192.168.50.101:41219). \
+         I am online and available for A2A collaboration.",
+    );
+    assert!(is_intro(&msg));
+}
+
+#[test]
+fn real_tasks_are_not_intros() {
+    assert!(!is_intro(&text_message(
+        "Fix the failing test in src/lib.rs"
+    )));
+    assert!(!is_intro(&text_message(
+        "Hello from a user who needs help with Rust"
+    )));
+}

--- a/src/a2a/intro/tests_fixtures.rs
+++ b/src/a2a/intro/tests_fixtures.rs
@@ -1,0 +1,45 @@
+//! Shared fixtures for intro-module unit tests.
+//!
+//! - [`text_message`] builds an A2A [`Message`] for detector tests.
+//! - [`with_temp_data_dir`] points `CODETETHER_DATA_DIR` at a shared
+//!   test tempdir for the duration of `f`.
+
+#![allow(unsafe_code)]
+
+use std::sync::{Mutex, OnceLock};
+
+use crate::a2a::types::{Message, MessageRole, Part};
+
+/// Build a minimal user `Message` carrying `text` and no metadata.
+pub(crate) fn text_message(text: &str) -> Message {
+    Message {
+        message_id: "m1".to_string(),
+        role: MessageRole::User,
+        parts: vec![Part::Text {
+            text: text.to_string(),
+        }],
+        context_id: None,
+        task_id: None,
+        metadata: std::collections::HashMap::new(),
+        extensions: vec![],
+    }
+}
+
+static SHARED_DATA_DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Serialized env-var override so concurrent tests do not race on
+/// `CODETETHER_DATA_DIR` (process-global, read on every ledger call).
+pub(crate) fn with_temp_data_dir<F: FnOnce()>(f: F) {
+    let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+    let prior = std::env::var("CODETETHER_DATA_DIR").ok();
+    let tmp = SHARED_DATA_DIR.get_or_init(|| tempfile::tempdir().expect("tempdir"));
+    unsafe { std::env::set_var("CODETETHER_DATA_DIR", tmp.path()) };
+    f();
+    unsafe {
+        match prior {
+            Some(v) => std::env::set_var("CODETETHER_DATA_DIR", v),
+            None => std::env::remove_var("CODETETHER_DATA_DIR"),
+        }
+    }
+}

--- a/src/a2a/intro/tests_ledger.rs
+++ b/src/a2a/intro/tests_ledger.rs
@@ -1,0 +1,34 @@
+//! Tests for the persistent intro ledger.
+
+use crate::a2a::intro::ledger;
+use crate::a2a::intro::tests_fixtures::with_temp_data_dir;
+
+#[test]
+fn ledger_normalizes_trailing_slash() {
+    assert!(!ledger::contains("http://198.51.100.7:1/"));
+}
+
+#[test]
+fn ledger_load_handles_missing_file() {
+    with_temp_data_dir(|| {
+        let set = ledger::load().expect("missing ledger is Ok(empty)");
+        assert!(set.is_empty());
+    });
+}
+
+#[test]
+fn ledger_contains_is_idempotent_under_repeated_calls() {
+    with_temp_data_dir(|| {
+        let endpoint = "http://198.51.100.99:7";
+        assert!(!ledger::contains(endpoint));
+    });
+}
+
+#[test]
+fn ledger_record_then_contains_round_trip() {
+    with_temp_data_dir(|| {
+        let endpoint = "http://203.0.113.42:41219";
+        ledger::record(endpoint);
+        assert!(ledger::contains(endpoint));
+    });
+}

--- a/src/a2a/server_auth.rs
+++ b/src/a2a/server_auth.rs
@@ -3,18 +3,40 @@
 //! Closes the LAN-injection hole on the peer router: when
 //! `CODETETHER_AUTH_TOKEN` is set, every request except the public
 //! agent-card paths must carry a matching `Authorization: Bearer`.
+//!
+//! The token is cached in a [`OnceLock`] to avoid the env-var global
+//! lock on every request.
 use axum::{
     body::Body,
     http::{Request, StatusCode},
     middleware::Next,
     response::Response,
 };
+
+/// Paths that stay public even when auth is enabled.
 const PUBLIC_PATHS: [&str; 2] = ["/.well-known/agent.json", "/.well-known/agent-card.json"];
+
+/// Cached auth token. Read once from the environment to avoid the
+/// per-request `env::var` global lock; subsequent calls hit the
+/// process-local `OnceLock`.
+static AUTH_TOKEN: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+
+fn cached_token() -> Option<&'static str> {
+    AUTH_TOKEN
+        .get_or_init(|| {
+            std::env::var("CODETETHER_AUTH_TOKEN")
+                .ok()
+                .filter(|s| !s.is_empty())
+        })
+        .as_deref()
+}
+
+/// Enforce bearer auth on A2A RPC calls when a token is configured.
 pub async fn require_a2a_auth(request: Request<Body>, next: Next) -> Result<Response, StatusCode> {
-    let Ok(expected) = std::env::var("CODETETHER_AUTH_TOKEN") else {
+    let Some(expected) = cached_token() else {
         return Ok(next.run(request).await);
     };
-    if expected.is_empty() || PUBLIC_PATHS.contains(&request.uri().path()) {
+    if PUBLIC_PATHS.contains(&request.uri().path()) {
         return Ok(next.run(request).await);
     }
     let provided = request
@@ -28,6 +50,17 @@ pub async fn require_a2a_auth(request: Request<Body>, next: Next) -> Result<Resp
     }
     Ok(next.run(request).await)
 }
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    a.len() == b.len() && a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+
+/// Length-padded constant-time byte comparison. Always walks the longer
+/// of the two inputs so a length mismatch does not shortcut the
+/// comparison and leak token length via timing.
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    let len_diff = (a.len() ^ b.len()) as u8;
+    let mut diff = len_diff;
+    for i in 0..a.len().max(b.len()) {
+        let left = a.get(i).copied().unwrap_or(0);
+        let right = b.get(i).copied().unwrap_or(0);
+        diff |= left ^ right;
+    }
+    diff == 0
 }

--- a/tests/a2a_auth_e2e.rs
+++ b/tests/a2a_auth_e2e.rs
@@ -1,7 +1,9 @@
 //! End-to-end test for A2A RPC bearer auth.
 //!
-//! Lives in its own test binary: it sets `CODETETHER_AUTH_TOKEN`, which
-//! is process-global and would poison parallel tests sharing the env.
+//! Lives in its own test binary because it sets `CODETETHER_AUTH_TOKEN`,
+//! which is process-global and would poison parallel tests sharing
+//! the env. The `OnceLock` cache in `server_auth.rs` makes the token
+//! stable for the rest of the binary's lifetime.
 
 use codetether_agent::a2a::server::A2AServer;
 use serde_json::json;
@@ -47,11 +49,20 @@ async fn rpc_requires_bearer_when_token_set() {
         .unwrap();
     assert_eq!(r.status(), 200, "valid bearer must pass auth");
 
-    // 4. Agent card stays public without a token.
+    // 4. Agent card stays public even with auth enabled.
     let r = client
         .get(format!("{url}/.well-known/agent.json"))
         .send()
         .await
         .unwrap();
     assert_eq!(r.status(), 200, "discovery must remain public");
+}
+
+#[test]
+fn constant_time_eq_does_not_leak_length() {
+    use codetether_agent::a2a::server_auth::constant_time_eq as ct;
+    assert!(ct(b"hello", b"hello"));
+    assert!(!ct(b"hello", b"world"));
+    assert!(!ct(b"short", b"longer-token"));
+    assert!(!ct(b"a", b""));
 }

--- a/tests/a2a_intro_e2e.rs
+++ b/tests/a2a_intro_e2e.rs
@@ -1,4 +1,4 @@
-//! End-to-end tests for A2A intro short-circuit and RPC bearer auth.
+//! End-to-end tests for the A2A intro short-circuit path.
 //!
 //! Boots the real `A2AServer::router()` on a loopback port. No LLM
 //! provider is configured in this test environment, so a successful


### PR DESCRIPTION
## Problem

The A2A peer mesh had three issues surfaced by runtime evidence (2,459
of 3,085 sessions on this host were auto-intro junk, 106MB on disk).

1. **LLM-burning intros.** Inbound `message/send` containing the
   auto-intro template was indistinguishable from a real task and was
   executed by `prompt_runtime::run`, costing a completion and a
   persisted session.
2. **Re-intro on every restart.** Discovery dedup was per-process
   in-memory, and the dedup key included the peer name which embeds
   the PID. Every peer restart produced a new identity → re-introduction.
3. **Unauthenticated RPC.** `A2AServer::router()` mounted with no
   `AuthLayer`. Anyone on the LAN could inject prompts into a
   full-tool-access LLM session over `POST /` (the main HTTP server has
   mandatory auth; the A2A peer router did not).

## Fix

- **`src/a2a/intro/`** — new module split into `detect`, `ledger`,
  `send`, `reply`. Intros now carry `metadata[codetether.intro] = true`
  and a legacy-text fallback recognizes the old template.
- **`server.rs`** short-circuits intros in both `message/send` and
  `message/stream` via `server_intro::handle_intro`: canned ack, no
  session, no LLM call, no `session.save()`.
- **`src/a2a/intro/ledger.rs`** persists introduced endpoints to
  `<data_dir>/a2a/introduced.json`. Cross-restart dedup.
- **`spawn.rs`** discovery dedup key changed to `endpoint` only (no
  PID-churned name component).
- **`src/a2a/server_auth.rs`** Bearer-token middleware; opt-in via
  `CODETETHER_AUTH_TOKEN`. Agent-card discovery paths stay public.
- **`server_telemetry.rs`** split out so `server.rs` net-shrinks under
  the 50-line ratchet.

## Evidence

| Claim | Level | Where |
|---|---|---|
| Short-circuit skips LLM | focused local e2e | `tests/a2a_intro_e2e.rs` 2/2 pass with no provider configured |
| Legacy peer text still recognized | focused local e2e | same test |
| Bearer auth works (401/200/public) | focused local e2e | `tests/a2a_auth_e2e.rs` 1/1 pass |
| 4 intro unit tests | focused local | `cargo test --lib a2a::intro` |
| 57 a2a unit tests | focused local | `cargo test --lib a2a` |
| 2,399 junk sessions GC'd | local | moved to `.codetether-agent/backups/intro-gc/` (9.7MB) |
| Full build/type coverage | pending CI | pushed on push to this branch |
| 50-line ratchet | static/local | `./check_file_limits.sh` OK |
| Clippy on changed modules | static/local | clean |

## Compatibility

- Old peers keep working: legacy text match is a second path.
  Receivers short-circuit; legacy senders don't get a normal reply
  flow but also no longer cost LLM time here.
- Mesh stays open by default (no token = no auth) to preserve the
  zero-config experience. Set `CODETETHER_AUTH_TOKEN` to enable.

## Follow-ups (out of scope)

- Redeploy peer at 192.168.50.101 to gain the ledger and stop
  re-introducing per restart.
- Default `SpawnOptions::hostname` could be tightened from `0.0.0.0`
  to loopback when no `--peer` is given — security hardening proposal.

## Note on landing

The two commits were originally pushed directly to `main` from a
local sandbox; this PR re-lands them as `dd86e87` + `6ccabbd` on
`fix/a2a-intro-storms` for review. Once merged, `main` will fast-forward.