### PR TITLE
fix(approval): recover poisoned test env lock

### DIFF
--- a/src/approval/mod.rs
+++ b/src/approval/mod.rs
@@ -33,6 +33,14 @@ pub use store::ApprovalStore;
 #[cfg(test)]
 pub(crate) mod test_env {
     pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Acquire the shared env lock, recovering from poison so one panicking
+    /// test does not cascade `PoisonError` failures into unrelated tests.
+    pub(crate) fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 }
 
 #[cfg(test)]

--- a/src/mcp/approval/session_decision_tests.rs
+++ b/src/mcp/approval/session_decision_tests.rs
@@ -1,4 +1,4 @@
-use crate::approval::{ApprovalStore, session_command_grants, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, session_command_grants, test_env::lock_env};
 use serde_json::json;
 
 struct EnvGuard;
@@ -12,7 +12,7 @@ impl Drop for EnvGuard {
 
 #[tokio::test]
 async fn mcp_execpolicy_decision_grants_session_prefix() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     unsafe { std::env::set_var("CODETETHER_DATA_DIR", data.path()) };
     session_command_grants::reset();

--- a/src/mcp/approval/tests.rs
+++ b/src/mcp/approval/tests.rs
@@ -1,5 +1,5 @@
 use crate::approval::{
-    ApprovalStore, LiveApprovalDecision, LiveApprovalRequest, test_env::ENV_LOCK,
+    ApprovalStore, LiveApprovalDecision, LiveApprovalRequest, test_env::lock_env,
 };
 use serde_json::json;
 
@@ -20,7 +20,7 @@ impl Drop for EnvGuard {
 
 #[tokio::test]
 async fn mcp_decision_resumes_live_approval_request() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     let store = ApprovalStore::open(data.path().join("approvals")).expect("store");

--- a/src/mcp/subprocess_policy_alias_tests.rs
+++ b/src/mcp/subprocess_policy_alias_tests.rs
@@ -1,8 +1,8 @@
-use super::{ApprovalStore, ENV_LOCK, EnvGuard, guard, policy_args};
+use super::{ApprovalStore, EnvGuard, guard, lock_env, policy_args};
 
 #[tokio::test]
 async fn approved_mcp_bridge_alias_allows_subprocess_spawn_gate() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     let store = ApprovalStore::open(data.path().join("approvals")).expect("store");

--- a/src/mcp/subprocess_policy_tests.rs
+++ b/src/mcp/subprocess_policy_tests.rs
@@ -1,5 +1,5 @@
 use super::{guard, policy_args};
-use crate::approval::{ApprovalStore, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, test_env::lock_env};
 
 #[path = "subprocess_policy_alias_tests.rs"]
 mod alias;
@@ -21,7 +21,7 @@ impl Drop for EnvGuard {
 
 #[tokio::test]
 async fn subprocess_spawn_requires_policy_approval() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     assert!(guard("npx", &["server"], None).await.is_err());
@@ -29,7 +29,7 @@ async fn subprocess_spawn_requires_policy_approval() {
 
 #[tokio::test]
 async fn approved_mcp_receipt_allows_subprocess_spawn_gate() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     let store = ApprovalStore::open(data.path().join("approvals")).expect("store");

--- a/src/ralph/verification/tests_shell.rs
+++ b/src/ralph/verification/tests_shell.rs
@@ -1,5 +1,5 @@
 use super::run_story_verification;
-use crate::approval::test_env::ENV_LOCK;
+use crate::approval::test_env::lock_env;
 use crate::ralph::types::{UserStory, VerificationStep};
 use tempfile::tempdir;
 
@@ -8,7 +8,7 @@ mod shell_env;
 
 #[tokio::test]
 async fn shell_step_checks_output_and_artifacts() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let dir = tempdir().expect("tempdir");
     let _env = shell_env::TrustedShellProject::new(dir.path());
     let step = VerificationStep::Shell {

--- a/src/runtime_policy/approval_tests.rs
+++ b/src/runtime_policy/approval_tests.rs
@@ -1,5 +1,5 @@
 use super::{RuntimeToolPolicy, ToolPolicyOutcome};
-use crate::approval::test_env::ENV_LOCK;
+use crate::approval::test_env::lock_env;
 use crate::config::Config;
 
 struct EnvGuard;
@@ -19,7 +19,7 @@ impl Drop for EnvGuard {
 
 #[test]
 fn approval_required_result_includes_request_id() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     let policy = RuntimeToolPolicy::from_config(&Config::default());

--- a/src/runtime_policy/invocation_tests.rs
+++ b/src/runtime_policy/invocation_tests.rs
@@ -1,5 +1,5 @@
 use super::evaluate_tool_invocation_with_config;
-use crate::approval::{ApprovalStore, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, test_env::lock_env};
 use crate::config::{Config, PermissionProfile, PermissionProfileConfig};
 use serde_json::json;
 
@@ -20,7 +20,7 @@ impl Drop for EnvGuard {
 
 #[test]
 fn approved_invocation_id_allows_required_tool() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     let store = ApprovalStore::open(data.path().join("approvals")).expect("store");

--- a/src/runtime_policy/patch_invocation_tests.rs
+++ b/src/runtime_policy/patch_invocation_tests.rs
@@ -1,5 +1,5 @@
 use super::evaluate_tool_invocation_with_config;
-use crate::approval::{ApprovalStore, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, test_env::lock_env};
 use crate::config::Config;
 use serde_json::json;
 
@@ -20,7 +20,7 @@ impl Drop for EnvGuard {
 
 #[test]
 fn patch_write_receipt_satisfies_runtime_gate() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     let store = ApprovalStore::open(data.path().join("approvals")).expect("store");

--- a/src/runtime_policy/session_command_grants_tests.rs
+++ b/src/runtime_policy/session_command_grants_tests.rs
@@ -1,4 +1,4 @@
-use crate::approval::{ApprovalStore, session_command_grants, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, session_command_grants, test_env::lock_env};
 use crate::config::{Config, PermissionAction};
 use crate::runtime_policy::evaluate_tool_invocation_with_config;
 use serde_json::json;
@@ -21,7 +21,7 @@ fn setup() -> (tempfile::TempDir, EnvGuard) {
 
 #[test]
 fn proposed_prefix_session_approval_allows_future_matching_command() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let (data, _env) = setup();
     let store = ApprovalStore::open_default().expect("store");
     let args = json!({
@@ -42,7 +42,7 @@ fn proposed_prefix_session_approval_allows_future_matching_command() {
 
 #[test]
 fn configured_deny_overrides_session_prefix() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let (_data, _env) = setup();
     session_command_grants::remember_request("approval-1", vec!["cargo test".into()]);
     session_command_grants::grant_for_request("approval-1");

--- a/src/runtime_policy/session_grants_tests.rs
+++ b/src/runtime_policy/session_grants_tests.rs
@@ -1,5 +1,5 @@
 use super::evaluate_tool_invocation_with_config;
-use crate::approval::{ApprovalStore, session_grants, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, session_grants, test_env::lock_env};
 use crate::config::Config;
 use serde_json::json;
 
@@ -15,7 +15,7 @@ impl Drop for EnvGuard {
 
 #[test]
 fn session_grant_allows_future_matching_invocation() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     unsafe { std::env::set_var("CODETETHER_DATA_DIR", data.path()) };
     let _env = EnvGuard;

--- a/src/runtime_policy/workspace_tests.rs
+++ b/src/runtime_policy/workspace_tests.rs
@@ -1,5 +1,5 @@
 use super::evaluate_tool_invocation;
-use crate::approval::test_env::ENV_LOCK;
+use crate::approval::test_env::lock_env;
 use crate::config::ProjectTrustStore;
 use serde_json::json;
 
@@ -20,7 +20,7 @@ impl Drop for EnvGuard {
 
 #[tokio::test]
 async fn policy_loads_config_for_tool_cwd_workspace() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("data");
     let _env = EnvGuard::data_dir(data.path());
     let workspace = tempfile::tempdir().expect("workspace");

--- a/src/server/approval_routes/session_decision_tests.rs
+++ b/src/server/approval_routes/session_decision_tests.rs
@@ -1,4 +1,4 @@
-use crate::approval::{ApprovalStore, session_command_grants, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, session_command_grants, test_env::lock_env};
 use axum::http::{Request, StatusCode};
 use serde_json::json;
 use tower::ServiceExt;
@@ -8,7 +8,7 @@ mod env;
 
 #[tokio::test]
 async fn server_session_decision_grants_prefix() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = env::EnvGuard::data_dir(data.path());
     session_command_grants::reset();

--- a/src/server/approval_routes/tests.rs
+++ b/src/server/approval_routes/tests.rs
@@ -1,4 +1,4 @@
-use crate::approval::{ApprovalEvent, ApprovalStore, test_env::ENV_LOCK};
+use crate::approval::{ApprovalEvent, ApprovalStore, test_env::lock_env};
 use axum::http::{Request, StatusCode};
 use serde_json::json;
 use tower::ServiceExt;
@@ -8,7 +8,7 @@ mod env;
 
 #[tokio::test]
 async fn approval_request_and_decision_routes_round_trip() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = env::EnvGuard::data_dir(data.path());
     let app = super::router::<()>();

--- a/src/swarm/quality_shell_tests.rs
+++ b/src/swarm/quality_shell_tests.rs
@@ -1,5 +1,5 @@
 use super::cargo_check_quiet;
-use crate::approval::test_env::ENV_LOCK;
+use crate::approval::test_env::lock_env;
 
 struct EnvGuard;
 
@@ -18,7 +18,7 @@ impl Drop for EnvGuard {
 
 #[test]
 fn cargo_check_requires_runtime_policy_approval() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     assert!(!cargo_check_quiet(None).expect("policy result"));

--- a/src/tool/bash_tests_approved.rs
+++ b/src/tool/bash_tests_approved.rs
@@ -1,5 +1,5 @@
 use super::super::{BashTool, Tool};
-use crate::approval::{ApprovalStore, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, test_env::lock_env};
 use crate::config::Config;
 use serde_json::json;
 
@@ -13,7 +13,7 @@ impl Drop for EnvGuard {
 
 #[tokio::test]
 async fn approved_bash_keeps_sandbox_or_uses_approved_fallback() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     unsafe { std::env::set_var("CODETETHER_DATA_DIR", data.path()) };
     let _env = EnvGuard;

--- a/src/tool/batch_policy_tests.rs
+++ b/src/tool/batch_policy_tests.rs
@@ -1,13 +1,13 @@
 use super::execute;
-use crate::approval::test_env::ENV_LOCK;
+use crate::approval::test_env::lock_env;
 use crate::tool::ToolRegistry;
 use serde_json::json;
 
 #[tokio::test(flavor = "current_thread")]
 async fn nested_mutating_tool_requires_policy_approval() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = lock_env();
     let data = tempfile::tempdir().expect("data dir");
-    // SAFETY: this focused test serializes process env access with ENV_LOCK.
+    // SAFETY: this focused test serializes process env access with the shared env lock.
     unsafe { std::env::set_var("CODETETHER_DATA_DIR", data.path()) };
     let registry = ToolRegistry::with_defaults_arc();
     let (_, tool_id, result) = execute(

--- a/src/tool/mcp_bridge_policy_tests.rs
+++ b/src/tool/mcp_bridge_policy_tests.rs
@@ -1,5 +1,5 @@
 use super::{blocked, policy_args};
-use crate::approval::{ApprovalStore, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, test_env::lock_env};
 
 struct EnvGuard;
 
@@ -11,7 +11,7 @@ impl Drop for EnvGuard {
 
 #[tokio::test]
 async fn bridge_policy_block_includes_approval_id() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     unsafe { std::env::set_var("CODETETHER_DATA_DIR", data.path()) };
     let _env = EnvGuard;
@@ -23,7 +23,7 @@ async fn bridge_policy_block_includes_approval_id() {
 
 #[tokio::test]
 async fn bridge_policy_accepts_approved_id() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     unsafe { std::env::set_var("CODETETHER_DATA_DIR", data.path()) };
     let _env = EnvGuard;
@@ -38,7 +38,7 @@ async fn bridge_policy_accepts_approved_id() {
 
 #[tokio::test]
 async fn bridge_policy_accepts_alias_approved_id() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     unsafe { std::env::set_var("CODETETHER_DATA_DIR", data.path()) };
     let _env = EnvGuard;

--- a/src/tool/patch/approval_tests.rs
+++ b/src/tool/patch/approval_tests.rs
@@ -1,12 +1,12 @@
 //! Tests for approval-gated patch execution.
 
 use super::test_support::{EnvGuard, ORIGINAL, execute, sample_patch, seed};
-use crate::approval::test_env::ENV_LOCK;
+use crate::approval::test_env::lock_env;
 use serde_json::json;
 
 #[tokio::test]
 async fn patch_approval_required_does_not_write() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let _env = EnvGuard::set("CODETETHER_PATCH_APPROVAL_REQUIRED", "1");
     let data = tempfile::tempdir().expect("tempdir");
     let _data_env = EnvGuard::set("CODETETHER_DATA_DIR", data.path().to_str().unwrap());

--- a/src/tool/patch/approval_verify_tests.rs
+++ b/src/tool/patch/approval_verify_tests.rs
@@ -1,12 +1,12 @@
 //! Tests for store-backed patch approval verification.
 
 use super::test_support::{EnvGuard, ORIGINAL, execute, sample_patch, seed};
-use crate::approval::{ApprovalStore, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStore, test_env::lock_env};
 use serde_json::json;
 
 #[tokio::test]
 async fn approved_patch_id_allows_write() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let _env = EnvGuard::set("CODETETHER_PATCH_APPROVAL_REQUIRED", "1");
     let data = tempfile::tempdir().expect("tempdir");
     let _data_env = EnvGuard::set("CODETETHER_DATA_DIR", data.path().to_str().unwrap());

--- a/src/tui/app/event_handlers/approval_key_tests.rs
+++ b/src/tui/app/event_handlers/approval_key_tests.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::approval::{ApprovalStatus, ApprovalStore, LiveApprovalRequest, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStatus, ApprovalStore, LiveApprovalRequest, test_env::lock_env};
 use crate::tui::app::event_handlers::keyboard::handle_ctrl_key;
 use crate::tui::app::session_runtime;
 use crate::tui::app::state::{App, approval_queue};
@@ -35,7 +35,7 @@ fn setup() -> (tempfile::TempDir, EnvGuard, ApprovalStore, String) {
 
 #[tokio::test(flavor = "current_thread")]
 async fn ctrl_a_approves_active_request() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let (_dir, _env, store, id) = setup();
     let mut app = App::default();
     let (tx, _) = tokio::sync::mpsc::channel(1);

--- a/src/tui/app/input/approval_command_deny_tests.rs
+++ b/src/tui/app/input/approval_command_deny_tests.rs
@@ -1,5 +1,5 @@
 use super::approval_command;
-use crate::approval::{ApprovalStatus, ApprovalStore, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStatus, ApprovalStore, test_env::lock_env};
 use crate::tui::app::state::App;
 
 struct EnvGuard;
@@ -19,7 +19,7 @@ impl Drop for EnvGuard {
 
 #[test]
 fn deny_records_decision() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     let store = ApprovalStore::open_default().expect("store");

--- a/src/tui/app/input/approval_command_queue_tests.rs
+++ b/src/tui/app/input/approval_command_queue_tests.rs
@@ -1,10 +1,10 @@
 use super::test_support as support;
-use crate::approval::{ApprovalStatus, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStatus, test_env::lock_env};
 use crate::tui::app::state::{App, approval_queue};
 
 #[test]
 fn approve_session_uses_active_queued_request() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let (_data, _env, store, id) = support::setup();
     let mut app = App::default();
 
@@ -19,7 +19,7 @@ fn approve_session_uses_active_queued_request() {
 
 #[test]
 fn abort_denies_active_queued_request() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let (_data, _env, store, id) = support::setup();
     let mut app = App::default();
 
@@ -31,7 +31,7 @@ fn abort_denies_active_queued_request() {
 
 #[test]
 fn approve_session_grants_remembered_command_prefix() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let (_data, _env, _store, id) = support::setup();
     crate::approval::session_command_grants::remember_request(&id, vec!["cargo test".into()]);
     let mut app = App::default();

--- a/src/tui/app/input/approval_command_tests.rs
+++ b/src/tui/app/input/approval_command_tests.rs
@@ -1,5 +1,5 @@
 use super::approval_command;
-use crate::approval::{ApprovalStatus, ApprovalStore, test_env::ENV_LOCK};
+use crate::approval::{ApprovalStatus, ApprovalStore, test_env::lock_env};
 use crate::tui::app::state::App;
 
 struct EnvGuard;
@@ -19,7 +19,7 @@ impl Drop for EnvGuard {
 
 #[test]
 fn approve_records_decision_without_retry_prompt() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _lock = lock_env();
     let data = tempfile::tempdir().expect("tempdir");
     let _env = EnvGuard::data_dir(data.path());
     let store = ApprovalStore::open_default().expect("store");

--- a/src/tui/app/session_events/tests_tool_status.rs
+++ b/src/tui/app/session_events/tests_tool_status.rs
@@ -39,6 +39,6 @@ async fn approval_required_tool_result_surfaces_approve_command() {
     )
     .await;
     assert!(app.state.status.contains("/approve approval-1"));
-    assert!(app.state.status.contains("--access-mode approve"));
+    assert!(app.state.status.contains("/access-mode approve"));
     assert!(!app.state.status.contains("retry"));
 }


### PR DESCRIPTION
## Summary

- Add `approval::test_env::lock_env()` to recover from poisoned test mutex state instead of cascading `PoisonError` failures.
- Update approval/runtime-policy/TUI tests to use the helper consistently.
- Correct the approval-required TUI status assertion from `--access-mode approve` to the slash-command form `/access-mode approve` emitted by the UI.

## Validation

- focused CI-like: `./check_file_limits.sh <changed src/**/*.rs>` — passed
- focused CI-like: `cargo test approval --lib` — passed (46 tests)

## Notes

This PR is test-infrastructure only except for the status assertion correction. It does not change runtime approval behavior.