### PR TITLE
fix(runtime_policy): skip sandbox preflight for approval-never

### DIFF
--- a/src/runtime_policy/policy.rs
+++ b/src/runtime_policy/policy.rs
@@ -44,6 +44,10 @@ impl RuntimeToolPolicy {
         super::command_rule::outcome(&self.permissions, command)
     }
 
+    pub(crate) fn approval_policy(&self) -> ApprovalPolicy {
+        self.approval_policy
+    }
+
     pub(crate) fn sandbox_mode(&self) -> SandboxMode {
         self.sandbox_mode
     }

--- a/src/runtime_policy/sandbox_preflight.rs
+++ b/src/runtime_policy/sandbox_preflight.rs
@@ -1,7 +1,7 @@
 //! Approval preflight for unavailable OS sandbox runners.
 
 use super::{DecisionReason, RuntimeToolPolicy, ToolKind, ToolPolicyDecision, ToolPolicyOutcome};
-use crate::config::SandboxMode;
+use crate::config::{ApprovalPolicy, SandboxMode};
 use serde_json::Value;
 
 pub(super) fn decision(
@@ -10,6 +10,9 @@ pub(super) fn decision(
     args: &Value,
 ) -> Option<ToolPolicyDecision> {
     let command = args.get("command").and_then(Value::as_str)?;
+    if matches!(policy.approval_policy(), ApprovalPolicy::Never) {
+        return None;
+    }
     decision_for_state(
         tool_name,
         command,
@@ -42,3 +45,6 @@ fn decision_for_state(
 #[cfg(test)]
 #[path = "sandbox_preflight_tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "sandbox_preflight_policy_tests.rs"]
+mod policy_tests;

--- a/src/runtime_policy/sandbox_preflight_policy_tests.rs
+++ b/src/runtime_policy/sandbox_preflight_policy_tests.rs
@@ -1,0 +1,15 @@
+use super::decision;
+use crate::config::{ApprovalPolicy, Config, SandboxMode};
+use crate::runtime_policy::RuntimeToolPolicy;
+use serde_json::json;
+
+#[test]
+fn approval_never_skips_sandbox_unavailable_preflight() {
+    let mut config = Config::default();
+    config.approval_policy = Some(ApprovalPolicy::Never);
+    config.sandbox_mode = Some(SandboxMode::WorkspaceWrite);
+    let policy = RuntimeToolPolicy::from_config(&config);
+    let args = json!({"command": "printf ok > file"});
+
+    assert!(decision(&policy, "bash", &args).is_none());
+}


### PR DESCRIPTION
## Summary

- Add `RuntimeToolPolicy::approval_policy()` for sandbox preflight decisions.
- Skip sandbox-unavailable approval preflight when the effective `approval_policy` is `Never`.
- Add a focused regression test for mutating bash commands under `WorkspaceWrite` with approval policy set to `Never`.

## Validation

- focused CI-like: `./check_file_limits.sh src/runtime_policy/policy.rs src/runtime_policy/sandbox_preflight.rs src/runtime_policy/sandbox_preflight_policy_tests.rs` — passed
- static/local: LSP diagnostics on the three changed Rust files — no diagnostics found
- focused CI-like: `cargo test approval_never_skips_sandbox_unavailable_preflight --lib` — passed (1 test)

## Notes

This intentionally does **not** reorder `command_rule` ahead of `sandbox_preflight`. Explicit deny rules still short-circuit first, but command allow rules should not bypass sandbox-unavailable preflight unless approvals are globally disabled with `approval_policy = "never"`.