### PR TITLE
Session listing index + env-tunable agent-loop guardrails

### DIFF
--- a/src/session/helper/loop_constants.rs
+++ b/src/session/helper/loop_constants.rs
@@ -5,6 +5,12 @@
 //! guardrails that detect and break pathological loops (e.g. the model keeps
 //! running the same tool, keeps promising to call a tool without ever doing
 //! it, etc.).
+//!
+//! The numeric guardrails can be overridden per-invocation via environment
+//! variables (`CODETETHER_MAX_TOOL_CALLS`,
+//! `CODETETHER_MAX_CONSECUTIVE_SAME_TOOL`,
+//! `CODETETHER_MAX_STEPS_WITHOUT_PROGRESS`) — mirroring how
+//! [`crate::config::guardrails::CostGuardrails`] reads its cost caps.
 
 /// Reminder sent when the build-mode agent responds with a plan-only answer
 /// despite the user asking for a file change.
@@ -28,17 +34,46 @@ pub(crate) const MAX_CONSECUTIVE_CODESEARCH_NO_MATCHES: u32 = 5;
 /// we give up and surface the report to the caller.
 pub(crate) const POST_EDIT_VALIDATION_MAX_RETRIES: u8 = 3;
 
+/// Default for [`max_consecutive_same_tool`].
+pub(crate) const DEFAULT_MAX_CONSECUTIVE_SAME_TOOL: u32 = 3;
+
+/// Default for [`max_total_tool_calls`]. Sized as a stuck-model backstop,
+/// not a working budget: legitimate implementation turns routinely need
+/// >100 calls, and `--max-steps` (default 250) already bounds the loop.
+pub(crate) const DEFAULT_MAX_TOTAL_TOOL_CALLS: u32 = 200;
+
+/// Default for [`max_steps_without_progress`].
+pub(crate) const DEFAULT_MAX_STEPS_WITHOUT_PROGRESS: u32 = 15;
+
 /// Maximum number of consecutive identical tool calls allowed before the loop
-/// forces a final answer.
-pub(crate) const MAX_CONSECUTIVE_SAME_TOOL: u32 = 3;
+/// forces a final answer. Overridable via
+/// `CODETETHER_MAX_CONSECUTIVE_SAME_TOOL`.
+pub(crate) fn max_consecutive_same_tool() -> u32 {
+    env_u32("CODETETHER_MAX_CONSECUTIVE_SAME_TOOL").unwrap_or(DEFAULT_MAX_CONSECUTIVE_SAME_TOOL)
+}
 
 /// Absolute ceiling on total tool calls within a single agentic turn.
 /// Beyond this the loop terminates with an error summarising what happened.
-pub(crate) const MAX_TOTAL_TOOL_CALLS: u32 = 60;
+/// Overridable via `CODETETHER_MAX_TOOL_CALLS`.
+pub(crate) fn max_total_tool_calls() -> u32 {
+    env_u32("CODETETHER_MAX_TOOL_CALLS").unwrap_or(DEFAULT_MAX_TOTAL_TOOL_CALLS)
+}
 
 /// Steps with no file mutations (write/edit/bash) before we nudge the model
-/// to either make progress or provide a final answer.
-pub(crate) const MAX_STEPS_WITHOUT_PROGRESS: u32 = 15;
+/// to either make progress or provide a final answer. Overridable via
+/// `CODETETHER_MAX_STEPS_WITHOUT_PROGRESS`.
+pub(crate) fn max_steps_without_progress() -> u32 {
+    env_u32("CODETETHER_MAX_STEPS_WITHOUT_PROGRESS").unwrap_or(DEFAULT_MAX_STEPS_WITHOUT_PROGRESS)
+}
+
+/// Parse a positive integer from the environment. Zero is treated as
+/// unset — every guardrail here would otherwise trip on the first step.
+fn env_u32(key: &str) -> Option<u32> {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .filter(|v: &u32| *v > 0)
+}
 
 /// Nudge sent when the model keeps trying punctuation/casing variants of the
 /// same identifier via codesearch.
@@ -61,3 +96,51 @@ in plain text based on the tool results you already received. Do NOT output any 
 pub(crate) const NO_PROGRESS_NUDGE: &str = "You have made many tool calls without writing or editing \
 any files. If you are still investigating, that is fine — but if you have gathered enough information, \
 stop reading/searching and start implementing. Provide a final answer if you cannot complete the task.";
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Serialise env mutation across tests in this module.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: serialised by ENV_LOCK above.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        f();
+        // SAFETY: serialised by ENV_LOCK above.
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn tool_call_budget_defaults_when_unset() {
+        with_env("CODETETHER_MAX_TOOL_CALLS", None, || {
+            assert_eq!(max_total_tool_calls(), DEFAULT_MAX_TOTAL_TOOL_CALLS);
+        });
+    }
+
+    #[test]
+    fn tool_call_budget_env_override() {
+        with_env("CODETETHER_MAX_TOOL_CALLS", Some("500"), || {
+            assert_eq!(max_total_tool_calls(), 500);
+        });
+    }
+
+    #[test]
+    fn zero_and_garbage_fall_back_to_default() {
+        with_env("CODETETHER_MAX_TOOL_CALLS", Some("0"), || {
+            assert_eq!(max_total_tool_calls(), DEFAULT_MAX_TOTAL_TOOL_CALLS);
+        });
+        with_env("CODETETHER_MAX_TOOL_CALLS", Some("lots"), || {
+            assert_eq!(max_total_tool_calls(), DEFAULT_MAX_TOTAL_TOOL_CALLS);
+        });
+    }
+}

--- a/src/session/helper/prompt.rs
+++ b/src/session/helper/prompt.rs
@@ -42,9 +42,9 @@ use super::edit::{detect_stub_in_tool_input, normalize_tool_call_for_execution};
 use super::error::is_retryable_upstream_error;
 use super::loop_constants::{
     BUILD_MODE_TOOL_FIRST_MAX_RETRIES, BUILD_MODE_TOOL_FIRST_NUDGE, CODESEARCH_THRASH_NUDGE,
-    FORCE_FINAL_ANSWER_NUDGE, MAX_CONSECUTIVE_CODESEARCH_NO_MATCHES, MAX_CONSECUTIVE_SAME_TOOL,
-    MAX_STEPS_WITHOUT_PROGRESS, MAX_TOTAL_TOOL_CALLS, NATIVE_TOOL_PROMISE_NUDGE,
+    FORCE_FINAL_ANSWER_NUDGE, MAX_CONSECUTIVE_CODESEARCH_NO_MATCHES, NATIVE_TOOL_PROMISE_NUDGE,
     NATIVE_TOOL_PROMISE_RETRY_MAX_RETRIES, NO_PROGRESS_NUDGE, POST_EDIT_VALIDATION_MAX_RETRIES,
+    max_consecutive_same_tool, max_steps_without_progress, max_total_tool_calls,
 };
 use super::markup::normalize_textual_tool_calls;
 use super::provider::{
@@ -142,6 +142,10 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
     let turn_id = Uuid::new_v4().to_string();
     let mut total_tool_calls: u32 = 0;
     let mut steps_since_last_write: u32 = 0;
+    // Loop guardrails, resolved once per turn (env-overridable).
+    let same_tool_limit = max_consecutive_same_tool();
+    let tool_call_budget = max_total_tool_calls();
+    let no_progress_limit = max_steps_without_progress();
 
     let tool_router: Option<ToolCallRouter> = {
         let cfg = ToolRouterConfig::from_env();
@@ -534,7 +538,7 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
                 last_tool_sig = Some(sig);
             }
 
-            let force_answer = consecutive_same_tool > MAX_CONSECUTIVE_SAME_TOOL
+            let force_answer = consecutive_same_tool > same_tool_limit
                 || (!model_supports_tools && step >= 3);
 
             if force_answer {
@@ -562,11 +566,11 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
 
         // ── Total tool call budget ──────────────────────────────
         total_tool_calls += tool_calls.len() as u32;
-        if total_tool_calls > MAX_TOTAL_TOOL_CALLS {
+        if total_tool_calls > tool_call_budget {
             tracing::warn!(
                 step = step,
                 total_tool_calls,
-                budget = MAX_TOTAL_TOOL_CALLS,
+                budget = tool_call_budget,
                 "Hard tool-call budget exceeded; terminating agent loop"
             );
             let mut nudge_msg = response.message.clone();
@@ -577,7 +581,9 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
                 session.add_message(nudge_msg);
             }
             return Err(anyhow::anyhow!(
-                "Agent loop terminated: exceeded maximum tool call budget ({} calls across {} steps).                  The model appears stuck. Review the tool history to understand what went wrong.",
+                "Agent loop terminated: exceeded maximum tool call budget ({} calls across {} steps). \
+                 If the model was stuck, review the tool history; if the task is simply large, raise \
+                 CODETETHER_MAX_TOOL_CALLS and resume with --continue-session.",
                 total_tool_calls,
                 step
             ));
@@ -595,7 +601,7 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
         } else {
             steps_since_last_write += 1;
         }
-        if steps_since_last_write >= MAX_STEPS_WITHOUT_PROGRESS {
+        if steps_since_last_write >= no_progress_limit {
             tracing::warn!(
                 step = step,
                 steps_since_last_write,

--- a/src/session/helper/prompt_events.rs
+++ b/src/session/helper/prompt_events.rs
@@ -40,9 +40,9 @@ use super::edit::{detect_stub_in_tool_input, normalize_tool_call_for_execution};
 use super::error::is_retryable_upstream_error;
 use super::loop_constants::{
     BUILD_MODE_TOOL_FIRST_MAX_RETRIES, BUILD_MODE_TOOL_FIRST_NUDGE, CODESEARCH_THRASH_NUDGE,
-    FORCE_FINAL_ANSWER_NUDGE, MAX_CONSECUTIVE_CODESEARCH_NO_MATCHES, MAX_CONSECUTIVE_SAME_TOOL,
-    MAX_STEPS_WITHOUT_PROGRESS, MAX_TOTAL_TOOL_CALLS, NATIVE_TOOL_PROMISE_NUDGE,
+    FORCE_FINAL_ANSWER_NUDGE, MAX_CONSECUTIVE_CODESEARCH_NO_MATCHES, NATIVE_TOOL_PROMISE_NUDGE,
     NATIVE_TOOL_PROMISE_RETRY_MAX_RETRIES, NO_PROGRESS_NUDGE, POST_EDIT_VALIDATION_MAX_RETRIES,
+    max_consecutive_same_tool, max_steps_without_progress, max_total_tool_calls,
 };
 use super::markup::normalize_textual_tool_calls;
 use super::provider::{
@@ -162,6 +162,10 @@ pub(crate) async fn run_prompt_with_events(
     let mut total_tool_calls: u32 = 0;
     let mut steps_since_last_write: u32 = 0;
     let turn_id = Uuid::new_v4().to_string();
+    // Loop guardrails, resolved once per turn (env-overridable).
+    let same_tool_limit = max_consecutive_same_tool();
+    let tool_call_budget = max_total_tool_calls();
+    let no_progress_limit = max_steps_without_progress();
 
     let tool_router: Option<ToolCallRouter> = {
         let cfg = ToolRouterConfig::from_env();
@@ -598,7 +602,7 @@ pub(crate) async fn run_prompt_with_events(
                 last_tool_sig = Some(sig);
             }
 
-            let force_answer = consecutive_same_tool > MAX_CONSECUTIVE_SAME_TOOL
+            let force_answer = consecutive_same_tool > same_tool_limit
                 || (!model_supports_tools && step >= 3);
 
             if force_answer {
@@ -626,11 +630,11 @@ pub(crate) async fn run_prompt_with_events(
 
         // ── Total tool call budget ──────────────────────────────
         total_tool_calls += tool_calls.len() as u32;
-        if total_tool_calls > MAX_TOTAL_TOOL_CALLS {
+        if total_tool_calls > tool_call_budget {
             tracing::warn!(
                 step = step,
                 total_tool_calls,
-                budget = MAX_TOTAL_TOOL_CALLS,
+                budget = tool_call_budget,
                 "Hard tool-call budget exceeded; terminating agent loop"
             );
             let mut nudge_msg = response.message.clone();
@@ -641,7 +645,9 @@ pub(crate) async fn run_prompt_with_events(
                 session.add_message(nudge_msg);
             }
             return Err(anyhow::anyhow!(
-                "Agent loop terminated: exceeded maximum tool call budget ({} calls across {} steps).                  The model appears stuck. Review the tool history to understand what went wrong.",
+                "Agent loop terminated: exceeded maximum tool call budget ({} calls across {} steps). \
+                 If the model was stuck, review the tool history; if the task is simply large, raise \
+                 CODETETHER_MAX_TOOL_CALLS and resume with --continue-session.",
                 total_tool_calls,
                 step
             ));
@@ -659,7 +665,7 @@ pub(crate) async fn run_prompt_with_events(
         } else {
             steps_since_last_write += 1;
         }
-        if steps_since_last_write >= MAX_STEPS_WITHOUT_PROGRESS {
+        if steps_since_last_write >= no_progress_limit {
             tracing::warn!(
                 step = step,
                 steps_since_last_write,

--- a/src/session/listing.rs
+++ b/src/session/listing.rs
@@ -1,11 +1,32 @@
 //! Session listing facade.
+//!
+//! Listing flows through an append-only `index.jsonl` so we do not have
+//! to open every session file just to render a list:
+//! - [`index_file`] resolves the path and triggers cheap appends.
+//! - [`index_file_io`] owns the blocking read/append I/O.
+//! - [`index_file_compact`] atomically rewrites the index when it
+//!   becomes bloated or when we rebuild from a full scan.
+//! - [`scan`] is the full-directory rebuild/repair path.
+//! - [`parse_summary`] is the per-file header parser.
+//! - [`directory`] is the public entry point and tries the index first.
 
 mod count_seq;
 mod directory;
+mod directory_query;
+mod disk_walk;
+pub(crate) mod index_file;
+mod index_file_compact;
+mod index_file_compact_io;
+mod index_file_io;
+mod index_prune;
+mod merge_disk;
+mod parse_summary;
+mod rebuild;
 mod record;
 mod scan;
 mod summary;
 mod workspace;
+mod workspace_query;
 
 #[cfg(test)]
 mod tests;

--- a/src/session/listing/directory.rs
+++ b/src/session/listing/directory.rs
@@ -1,8 +1,11 @@
+//! Public listing entry points. The actual index-first lookup lives in
+//! [`super::directory_query`]; this file is just the facade.
+
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use super::scan::scan;
+use super::directory_query;
 use super::summary::SessionSummary;
 use super::workspace::canonical;
 
@@ -12,7 +15,7 @@ use super::workspace::canonical;
 ///
 /// Returns an error if the data directory cannot be read.
 pub async fn list_sessions() -> Result<Vec<SessionSummary>> {
-    scan(sessions_dir()?, None).await
+    directory_query::list_indexed(sessions_dir()?, None).await
 }
 
 /// List sessions scoped to a workspace directory.
@@ -21,7 +24,8 @@ pub async fn list_sessions() -> Result<Vec<SessionSummary>> {
 ///
 /// Returns an error if the data directory cannot be read.
 pub async fn list_sessions_for_directory(dir: &Path) -> Result<Vec<SessionSummary>> {
-    scan(sessions_dir()?, Some(canonical(dir))).await
+    // `matches_workspace` expects an already-canonicalized workspace path.
+    directory_query::list_indexed(sessions_dir()?, Some(canonical(dir))).await
 }
 
 /// List workspace sessions with pagination.
@@ -38,7 +42,7 @@ pub async fn list_sessions_paged(
     Ok(sessions.into_iter().skip(offset).take(limit).collect())
 }
 
-fn sessions_dir() -> Result<PathBuf> {
+pub(super) fn sessions_dir() -> Result<PathBuf> {
     crate::config::Config::data_dir()
         .map(|dir| dir.join("sessions"))
         .ok_or_else(|| anyhow::anyhow!("Could not determine data directory"))

--- a/src/session/listing/directory_query.rs
+++ b/src/session/listing/directory_query.rs
@@ -1,0 +1,46 @@
+//! Index-first query pipeline for session listings.
+//!
+//! Pipeline:
+//! 1. Try `index.jsonl`; if missing/unreadable, scan and rebuild.
+//! 2. Walk `sessions_dir` for `.json` files not in the index, parse
+//!    them via [`super::disk_walk::collect_disk_summaries`], append
+//!    them, and prune index entries whose backing file is gone.
+//! 3. Compact the index when it grows bloated (>= 4 * unique lines).
+//! 4. Filter by workspace and sort by `updated_at` desc.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use super::index_file::path as index_path;
+use super::index_file_io::read_sync;
+use super::summary::SessionSummary;
+
+/// Index-first listing with full rebuild on missing/stale index.
+pub(super) async fn list_indexed(
+    sessions_dir: PathBuf,
+    workspace_dir: Option<PathBuf>,
+) -> Result<Vec<SessionSummary>> {
+    if !sessions_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let index_p = index_path().ok();
+    let (mut from_index, index_lines): (HashMap<String, SessionSummary>, usize) =
+        match index_p.as_ref().and_then(|p| read_sync(p).ok()) {
+            Some((map, lines)) if !map.is_empty() => (map, lines),
+            _ => {
+                return super::rebuild::rebuild_from_scan(sessions_dir, index_p, workspace_dir)
+                    .await;
+            }
+        };
+
+    super::merge_disk::merge_disk_into(&mut from_index, &sessions_dir, &index_p, index_lines)
+        .await;
+    let summaries: Vec<SessionSummary> = from_index.into_values().collect();
+    Ok(super::workspace_query::filter_and_sort(
+        summaries,
+        workspace_dir.as_deref(),
+    ))
+}

--- a/src/session/listing/directory_query.rs
+++ b/src/session/listing/directory_query.rs
@@ -27,14 +27,21 @@ pub(super) async fn list_indexed(
     }
 
     let index_p = index_path().ok();
-    let (mut from_index, index_lines): (HashMap<String, SessionSummary>, usize) =
-        match index_p.as_ref().and_then(|p| read_sync(p).ok()) {
-            Some((map, lines)) if !map.is_empty() => (map, lines),
-            _ => {
-                return super::rebuild::rebuild_from_scan(sessions_dir, index_p, workspace_dir)
-                    .await;
-            }
-        };
+    // Read the index on the blocking pool — file I/O and per-line JSON
+    // parsing must not stall the async executor.
+    let loaded = match index_p.clone() {
+        Some(p) => tokio::task::spawn_blocking(move || read_sync(&p).ok())
+            .await
+            .ok()
+            .flatten(),
+        None => None,
+    };
+    let (mut from_index, index_lines): (HashMap<String, SessionSummary>, usize) = match loaded {
+        Some((map, lines)) if !map.is_empty() => (map, lines),
+        _ => {
+            return super::rebuild::rebuild_from_scan(sessions_dir, index_p, workspace_dir).await;
+        }
+    };
 
     super::merge_disk::merge_disk_into(&mut from_index, &sessions_dir, &index_p, index_lines)
         .await;

--- a/src/session/listing/disk_walk.rs
+++ b/src/session/listing/disk_walk.rs
@@ -1,0 +1,52 @@
+//! Read the sessions directory and parse `.json` files not yet in the
+//! index. See [`super::index_prune`] for the dead-entry reaper.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use tokio::fs;
+
+use super::parse_summary::parse_summary_unfiltered;
+use super::summary::SessionSummary;
+
+/// Walk `sessions_dir` and parse any `.json` whose id (filename stem) is
+/// not already known to the index. Non-session json files (e.g.,
+/// `.workspace_index.json`) are excluded by the id-shape check.
+pub(super) async fn collect_disk_summaries(
+    sessions_dir: &Path,
+    known: &HashMap<String, SessionSummary>,
+) -> Vec<SessionSummary> {
+    let mut entries = match fs::read_dir(sessions_dir).await {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if !is_session_json(&path) {
+            continue;
+        }
+        let stem = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        if !is_valid_id_shape(&stem) || known.contains_key(&stem) {
+            continue;
+        }
+        if let Some(summary) = parse_summary_unfiltered(&path) {
+            out.push(summary);
+        }
+    }
+    out
+}
+
+fn is_session_json(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("json")
+}
+
+fn is_valid_id_shape(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 128
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}

--- a/src/session/listing/disk_walk.rs
+++ b/src/session/listing/disk_walk.rs
@@ -1,10 +1,8 @@
 //! Read the sessions directory and parse `.json` files not yet in the
 //! index. See [`super::index_prune`] for the dead-entry reaper.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
-
-use tokio::fs;
 
 use super::parse_summary::parse_summary_unfiltered;
 use super::summary::SessionSummary;
@@ -12,32 +10,52 @@ use super::summary::SessionSummary;
 /// Walk `sessions_dir` and parse any `.json` whose id (filename stem) is
 /// not already known to the index. Non-session json files (e.g.,
 /// `.workspace_index.json`) are excluded by the id-shape check.
+///
+/// Returns the newly parsed summaries plus the full set of session ids
+/// present on disk, so the caller can prune dead index entries without
+/// any further disk I/O. The walk and parsing run on the blocking pool —
+/// readdir, file reads, and JSON parsing must not stall the async
+/// executor.
 pub(super) async fn collect_disk_summaries(
     sessions_dir: &Path,
     known: &HashMap<String, SessionSummary>,
-) -> Vec<SessionSummary> {
-    let mut entries = match fs::read_dir(sessions_dir).await {
-        Ok(e) => e,
-        Err(_) => return Vec::new(),
-    };
+) -> (Vec<SessionSummary>, HashSet<String>) {
+    let dir = sessions_dir.to_path_buf();
+    let known_ids: HashSet<String> = known.keys().cloned().collect();
+    tokio::task::spawn_blocking(move || collect_sync(&dir, &known_ids))
+        .await
+        .unwrap_or_default()
+}
+
+fn collect_sync(
+    sessions_dir: &Path,
+    known: &HashSet<String>,
+) -> (Vec<SessionSummary>, HashSet<String>) {
     let mut out = Vec::new();
-    while let Ok(Some(entry)) = entries.next_entry().await {
+    let mut present: HashSet<String> = HashSet::new();
+    let Ok(entries) = std::fs::read_dir(sessions_dir) else {
+        return (out, present);
+    };
+    for entry in entries.flatten() {
         let path = entry.path();
         if !is_session_json(&path) {
             continue;
         }
-        let stem = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(s) => s.to_string(),
-            None => continue,
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
         };
-        if !is_valid_id_shape(&stem) || known.contains_key(&stem) {
+        if !is_valid_id_shape(stem) {
+            continue;
+        }
+        present.insert(stem.to_string());
+        if known.contains(stem) {
             continue;
         }
         if let Some(summary) = parse_summary_unfiltered(&path) {
             out.push(summary);
         }
     }
-    out
+    (out, present)
 }
 
 fn is_session_json(path: &Path) -> bool {

--- a/src/session/listing/index_file.rs
+++ b/src/session/listing/index_file.rs
@@ -1,0 +1,37 @@
+//! Append-only session listing index (`<sessions_dir>/index.jsonl`).
+//!
+//! One [`SessionSummary`] per line. Duplicate lines per id are tolerated;
+//! the last line for a given id wins when read.
+//!
+//! Layout:
+//! - [`path`] — on-disk path of `index.jsonl`.
+//! - [`append_async`] — best-effort append used by `Session::save`.
+//! - [`read_sync`] lives in [`super::index_file_io`].
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use tokio::fs;
+
+use super::index_file_io::append_sync;
+use super::summary::SessionSummary;
+
+pub(super) const INDEX_FILENAME: &str = "index.jsonl";
+
+/// Resolve the on-disk path of the listing index.
+pub(super) fn path() -> Result<PathBuf> {
+    Ok(super::directory::sessions_dir()?.join(INDEX_FILENAME))
+}
+
+/// Append a single summary line to `index.jsonl`. O_APPEND, blocking pool,
+/// best-effort. A failure here is logged at debug, never propagated.
+/// `pub(crate)` so [`crate::session::save_index`] can call it from
+/// `Session::save`.
+pub(crate) async fn append_async(summary: &SessionSummary) {
+    let Ok(p) = path() else { return };
+    if let Some(parent) = p.parent() {
+        let _ = fs::create_dir_all(parent).await;
+    }
+    let s = summary.clone();
+    let _ = tokio::task::spawn_blocking(move || append_sync(&p, &s)).await;
+}

--- a/src/session/listing/index_file_compact.rs
+++ b/src/session/listing/index_file_compact.rs
@@ -1,0 +1,26 @@
+//! Atomic compact-rewrite of the session listing index.
+
+use std::path::Path;
+
+use anyhow::Result;
+use tokio::fs;
+
+use super::index_file_compact_io::write_compact_sync;
+use super::summary::SessionSummary;
+
+/// Rewrite the index with a single, deduped set of summaries (tmp + rename).
+pub(super) async fn write_compact_async(path: &Path, summaries: &[SessionSummary]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await.ok();
+    }
+    let final_path = path.to_path_buf();
+    let owned: Vec<SessionSummary> = summaries.to_vec();
+    tokio::task::spawn_blocking(move || write_compact_sync(&final_path, &owned))
+        .await
+        .map_err(|e| anyhow::anyhow!("compact task panicked: {e}"))?
+}
+
+/// Heuristic: total lines >= 4 * unique ids means the index is bloated.
+pub(super) fn should_compact(total_lines: usize, unique_ids: usize) -> bool {
+    unique_ids > 0 && total_lines >= unique_ids.saturating_mul(4)
+}

--- a/src/session/listing/index_file_compact_io.rs
+++ b/src/session/listing/index_file_compact_io.rs
@@ -1,0 +1,33 @@
+//! Blocking I/O for the listing index compact-rewrite.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use super::summary::SessionSummary;
+
+/// Synchronous tmp-file + atomic rename writer.
+pub(super) fn write_compact_sync(final_path: &Path, summaries: &[SessionSummary]) -> Result<()> {
+    if let Some(parent) = final_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let tmp = final_path.with_extension("jsonl.tmp");
+    let mut file = File::create(&tmp)
+        .with_context(|| format!("create tmp index {}", tmp.display()))?;
+    for s in summaries {
+        let mut line = serde_json::to_vec(s)?;
+        line.push(b'\n');
+        file.write_all(&line)?;
+    }
+    file.flush()?;
+    match std::fs::rename(&tmp, final_path) {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            let _ = std::fs::remove_file(final_path);
+            std::fs::rename(&tmp, final_path)
+                .with_context(|| format!("rename tmp into {}", final_path.display()))
+        }
+    }
+}

--- a/src/session/listing/index_file_compact_io.rs
+++ b/src/session/listing/index_file_compact_io.rs
@@ -8,8 +8,11 @@ use anyhow::{Context, Result};
 
 use super::summary::SessionSummary;
 
-/// Synchronous tmp-file + atomic rename writer.
+/// Synchronous tmp-file + atomic rename writer. Holds the index writer
+/// lock so a concurrent save's append cannot land on the unlinked
+/// pre-rename inode.
 pub(super) fn write_compact_sync(final_path: &Path, summaries: &[SessionSummary]) -> Result<()> {
+    let _guard = super::index_file_io::write_lock();
     if let Some(parent) = final_path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
@@ -24,10 +27,16 @@ pub(super) fn write_compact_sync(final_path: &Path, summaries: &[SessionSummary]
     file.flush()?;
     match std::fs::rename(&tmp, final_path) {
         Ok(()) => Ok(()),
-        Err(_) => {
+        Err(primary) => {
             let _ = std::fs::remove_file(final_path);
-            std::fs::rename(&tmp, final_path)
-                .with_context(|| format!("rename tmp into {}", final_path.display()))
+            if let Err(retry) = std::fs::rename(&tmp, final_path) {
+                let _ = std::fs::remove_file(&tmp);
+                anyhow::bail!(
+                    "rename tmp into {}: {primary} (retry: {retry})",
+                    final_path.display()
+                );
+            }
+            Ok(())
         }
     }
 }

--- a/src/session/listing/index_file_io.rs
+++ b/src/session/listing/index_file_io.rs
@@ -6,14 +6,29 @@
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
 
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 
 use super::summary::SessionSummary;
 
+/// Serialises in-process index writers: a save's append must not race a
+/// listing's compact-rewrite, or the append can land on the unlinked
+/// pre-compaction inode (Unix) or fail the rename (Windows). Writers
+/// from *other* processes are not covered — a lost cross-process append
+/// is self-healing, because the next listing's disk walk re-discovers
+/// the session file and re-appends it.
+static WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Take the index writer lock. Only call from the blocking pool.
+pub(super) fn write_lock() -> MutexGuard<'static, ()> {
+    WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// Append a single summary line to the index. O_APPEND.
 pub(super) fn append_sync(path: &Path, summary: &SessionSummary) -> Result<()> {
+    let _guard = write_lock();
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)

--- a/src/session/listing/index_file_io.rs
+++ b/src/session/listing/index_file_io.rs
@@ -1,0 +1,51 @@
+//! Sync I/O helpers for the session listing index.
+//!
+//! Kept separate from [`super::index_file`] so the async path stays small
+//! and the blocking file ops live next to each other.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+
+use super::summary::SessionSummary;
+
+/// Append a single summary line to the index. O_APPEND.
+pub(super) fn append_sync(path: &Path, summary: &SessionSummary) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open index {}", path.display()))?;
+    let mut line = serde_json::to_vec(summary)?;
+    line.push(b'\n');
+    file.write_all(&line)?;
+    file.flush()?;
+    Ok(())
+}
+
+/// Read the index from disk, collapsing duplicates so the last line per
+/// id wins. Also returns the raw (non-empty) line count so the caller
+/// can decide whether the index is bloated enough to compact.
+pub(super) fn read_sync(path: &Path) -> Result<(HashMap<String, SessionSummary>, usize)> {
+    let file = File::open(path).with_context(|| format!("open index {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut out: HashMap<String, SessionSummary> = HashMap::new();
+    let mut total_lines = 0usize;
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if line.is_empty() {
+            continue;
+        }
+        total_lines += 1;
+        if let Ok(summary) = serde_json::from_str::<SessionSummary>(&line) {
+            out.insert(summary.id.clone(), summary);
+        }
+    }
+    Ok((out, total_lines))
+}

--- a/src/session/listing/index_prune.rs
+++ b/src/session/listing/index_prune.rs
@@ -1,0 +1,17 @@
+//! Drop index entries whose backing session file is gone.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::summary::SessionSummary;
+
+pub(super) fn retain_existing(
+    index: &mut HashMap<String, SessionSummary>,
+    sessions_dir: &Path,
+) {
+    index.retain(|id, _| file_exists(sessions_dir, id));
+}
+
+fn file_exists(sessions_dir: &Path, id: &str) -> bool {
+    sessions_dir.join(format!("{id}.json")).exists()
+}

--- a/src/session/listing/index_prune.rs
+++ b/src/session/listing/index_prune.rs
@@ -1,17 +1,15 @@
 //! Drop index entries whose backing session file is gone.
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
 
 use super::summary::SessionSummary;
 
+/// Retain only entries whose id was seen on disk by the directory walk
+/// ([`super::disk_walk::collect_disk_summaries`]). Pure in-memory set
+/// lookups — no per-entry stat calls.
 pub(super) fn retain_existing(
     index: &mut HashMap<String, SessionSummary>,
-    sessions_dir: &Path,
+    existing_ids: &HashSet<String>,
 ) {
-    index.retain(|id, _| file_exists(sessions_dir, id));
-}
-
-fn file_exists(sessions_dir: &Path, id: &str) -> bool {
-    sessions_dir.join(format!("{id}.json")).exists()
+    index.retain(|id, _| existing_ids.contains(id));
 }

--- a/src/session/listing/merge_disk.rs
+++ b/src/session/listing/merge_disk.rs
@@ -20,7 +20,7 @@ pub(super) async fn merge_disk_into(
     index_p: &Option<std::path::PathBuf>,
     index_lines: usize,
 ) {
-    let disk = disk_walk::collect_disk_summaries(sessions_dir, from_index).await;
+    let (disk, present) = disk_walk::collect_disk_summaries(sessions_dir, from_index).await;
     let mut appended = 0usize;
     for s in disk {
         if !from_index.contains_key(&s.id) {
@@ -29,7 +29,7 @@ pub(super) async fn merge_disk_into(
             appended += 1;
         }
     }
-    index_prune::retain_existing(from_index, sessions_dir);
+    index_prune::retain_existing(from_index, &present);
 
     if let Some(p) = index_p.as_ref() {
         let unique = from_index.len();

--- a/src/session/listing/merge_disk.rs
+++ b/src/session/listing/merge_disk.rs
@@ -1,0 +1,41 @@
+//! Merge newly discovered disk summaries into the in-memory index,
+//! prune entries whose backing file is gone, and compact the on-disk
+//! index when it has accumulated too many superseded lines.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::disk_walk;
+use super::index_file::append_async;
+use super::index_file_compact::{should_compact, write_compact_async};
+use super::index_prune;
+use super::summary::SessionSummary;
+
+/// `index_lines` is the raw line count of `index.jsonl` as read, used
+/// together with the appends performed here to drive the compaction
+/// heuristic.
+pub(super) async fn merge_disk_into(
+    from_index: &mut HashMap<String, SessionSummary>,
+    sessions_dir: &Path,
+    index_p: &Option<std::path::PathBuf>,
+    index_lines: usize,
+) {
+    let disk = disk_walk::collect_disk_summaries(sessions_dir, from_index).await;
+    let mut appended = 0usize;
+    for s in disk {
+        if !from_index.contains_key(&s.id) {
+            append_async(&s).await;
+            from_index.insert(s.id.clone(), s);
+            appended += 1;
+        }
+    }
+    index_prune::retain_existing(from_index, sessions_dir);
+
+    if let Some(p) = index_p.as_ref() {
+        let unique = from_index.len();
+        if should_compact(index_lines + appended, unique) {
+            let values: Vec<SessionSummary> = from_index.values().cloned().collect();
+            let _ = write_compact_async(p, &values).await;
+        }
+    }
+}

--- a/src/session/listing/parse_summary.rs
+++ b/src/session/listing/parse_summary.rs
@@ -1,0 +1,48 @@
+//! Shared session-file header parser used by both the full-directory
+//! rebuild path and the per-file path inside the index-aware walk.
+//!
+//! Reads only the top-level fields (`id`, `title`, `created_at`,
+//! `updated_at`, `metadata.directory`, `agent`, `messages`) — never the
+//! rest of the transcript — so listing is cheap even for multi-megabyte
+//! sessions.
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+
+use super::record::SessionListingRecord;
+use super::summary::SessionSummary;
+use super::workspace::matches_workspace;
+
+/// Parse a session file into a [`SessionSummary`], optionally filtering
+/// by workspace. Returns `None` for unreadable, malformed, or
+/// non-matching files (with a warning logged).
+pub(super) fn parse_summary(path: &Path, workspace: Option<&Path>) -> Option<SessionSummary> {
+    let file = File::open(path).map_err(log_read(path)).ok()?;
+    let reader = BufReader::with_capacity(64 * 1024, file);
+    let record: SessionListingRecord = serde_json::from_reader(reader)
+        .map_err(log_malformed(path))
+        .ok()?;
+    let summary = record.into_summary();
+    matches_workspace(summary.directory.as_deref(), workspace).then_some(summary)
+}
+
+/// Like [`parse_summary`] but does not apply the workspace filter; used
+/// when the caller wants to keep a summary for the index regardless of
+/// which workspace the listing is scoped to.
+pub(super) fn parse_summary_unfiltered(path: &Path) -> Option<SessionSummary> {
+    let file = File::open(path).map_err(log_read(path)).ok()?;
+    let reader = BufReader::with_capacity(64 * 1024, file);
+    let record: SessionListingRecord = serde_json::from_reader(reader)
+        .map_err(log_malformed(path))
+        .ok()?;
+    Some(record.into_summary())
+}
+
+fn log_read(path: &Path) -> impl FnOnce(std::io::Error) {
+    |error| tracing::warn!(path = %path.display(), error = %error, "skipping unreadable session file")
+}
+
+fn log_malformed(path: &Path) -> impl FnOnce(serde_json::Error) {
+    |error| tracing::warn!(path = %path.display(), error = %error, "skipping malformed session file")
+}

--- a/src/session/listing/rebuild.rs
+++ b/src/session/listing/rebuild.rs
@@ -1,0 +1,29 @@
+//! Rebuild the index from a full directory scan.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use super::index_file_compact::write_compact_async;
+use super::scan::scan;
+use super::summary::SessionSummary;
+use super::workspace_query::filter_and_sort;
+
+/// Scan everything, persist a fresh compacted index, and return the
+/// workspace-filtered, sorted summaries.
+///
+/// The scan is deliberately unfiltered: the index is shared by every
+/// workspace, so a rebuild triggered from one workspace's listing must
+/// not drop the other workspaces' sessions from it. The workspace
+/// filter is applied only to the returned summaries.
+pub(super) async fn rebuild_from_scan(
+    sessions_dir: PathBuf,
+    index_p: Option<PathBuf>,
+    workspace_dir: Option<PathBuf>,
+) -> Result<Vec<SessionSummary>> {
+    let summaries = scan(sessions_dir, None).await?;
+    if let Some(p) = index_p.as_ref() {
+        let _ = write_compact_async(p, &summaries).await;
+    }
+    Ok(filter_and_sort(summaries, workspace_dir.as_deref()))
+}

--- a/src/session/listing/scan.rs
+++ b/src/session/listing/scan.rs
@@ -1,14 +1,13 @@
-use std::fs::File;
-use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use tokio::fs;
 
-use super::record::SessionListingRecord;
+use super::parse_summary::parse_summary;
 use super::summary::SessionSummary;
-use super::workspace::matches_workspace;
 
+/// Full-directory listing scan. Used as the rebuild/repair path when
+/// `index.jsonl` is missing or stale.
 pub(super) async fn scan(
     sessions_dir: PathBuf,
     workspace: Option<PathBuf>,
@@ -32,22 +31,4 @@ pub(super) async fn scan(
 
 fn is_json(path: &Path) -> bool {
     path.extension().is_some_and(|ext| ext == "json")
-}
-
-fn parse_summary(path: &Path, workspace: Option<&Path>) -> Option<SessionSummary> {
-    let file = File::open(path).map_err(log_read(path)).ok()?;
-    let reader = BufReader::with_capacity(64 * 1024, file);
-    let record: SessionListingRecord = serde_json::from_reader(reader)
-        .map_err(log_malformed(path))
-        .ok()?;
-    let summary = record.into_summary();
-    matches_workspace(summary.directory.as_deref(), workspace).then_some(summary)
-}
-
-fn log_read(path: &Path) -> impl FnOnce(std::io::Error) {
-    |error| tracing::warn!(path = %path.display(), error = %error, "skipping unreadable session file")
-}
-
-fn log_malformed(path: &Path) -> impl FnOnce(serde_json::Error) {
-    |error| tracing::warn!(path = %path.display(), error = %error, "skipping malformed session file")
 }

--- a/src/session/listing/scan.rs
+++ b/src/session/listing/scan.rs
@@ -1,26 +1,32 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use tokio::fs;
 
 use super::parse_summary::parse_summary;
 use super::summary::SessionSummary;
 
 /// Full-directory listing scan. Used as the rebuild/repair path when
-/// `index.jsonl` is missing or stale.
+/// `index.jsonl` is missing or stale. Runs entirely on the blocking
+/// pool — it opens and header-parses every session file.
 pub(super) async fn scan(
     sessions_dir: PathBuf,
     workspace: Option<PathBuf>,
 ) -> Result<Vec<SessionSummary>> {
+    tokio::task::spawn_blocking(move || scan_sync(&sessions_dir, workspace.as_deref()))
+        .await
+        .map_err(|e| anyhow::anyhow!("listing scan task panicked: {e}"))?
+}
+
+fn scan_sync(sessions_dir: &Path, workspace: Option<&Path>) -> Result<Vec<SessionSummary>> {
     if !sessions_dir.exists() {
         return Ok(Vec::new());
     }
     let mut summaries = Vec::new();
-    let mut entries = fs::read_dir(&sessions_dir).await?;
-    while let Some(entry) = entries.next_entry().await? {
+    for entry in std::fs::read_dir(sessions_dir)? {
+        let Ok(entry) = entry else { continue };
         let path = entry.path();
         if is_json(&path)
-            && let Some(summary) = parse_summary(&path, workspace.as_deref())
+            && let Some(summary) = parse_summary(&path, workspace)
         {
             summaries.push(summary);
         }

--- a/src/session/listing/tests.rs
+++ b/src/session/listing/tests.rs
@@ -1,44 +1,157 @@
-use serde_json::json;
+//! Tests for the append-only session listing index.
 
-use super::scan::scan;
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard};
 
-#[tokio::test]
-async fn scan_counts_messages_and_filters_workspace() {
-    let temp = tempfile::tempdir().unwrap();
-    let sessions = temp.path().join("sessions");
-    let workspace = temp.path().join("workspace");
-    let other = temp.path().join("other");
-    std::fs::create_dir_all(&sessions).unwrap();
-    std::fs::create_dir_all(&workspace).unwrap();
-    std::fs::create_dir_all(&other).unwrap();
+use chrono::Utc;
+use tempfile::TempDir;
 
-    write_session(&sessions, "keep", &workspace, 3);
-    write_session(&sessions, "skip", &other, 2);
+use super::directory::sessions_dir;
+use super::directory_query::list_indexed;
+use super::index_file_compact::should_compact;
+use super::index_file_io;
+use super::summary::SessionSummary;
 
-    let summaries = scan(sessions, Some(workspace)).await.unwrap();
-    assert_eq!(summaries.len(), 1);
-    assert_eq!(summaries[0].id, "keep");
-    assert_eq!(summaries[0].message_count, 3);
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Point `CODETETHER_DATA_DIR` at `tmp` and resolve the sessions dir.
+/// The returned guard serialises env mutation across tests; hold it for
+/// the duration of the test body.
+fn enter_data_dir(tmp: &TempDir) -> (MutexGuard<'static, ()>, PathBuf) {
+    let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    std::fs::create_dir_all(tmp.path().join("sessions")).unwrap();
+    // SAFETY: serialised by ENV_LOCK above.
+    unsafe { std::env::set_var("CODETETHER_DATA_DIR", tmp.path()) };
+    (guard, sessions_dir().unwrap())
 }
 
-fn write_session(sessions: &std::path::Path, id: &str, dir: &std::path::Path, count: usize) {
-    let large = "x".repeat(1024 * 1024);
-    let messages = (0..count)
-        .map(|idx| json!({ "ignored": idx, "payload": large }))
-        .collect::<Vec<_>>();
-    let payload = json!({
+fn make_summary(id: &str, title: Option<&str>, updated_offset_secs: i64) -> SessionSummary {
+    let now = Utc::now() + chrono::Duration::seconds(updated_offset_secs);
+    SessionSummary {
+        id: id.to_string(),
+        title: title.map(String::from),
+        created_at: now,
+        updated_at: now,
+        message_count: 0,
+        agent: "test".to_string(),
+        directory: None,
+    }
+}
+
+fn write_session_json(sessions: &std::path::Path, id: &str, workspace_label: &str, count: usize) {
+    let payload = serde_json::json!({
         "id": id,
         "title": format!("title-{id}"),
         "created_at": "2026-01-01T00:00:00Z",
         "updated_at": "2026-01-02T00:00:00Z",
         "metadata": {
-            "directory": dir,
+            "directory": format!("/tmp/{workspace_label}"),
             "shared": false,
             "share_url": null
         },
-        "agent": "default",
-        "messages": messages
+        "agent": "test",
+        "messages": (0..count).map(|i| serde_json::json!({"i": i})).collect::<Vec<_>>()
     });
     let path = sessions.join(format!("{id}.json"));
     std::fs::write(path, serde_json::to_vec(&payload).unwrap()).unwrap();
+}
+
+#[tokio::test]
+async fn index_round_trip_preserves_summaries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_guard, sessions) = enter_data_dir(&tmp);
+    let a = make_summary("aaa", Some("alpha"), 0);
+    let b = make_summary("bbb", Some("beta"), 10);
+    let p = sessions.join("index.jsonl");
+    index_file_io::append_sync(&p, &a).unwrap();
+    index_file_io::append_sync(&p, &b).unwrap();
+    let (map, lines) = index_file_io::read_sync(&p).unwrap();
+    assert_eq!(map.len(), 2);
+    assert_eq!(lines, 2);
+    assert_eq!(map.get("aaa").unwrap().title.as_deref(), Some("alpha"));
+    assert_eq!(map.get("bbb").unwrap().title.as_deref(), Some("beta"));
+}
+
+#[tokio::test]
+async fn last_line_wins_per_id() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_guard, sessions) = enter_data_dir(&tmp);
+    let p = sessions.join("index.jsonl");
+    let old = make_summary("same", Some("old"), 0);
+    let new = make_summary("same", Some("new"), 5);
+    index_file_io::append_sync(&p, &old).unwrap();
+    index_file_io::append_sync(&p, &new).unwrap();
+    let (map, lines) = index_file_io::read_sync(&p).unwrap();
+    assert_eq!(map.len(), 1);
+    assert_eq!(lines, 2);
+    assert_eq!(map.get("same").unwrap().title.as_deref(), Some("new"));
+}
+
+#[tokio::test]
+async fn rebuild_from_scan_when_index_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_guard, sessions) = enter_data_dir(&tmp);
+    write_session_json(&sessions, "s1", "workspace-a", 3);
+    write_session_json(&sessions, "s2", "workspace-b", 1);
+    let summaries = list_indexed(sessions.clone(), None).await.unwrap();
+    assert_eq!(summaries.len(), 2);
+    assert!(sessions.join("index.jsonl").exists());
+}
+
+#[tokio::test]
+async fn workspace_scoped_rebuild_keeps_full_index() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_guard, sessions) = enter_data_dir(&tmp);
+    write_session_json(&sessions, "mine", "workspace-a", 1);
+    write_session_json(&sessions, "other", "workspace-b", 1);
+    let scoped = list_indexed(sessions.clone(), Some(PathBuf::from("/tmp/workspace-a")))
+        .await
+        .unwrap();
+    assert_eq!(scoped.len(), 1);
+    assert_eq!(scoped[0].id, "mine");
+    // The rebuild must not drop the other workspace's session from the index.
+    let (map, _) = index_file_io::read_sync(&sessions.join("index.jsonl")).unwrap();
+    assert!(map.contains_key("other"));
+}
+
+#[tokio::test]
+async fn disk_only_session_still_appears_in_listing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_guard, sessions) = enter_data_dir(&tmp);
+    let stale = make_summary("stale", Some("stale"), 0);
+    let p = sessions.join("index.jsonl");
+    index_file_io::append_sync(&p, &stale).unwrap();
+    write_session_json(&sessions, "fresh", "ws", 2);
+    write_session_json(&sessions, "stale", "ws", 1);
+    let summaries = list_indexed(sessions.clone(), None).await.unwrap();
+    let ids: Vec<&str> = summaries.iter().map(|s| s.id.as_str()).collect();
+    assert!(ids.contains(&"fresh"));
+    // No duplicates: each id appears exactly once.
+    assert_eq!(summaries.len(), 2);
+}
+
+#[tokio::test]
+async fn entry_for_deleted_file_is_dropped() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_guard, sessions) = enter_data_dir(&tmp);
+    write_session_json(&sessions, "live", "ws", 1);
+    write_session_json(&sessions, "doomed", "ws", 2);
+    let live = make_summary("live", None, 0);
+    let doomed = make_summary("doomed", None, 0);
+    let p = sessions.join("index.jsonl");
+    index_file_io::append_sync(&p, &live).unwrap();
+    index_file_io::append_sync(&p, &doomed).unwrap();
+    std::fs::remove_file(sessions.join("doomed.json")).unwrap();
+    let summaries = list_indexed(sessions.clone(), None).await.unwrap();
+    let ids: Vec<&str> = summaries.iter().map(|s| s.id.as_str()).collect();
+    assert!(ids.contains(&"live"));
+    assert!(!ids.contains(&"doomed"));
+}
+
+#[test]
+fn should_compact_triggers_at_four_x() {
+    assert!(!should_compact(0, 0));
+    assert!(!should_compact(3, 1));
+    assert!(should_compact(4, 1));
+    assert!(should_compact(100, 10));
 }

--- a/src/session/listing/workspace_query.rs
+++ b/src/session/listing/workspace_query.rs
@@ -1,0 +1,19 @@
+//! Workspace filter + sort helper for listings.
+
+use std::path::Path;
+
+use super::summary::SessionSummary;
+use super::workspace::matches_workspace;
+
+/// Apply workspace filter, then sort by `updated_at` desc.
+pub(super) fn filter_and_sort(
+    summaries: Vec<SessionSummary>,
+    workspace: Option<&Path>,
+) -> Vec<SessionSummary> {
+    let mut out: Vec<SessionSummary> = summaries
+        .into_iter()
+        .filter(|s| matches_workspace(s.directory.as_deref(), workspace))
+        .collect();
+    out.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    out
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -56,6 +56,7 @@ pub(crate) mod history_files;
 mod lifecycle;
 mod persistence;
 mod prompt_api;
+mod save_index;
 pub mod step_limit;
 mod tail_load;
 mod tail_seed;

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -135,6 +135,10 @@ impl Session {
                 "save journal append failed (non-fatal)"
             );
         }
+        // Keep the listing index fresh so session lists render without
+        // re-parsing every session file. Best effort — never fails the
+        // save.
+        super::save_index::record_summary_index_after_save(self).await;
         // Update the workspace index so the next resume is O(1). Best
         // effort — a failed index write must not fail the session save.
         if let Some(dir) = &self.metadata.directory {

--- a/src/session/save_index.rs
+++ b/src/session/save_index.rs
@@ -1,0 +1,22 @@
+//! Bridge between `Session::save` and the listing index append path.
+//!
+//! Kept as its own file so `persistence.rs` does not have to grow — the
+//! per-save hook is one async call and lives here.
+
+use crate::session::Session;
+use crate::session::listing::{SessionSummary, index_file};
+
+/// Build a [`SessionSummary`] for `self` and append one line to the
+/// listing index. Best-effort, never fails the save.
+pub(crate) async fn record_summary_index_after_save(session: &Session) {
+    let summary = SessionSummary {
+        id: session.id.clone(),
+        title: session.title.clone(),
+        created_at: session.created_at,
+        updated_at: session.updated_at,
+        message_count: session.messages.len(),
+        agent: session.agent.clone(),
+        directory: session.metadata.directory.clone(),
+    };
+    index_file::append_async(&summary).await;
+}


### PR DESCRIPTION
## Summary

Two related changes that came out of "sessions are impossible to browse and sort":

### 1. Append-only session listing index (`8e67ba7`)

Listing previously opened and header-parsed **every** session file in `<data_dir>/sessions/` on each call. Sessions are now recorded in `sessions/index.jsonl` — one `SessionSummary` per line (`id`, `title`, `created_at`, `updated_at`, `directory`, `agent`, `message_count`), duplicate lines tolerated with last-line-wins.

- `Session::save()` appends the session's summary line after the atomic rename (best-effort, O_APPEND on the blocking pool — can never fail or slow the save).
- `list_sessions` / `list_sessions_for_directory` read the index first, parse only on-disk session files the index doesn't know about, and prune entries whose backing file is gone.
- Missing/empty index → full directory scan that writes back a fresh compacted index. Rebuild scans **unfiltered** so a workspace-scoped listing can't drop other workspaces' sessions from the shared index.
- Compaction (tmp + atomic rename) triggers when superseded lines reach 4× the unique-id count.
- Non-session json files (e.g. `.workspace_index.json`) are excluded by an id-shape check matching the existing path-traversal guard.

### 2. Env-tunable agent-loop guardrails (`0ddde9d`)

The loop guardrails were compile-time constants; a 60-tool-call hard ceiling terminated legitimate implementation turns with no recourse but editing source. They now resolve per-turn from the environment (same pattern as `CostGuardrails`):

| Variable | Default |
|---|---|
| `CODETETHER_MAX_TOOL_CALLS` | **200** (was 60) |
| `CODETETHER_MAX_CONSECUTIVE_SAME_TOOL` | 3 (unchanged) |
| `CODETETHER_MAX_STEPS_WITHOUT_PROGRESS` | 15 (unchanged) |

Zero/unparseable values fall back to defaults. The budget-exceeded error now names the env var and suggests `--continue-session`.

## Tests

- `./scripts/cargo-sccache.sh test --lib session::` — 232 passed, 0 failed.
- New coverage: index round-trip, last-line-wins dedup, rebuild-when-missing, disk-only session pickup (no duplicates), deleted-file entry pruning, workspace-scoped rebuild keeps full index, compaction threshold, env-override parsing (default / override / zero / garbage).

## Notes

- Filenames stay `<id>.json` in this PR; sortable human-readable filenames are a planned follow-up that builds on the id→filename indirection the index provides.
- No changes under `src/provider/` — concurrent uncommitted work in that area was deliberately left out.