### PR TITLE
fix: stabilize and surface sub-agent workflows

### DIFF
--- a/docs/worktree_lifecycle.md
+++ b/docs/worktree_lifecycle.md
@@ -1,0 +1,35 @@
+# Worktree Lifecycle for Multi-Edit Agent Tasks
+
+> Issue #297 Part B — worktree churn destroying in-flight edits.
+
+## Problem
+
+During multi-step agent tasks, per-turn worktree isolation could tear down
+the working directory mid-task, silently discarding uncommitted edits.
+
+## Lifecycle Contract
+
+1. **One task = one worktree.** A single agent task operates against a stable
+   worktree for its full duration. The worktree must not be torn down between
+   turns or steps of the same task.
+
+2. **Dirty-check guard.** Before `git worktree remove --force`, the
+   `WorktreeManager` checks `git status --porcelain`. If uncommitted changes
+   exist, removal is **refused** and an error is logged:
+   ```
+   Refusing to force-remove dirty worktree — commit or stash first.
+   ```
+
+3. **Cleanup responsibility.** The caller (CLI command, TUI, or agent loop)
+   is responsible for committing or stashing before requesting worktree
+   cleanup. The worktree manager will not silently destroy work.
+
+4. **Manual override.** If a caller truly needs to discard a worktree
+   regardless of dirty state (e.g., abandoned task), they should explicitly
+   commit or `git stash` first, or use `cleanup_all()` after confirming no
+   in-flight work exists.
+
+## Implementation
+
+- `src/worktree/dirty_check.rs` — `is_worktree_dirty()` method
+- `src/worktree/cleanup_remove.rs` — calls dirty check before `--force` removal

--- a/src/agent/builtin/prompts/build.rs
+++ b/src/agent/builtin/prompts/build.rs
@@ -48,6 +48,7 @@ Always:
 - Be concise and helpful
 - Show your work by using tools
 - Explain what you're doing
+- Always include a brief text explanation before making tool calls — narrate what you're about to do and why, so the user can follow along even during long tool-heavy workflows
 - In build mode, execute directly. Do not ask for permission to proceed (e.g., "should I go ahead?").
 - For implementation/debugging requests in build mode, lead with concrete tool use, not pseudo-patches or future-step proposals.
 - Ask clarifying questions only when blocked by missing requirements or ambiguity

--- a/src/okr/mod.rs
+++ b/src/okr/mod.rs
@@ -221,16 +221,29 @@ impl KeyResult {
     }
 
     /// Calculate progress as a ratio (0.0 to 1.0)
+    ///
+    /// For KRs with a target of zero (e.g. "No critical errors" with target 0),
+    /// progress is 1.0 when the current value also meets that target (zero
+    /// errors) and 0.0 otherwise. This keeps `progress()` consistent with
+    /// [`is_complete`](Self::is_complete).
     pub fn progress(&self) -> f64 {
         if self.target_value == 0.0 {
-            return 0.0;
+            return if self.current_value <= 0.0 { 1.0 } else { 0.0 };
         }
         (self.current_value / self.target_value).clamp(0.0, 1.0)
     }
 
     /// Check if the key result is complete
+    ///
+    /// For zero-target KRs (e.g. "No critical errors"), completion means the
+    /// current value is at or below the target (zero errors), not above it.
     pub fn is_complete(&self) -> bool {
-        self.status == KeyResultStatus::Completed || self.current_value >= self.target_value
+        self.status == KeyResultStatus::Completed
+            || if self.target_value == 0.0 {
+                self.current_value <= 0.0
+            } else {
+                self.current_value >= self.target_value
+            }
     }
 
     /// Add an outcome to this key result
@@ -700,67 +713,6 @@ fn default_unit() -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_okr_creation() {
-        let okr = Okr::new("Test Objective", "Description");
-        assert_eq!(okr.title, "Test Objective");
-        assert_eq!(okr.status, OkrStatus::Draft);
-        assert!(okr.validate().is_err()); // No key results
-    }
-
-    #[test]
-    fn test_okr_with_key_results() {
-        let mut okr = Okr::new("Test Objective", "Description");
-        let kr = KeyResult::new(okr.id, "KR1", 100.0, "%");
-        okr.add_key_result(kr);
-        assert!(okr.validate().is_ok());
-    }
-
-    #[test]
-    fn test_key_result_progress() {
-        let kr = KeyResult::new(Uuid::new_v4(), "Test KR", 100.0, "%");
-        assert_eq!(kr.progress(), 0.0);
-
-        let mut kr = kr;
-        kr.update_progress(50.0);
-        assert!((kr.progress() - 0.5).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_okr_run_workflow() {
-        let okr_id = Uuid::new_v4();
-        let mut run = OkrRun::new(okr_id, "Q1 2024 Run");
-
-        // Submit for approval
-        run.submit_for_approval().unwrap();
-        assert_eq!(run.status, OkrRunStatus::PendingApproval);
-
-        // Record approval
-        run.record_decision(ApprovalDecision::approve(run.id, "Looks good"));
-        assert_eq!(run.status, OkrRunStatus::Approved);
-
-        // Start execution
-        run.start().unwrap();
-        assert_eq!(run.status, OkrRunStatus::Running);
-
-        // Update progress
-        run.update_kr_progress("kr-1", 0.5);
-
-        // Complete
-        run.complete();
-        assert_eq!(run.status, OkrRunStatus::Completed);
-    }
-
-    #[test]
-    fn test_outcome_creation() {
-        let outcome = KrOutcome::new(Uuid::new_v4(), "Fixed bug in auth")
-            .with_value(1.0)
-            .add_evidence("commit:abc123");
-
-        assert_eq!(outcome.value, Some(1.0));
-        assert!(outcome.evidence.contains(&"commit:abc123".to_string()));
-    }
-}
+mod tests;
+#[cfg(test)]
+mod tests_model;

--- a/src/okr/tests.rs
+++ b/src/okr/tests.rs
@@ -1,0 +1,30 @@
+//! KR progress and completion tests.
+
+use super::*;
+
+#[test]
+fn test_key_result_progress() {
+    let kr = KeyResult::new(Uuid::new_v4(), "Test KR", 100.0, "%");
+    assert_eq!(kr.progress(), 0.0);
+
+    let mut kr = kr;
+    kr.update_progress(50.0);
+    assert!((kr.progress() - 0.5).abs() < 0.001);
+}
+
+#[test]
+fn test_key_result_progress_zero_target_achieved() {
+    // "No critical errors" with target 0 and current 0 → achieved → 100 %
+    let kr = KeyResult::new(Uuid::new_v4(), "No critical errors", 0.0, "count");
+    assert!(kr.is_complete());
+    assert_eq!(kr.progress(), 1.0);
+}
+
+#[test]
+fn test_key_result_progress_zero_target_not_met() {
+    // target 0 but errors occurred (current > 0) → 0 %
+    let mut kr = KeyResult::new(Uuid::new_v4(), "No critical errors", 0.0, "count");
+    kr.update_progress(3.0);
+    assert!(!kr.is_complete());
+    assert_eq!(kr.progress(), 0.0);
+}

--- a/src/okr/tests_model.rs
+++ b/src/okr/tests_model.rs
@@ -1,0 +1,48 @@
+//! OKR struct, run workflow, and outcome tests.
+
+use super::*;
+
+#[test]
+fn test_okr_creation() {
+    let okr = Okr::new("Test Objective", "Description");
+    assert_eq!(okr.title, "Test Objective");
+    assert_eq!(okr.status, OkrStatus::Draft);
+    assert!(okr.validate().is_err());
+}
+
+#[test]
+fn test_okr_with_key_results() {
+    let mut okr = Okr::new("Test Objective", "Description");
+    let kr = KeyResult::new(okr.id, "KR1", 100.0, "%");
+    okr.add_key_result(kr);
+    assert!(okr.validate().is_ok());
+}
+
+#[test]
+fn test_okr_run_workflow() {
+    let okr_id = Uuid::new_v4();
+    let mut run = OkrRun::new(okr_id, "Q1 2024 Run");
+
+    run.submit_for_approval().unwrap();
+    assert_eq!(run.status, OkrRunStatus::PendingApproval);
+
+    run.record_decision(ApprovalDecision::approve(run.id, "Looks good"));
+    assert_eq!(run.status, OkrRunStatus::Approved);
+
+    run.start().unwrap();
+    assert_eq!(run.status, OkrRunStatus::Running);
+
+    run.update_kr_progress("kr-1", 0.5);
+    run.complete();
+    assert_eq!(run.status, OkrRunStatus::Completed);
+}
+
+#[test]
+fn test_outcome_creation() {
+    let outcome = KrOutcome::new(Uuid::new_v4(), "Fixed bug in auth")
+        .with_value(1.0)
+        .add_evidence("commit:abc123");
+
+    assert_eq!(outcome.value, Some(1.0));
+    assert!(outcome.evidence.contains(&"commit:abc123".to_string()));
+}

--- a/src/provider/bedrock/body/fields.rs
+++ b/src/provider/bedrock/body/fields.rs
@@ -23,15 +23,12 @@ pub(in crate::provider::bedrock) fn additional_model_request_fields(
 }
 
 fn configured_service_tier() -> Option<String> {
-    std::env::var("CODETETHER_BEDROCK_SERVICE_TIER")
-        .ok()
-        .map(|v| v.trim().to_ascii_lowercase())
-        .filter(|v| !v.is_empty())
+    super::super::runtime_config::service_tier()
 }
 
 fn configured_effort() -> &'static str {
-    let raw = std::env::var("CODETETHER_BEDROCK_THINKING_EFFORT").unwrap_or_default();
-    match raw.trim().to_ascii_lowercase().as_str() {
+    let raw = super::super::runtime_config::thinking_effort().unwrap_or_default();
+    match raw.as_str() {
         "low" => "low",
         "high" => "high",
         _ => "medium",

--- a/src/provider/bedrock/body/fields.rs
+++ b/src/provider/bedrock/body/fields.rs
@@ -32,9 +32,9 @@ fn configured_service_tier() -> Option<String> {
 fn configured_effort() -> &'static str {
     let raw = std::env::var("CODETETHER_BEDROCK_THINKING_EFFORT").unwrap_or_default();
     match raw.trim().to_ascii_lowercase().as_str() {
-        "medium" => "medium",
+        "low" => "low",
         "high" => "high",
-        _ => "low",
+        _ => "medium",
     }
 }
 
@@ -51,5 +51,6 @@ mod tests {
     fn fable_fields_include_adaptive_thinking() {
         let fields = additional_model_request_fields("global.anthropic.claude-fable-5").unwrap();
         assert_eq!(fields["thinking"]["type"], "adaptive");
+        assert_eq!(fields["output_config"]["effort"], "medium");
     }
 }

--- a/src/provider/bedrock/mod.rs
+++ b/src/provider/bedrock/mod.rs
@@ -47,6 +47,7 @@ pub mod reasoning;
 pub mod reasoning_audit;
 pub mod response;
 pub mod retry;
+pub mod runtime_config;
 pub mod sigv4;
 pub mod sso_refresh;
 pub mod stream;
@@ -206,5 +207,4 @@ impl BedrockProvider {
     }
 }
 
-#[cfg(test)]
-mod tests;
+#[cfg(test)] mod tests;

--- a/src/provider/bedrock/runtime_config.rs
+++ b/src/provider/bedrock/runtime_config.rs
@@ -1,0 +1,66 @@
+//! Thread-safe runtime overrides for Bedrock request fields.
+//!
+//! Replaces runtime `std::env::set_var` mutation (unsafe in multi-threaded
+//! async contexts) with a process-wide `RwLock`. Values are seeded once from
+//! the corresponding env vars so externally-configured deployments keep
+//! working; the TUI Settings panel updates them in-process at runtime.
+
+use parking_lot::RwLock;
+use std::sync::OnceLock;
+
+#[derive(Default, Clone)]
+struct BedrockOverrides {
+    thinking_effort: Option<String>,
+    service_tier: Option<String>,
+}
+
+fn cell() -> &'static RwLock<BedrockOverrides> {
+    static CELL: OnceLock<RwLock<BedrockOverrides>> = OnceLock::new();
+    CELL.get_or_init(|| RwLock::new(seed_from_env()))
+}
+
+fn seed_from_env() -> BedrockOverrides {
+    BedrockOverrides {
+        thinking_effort: env_value("CODETETHER_BEDROCK_THINKING_EFFORT"),
+        service_tier: env_value("CODETETHER_BEDROCK_SERVICE_TIER"),
+    }
+}
+
+fn env_value(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_ascii_lowercase())
+        .filter(|v| !v.is_empty())
+}
+
+/// Current thinking-effort override (normalized), if any.
+pub fn thinking_effort() -> Option<String> {
+    cell().read().thinking_effort.clone()
+}
+
+/// Set (or clear with `None`) the thinking-effort override.
+pub fn set_thinking_effort(value: Option<String>) {
+    cell().write().thinking_effort = value;
+}
+
+/// Current service-tier override (normalized), if any.
+pub fn service_tier() -> Option<String> {
+    cell().read().service_tier.clone()
+}
+
+/// Set (or clear with `None`) the service-tier override.
+pub fn set_service_tier(value: Option<String>) {
+    cell().write().service_tier = value;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn overrides_round_trip_without_env_mutation() {
+        set_thinking_effort(Some("high".to_string()));
+        assert_eq!(thinking_effort().as_deref(), Some("high"));
+        set_service_tier(None);
+        assert_eq!(service_tier(), None);
+    }
+}

--- a/src/session/helper/mod.rs
+++ b/src/session/helper/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod prompt_too_long;
 pub mod provider;
 pub mod recall_context;
 mod refactor_guard;
+mod repeat_guard;
 pub mod request_state;
 mod retry_error;
 pub(crate) mod rlm_background;
@@ -51,11 +52,8 @@ mod tool_heartbeat;
 pub mod validation;
 mod workspace_tools;
 
-#[cfg(test)]
-mod prompt_events_test_provider;
-#[cfg(test)]
-mod prompt_events_tests;
-#[cfg(test)]
-mod retry_error_tests;
-#[cfg(test)]
-mod validation_tests;
+#[cfg(test)] mod prompt_events_test_provider;
+#[cfg(test)] mod prompt_events_tests;
+#[cfg(test)] #[path = "repeat_guard_tests.rs"] mod repeat_guard_tests;
+#[cfg(test)] mod retry_error_tests;
+#[cfg(test)] mod validation_tests;

--- a/src/session/helper/prompt.rs
+++ b/src/session/helper/prompt.rs
@@ -140,6 +140,7 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
 
     let mut last_tool_sig: Option<String> = None;
     let mut consecutive_same_tool: u32 = 0;
+    let mut repeat_guard = super::repeat_guard::RepeatGuard::default();
     let mut consecutive_codesearch_no_matches: u32 = 0;
     let mut build_mode_tool_retry_count: u8 = 0;
     let mut native_tool_promise_retry_count: u8 = 0;
@@ -662,12 +663,11 @@ pub(crate) async fn run_prompt(session: &mut Session, message: &str) -> Result<S
                 continue;
             }
 
-            if let Some(reason) = detect_stub_in_tool_input(&tool_name, &tool_input) {
-                tracing::warn!(tool = %tool_name, reason = %reason, "Blocking suspected stubbed edit");
-                let content = format!(
-                    "Error: Refactor guard rejected this edit: {reason}. \
-                     Provide concrete, behavior-preserving implementation (no placeholders/stubs)."
-                );
+            if let Some(reason) = detect_stub_in_tool_input(&tool_name, &tool_input)
+                .or_else(|| repeat_guard.check(&tool_name, &tool_input))
+            {
+                tracing::warn!(tool = %tool_name, reason = %reason, "Pre-exec guard blocked tool call");
+                let content = format!("Error: {reason}");
                 session.add_message(super::tool_output::tool_result_with_status(
                     tool_id, &tool_name, false, content,
                 ));

--- a/src/session/helper/prompt_events.rs
+++ b/src/session/helper/prompt_events.rs
@@ -153,6 +153,7 @@ pub(crate) async fn run_prompt_with_events(
 
     let mut last_tool_sig: Option<String> = None;
     let mut consecutive_same_tool: u32 = 0;
+    let mut repeat_guard = super::repeat_guard::RepeatGuard::default();
     let mut consecutive_codesearch_no_matches: u32 = 0;
     let mut build_mode_tool_retry_count: u8 = 0;
     let mut native_tool_promise_retry_count: u8 = 0;
@@ -722,12 +723,11 @@ pub(crate) async fn run_prompt_with_events(
                 continue;
             }
 
-            if let Some(reason) = detect_stub_in_tool_input(&tool_name, &tool_input) {
-                tracing::warn!(tool = %tool_name, reason = %reason, "Blocking suspected stubbed edit");
-                let content = format!(
-                    "Error: Refactor guard rejected this edit: {reason}. \
-                     Provide concrete, behavior-preserving implementation (no placeholders/stubs)."
-                );
+            if let Some(reason) = detect_stub_in_tool_input(&tool_name, &tool_input)
+                .or_else(|| repeat_guard.check(&tool_name, &tool_input))
+            {
+                tracing::warn!(tool = %tool_name, reason = %reason, "Pre-exec guard blocked tool call");
+                let content = format!("Error: {reason}");
                 events::complete(&event_tx, &tool_id, &tool_name, content.clone(), false, 0).await;
                 session.add_message(super::tool_output::tool_result_with_status(
                     tool_id, &tool_name, false, content,

--- a/src/session/helper/repeat_guard.rs
+++ b/src/session/helper/repeat_guard.rs
@@ -1,0 +1,75 @@
+//! Per-turn repeat-call guard for edit-family tools (issue #294).
+//!
+//! The existing `consecutive_same_tool` loop guard compares the *entire*
+//! tool-call batch signature.  When the model interleaves a read with the
+//! same failing edit, the batch sig changes and the counter resets, so the
+//! model can re-issue an identical edit indefinitely.
+//!
+//! This guard tracks individual edit-family tool calls by their content
+//! signature (`name` + canonical `args`) and blocks the call once it has
+//! been seen `THRESHOLD` times within a single turn, injecting a clear
+//! message that tells the model to stop retrying.
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Edit-family tools whose repetitions we guard against.
+const EDIT_TOOLS: &[&str] =
+    &["edit", "write", "multiedit", "patch", "apply_patch", "confirm_edit"];
+
+/// Repetitions allowed before the guard fires.
+const THRESHOLD: u8 = 3;
+
+/// Tracks per-signature call counts for the duration of one agentic turn.
+#[derive(Default)]
+pub struct RepeatGuard {
+    counts: HashMap<String, u8>,
+}
+
+impl RepeatGuard {
+    /// Returns `Some(reason)` when the tool call should be blocked.
+    pub fn check(&mut self, tool_name: &str, tool_input: &Value) -> Option<String> {
+        if !EDIT_TOOLS.contains(&tool_name) {
+            return None;
+        }
+        let sig = signature(tool_name, tool_input);
+        let count = self.counts.entry(sig).or_insert(0);
+        *count += 1;
+        (*count > THRESHOLD).then(|| {
+            "You have already attempted this exact edit multiple times and it was \
+             not applied. Stop retrying the identical edit — the target text may \
+             have changed or the edit may not be applicable. Re-read the file to \
+             see its current content, then adjust your edit or report the blocker."
+                .to_string()
+        })
+    }
+}
+
+fn signature(tool_name: &str, input: &Value) -> String {
+    let canonical = canonicalize(input);
+    format!("{tool_name}:{canonical}")
+}
+
+/// Produce a stable string key from tool input, ignoring volatile fields
+/// like `tool_call_id` or `instruction` that change per call.
+fn canonicalize(input: &Value) -> String {
+    let filtered = filter_volatile(input);
+    serde_json::to_string(&filtered).unwrap_or_else(|_| input.to_string())
+}
+
+fn filter_volatile(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, v) in map {
+                if matches!(k.as_str(), "tool_call_id" | "instruction" | "update") {
+                    continue;
+                }
+                out.insert(k.clone(), filter_volatile(v));
+            }
+            Value::Object(out)
+        }
+        Value::Array(arr) => Value::Array(arr.iter().map(filter_volatile).collect()),
+        _ => value.clone(),
+    }
+}

--- a/src/session/helper/repeat_guard.rs
+++ b/src/session/helper/repeat_guard.rs
@@ -6,8 +6,9 @@
 //! model can re-issue an identical edit indefinitely.
 //!
 //! This guard tracks individual edit-family tool calls by their content
-//! signature (`name` + canonical `args`) and blocks the call once it has
-//! been seen `THRESHOLD` times within a single turn, injecting a clear
+//! signature (`name` + canonical `args`). It allows up to `THRESHOLD`
+//! identical attempts within a single turn and blocks every attempt after
+//! that (i.e. the `THRESHOLD + 1`-th call and beyond), injecting a clear
 //! message that tells the model to stop retrying.
 
 use serde_json::Value;
@@ -17,7 +18,7 @@ use std::collections::HashMap;
 const EDIT_TOOLS: &[&str] =
     &["edit", "write", "multiedit", "patch", "apply_patch", "confirm_edit"];
 
-/// Repetitions allowed before the guard fires.
+/// Identical attempts allowed before the guard fires on the next one.
 const THRESHOLD: u8 = 3;
 
 /// Tracks per-signature call counts for the duration of one agentic turn.

--- a/src/session/helper/repeat_guard_tests.rs
+++ b/src/session/helper/repeat_guard_tests.rs
@@ -1,0 +1,55 @@
+use super::repeat_guard::*;
+use serde_json::json;
+
+#[test]
+fn non_edit_tools_are_not_tracked() {
+    let mut g = RepeatGuard::default();
+    assert!(g.check("read", &json!({"path": "a.rs"})).is_none());
+    assert!(g.check("read", &json!({"path": "a.rs"})).is_none());
+}
+
+#[test]
+fn allows_up_to_threshold_repeats() {
+    let mut g = RepeatGuard::default();
+    let inp = json!({"path": "a.rs", "old_string": "x", "new_string": "y"});
+    assert!(g.check("edit", &inp).is_none());
+    assert!(g.check("edit", &inp).is_none());
+    assert!(g.check("edit", &inp).is_none());
+}
+
+#[test]
+fn blocks_after_threshold() {
+    let mut g = RepeatGuard::default();
+    let inp = json!({"path": "a.rs", "old_string": "x", "new_string": "y"});
+    for _ in 0..3 {
+        g.check("edit", &inp);
+    }
+    let blocked = g.check("edit", &inp);
+    assert!(blocked.is_some());
+    assert!(blocked.unwrap().contains("already attempted"));
+}
+
+#[test]
+fn different_edits_are_tracked_separately() {
+    let mut g = RepeatGuard::default();
+    let a = json!({"path": "a.rs", "new_string": "aa"});
+    let b = json!({"path": "b.rs", "new_string": "bb"});
+    for _ in 0..3 {
+        g.check("write", &a);
+    }
+    assert!(g.check("write", &b).is_none());
+}
+
+#[test]
+fn volatile_fields_ignored() {
+    let mut g = RepeatGuard::default();
+    let base = json!({"path": "a.rs", "new_string": "y"});
+    for _ in 0..3 {
+        g.check("edit", &base);
+    }
+    let with_id = json!({
+        "path": "a.rs", "new_string": "y",
+        "tool_call_id": "call_abc123"
+    });
+    assert!(g.check("edit", &with_id).is_some());
+}

--- a/src/tool/agent/bridge.rs
+++ b/src/tool/agent/bridge.rs
@@ -1,0 +1,35 @@
+//! Public bridge for TUI observability of agent-tool-spawned sub-agents.
+//!
+//! The TUI has its own `spawned_agents` map for `/spawn`-created agents, but
+//! agents spawned via the `agent` tool live in the private [`store`]. This
+//! module exposes a read-only snapshot so the TUI's `/agents`, `/bus`, and
+//! `/swarm` views can display all live sub-agents regardless of origin
+//! (issue #295 / #297 Part A).
+
+use super::store;
+
+/// A read-only snapshot of a spawned sub-agent, suitable for TUI display.
+#[derive(Clone, Debug)]
+pub struct AgentSnapshot {
+    pub name: String,
+    pub instructions: String,
+    pub message_count: usize,
+    pub model_id: Option<String>,
+    pub parent: Option<String>,
+    pub depth: u8,
+}
+
+/// Returns snapshots of all agents spawned via the `agent` tool.
+pub fn list_agent_tool_agents() -> Vec<AgentSnapshot> {
+    let rows = store::list_with_metadata();
+    rows.into_iter()
+        .map(|(name, instructions, msg_count, model_id, parent, depth)| AgentSnapshot {
+            name,
+            instructions,
+            message_count: msg_count,
+            model_id,
+            parent,
+            depth,
+        })
+        .collect()
+}

--- a/src/tool/agent/message.rs
+++ b/src/tool/agent/message.rs
@@ -53,7 +53,7 @@ pub(super) async fn handle_message(params: &helpers::Params) -> Result<ToolResul
             .map(|_| session_for_task)
     });
 
-    if params.detach {
+    if params.detach_or_default() {
         return Ok(super::message_detach::dispatch(
             name, _run_guard, rx, handle,
         ));

--- a/src/tool/agent/mod.rs
+++ b/src/tool/agent/mod.rs
@@ -12,6 +12,7 @@
 //! ```
 
 mod actions;
+pub mod bridge;
 mod bus_publish;
 mod event_loop;
 mod execution_state;

--- a/src/tool/agent/mod.rs
+++ b/src/tool/agent/mod.rs
@@ -39,6 +39,10 @@ mod spawn_messages;
 mod spawn_request;
 #[cfg(test)]
 mod spawn_request_tests;
+#[cfg(test)]
+#[path = "spawn_detach_tests.rs"]
+mod spawn_detach_tests;
+mod spawn_run;
 mod spawn_store;
 mod spawn_validation;
 #[cfg(test)]

--- a/src/tool/agent/params.rs
+++ b/src/tool/agent/params.rs
@@ -37,13 +37,23 @@ pub(super) struct Params {
     pub model: Option<String>,
     #[serde(default)]
     pub ephemeral: bool,
-    /// When true, `message` dispatches in the background and returns immediately
-    /// instead of blocking the caller until the sub-agent's turn finishes.
-    /// Progress is observable via the `status` action (issue #296).
+    /// Controls whether `message`/`spawn` blocks the caller.
+    ///
+    /// `None` (default) → non-blocking (detach = true): the sub-agent runs in
+    /// the background and the caller is free to continue (issue #296).
+    /// `Some(false)` → blocking: waits for the full sub-agent turn.
     #[serde(default)]
-    pub detach: bool,
+    pub detach: Option<bool>,
     #[serde(default, rename = "__ct_current_model")]
     pub _current_model: Option<String>,
     #[serde(default, rename = "__ct_parent_workspace")]
     pub parent_workspace: Option<PathBuf>,
+}
+
+impl Params {
+    /// Returns the effective detach flag, defaulting to `true` (non-blocking)
+    /// when not explicitly set (issue #296).
+    pub(super) fn detach_or_default(&self) -> bool {
+        self.detach.unwrap_or(true)
+    }
 }

--- a/src/tool/agent/params_tests.rs
+++ b/src/tool/agent/params_tests.rs
@@ -8,13 +8,23 @@ fn parse(value: serde_json::Value) -> Params {
 }
 
 #[test]
-fn detach_defaults_to_false() {
+fn detach_defaults_to_true() {
     let p = parse(json!({ "action": "message", "name": "w", "message": "hi" }));
-    assert!(!p.detach);
+    assert!(p.detach_or_default(), "detach should default to true (#296)");
 }
 
 #[test]
-fn detach_parses_true() {
-    let p = parse(json!({ "action": "message", "name": "w", "message": "hi", "detach": true }));
-    assert!(p.detach);
+fn detach_explicit_false() {
+    let p = parse(json!({
+        "action": "message", "name": "w", "message": "hi", "detach": false
+    }));
+    assert!(!p.detach_or_default());
+}
+
+#[test]
+fn detach_explicit_true() {
+    let p = parse(json!({
+        "action": "message", "name": "w", "message": "hi", "detach": true
+    }));
+    assert!(p.detach_or_default());
 }

--- a/src/tool/agent/spawn.rs
+++ b/src/tool/agent/spawn.rs
@@ -1,19 +1,21 @@
 //! Spawn orchestration for the agent tool.
 //!
 //! Coordinates spawn request parsing, validation, session creation, and the
-//! durable/ephemeral persistence policy. Model eligibility issues surface as
-//! warnings appended to the spawn result rather than hard errors.
+//! durable/ephemeral persistence policy. After persistence succeeds, the first
+//! model turn is auto-started via [`super::spawn_run`] so the sub-agent begins
+//! working immediately instead of sitting idle (issue #295).
 
 use super::params::Params;
 use super::session_factory;
 use super::spawn_messages::{ephemeral_message, failure_message, success_message, with_warning};
 use super::spawn_request::SpawnRequest;
+use super::spawn_run;
 use super::spawn_store;
 use super::spawn_validation;
 use crate::tool::ToolResult;
 use anyhow::Result;
 
-/// Spawns a new sub-agent after validating the request.
+/// Spawns a new sub-agent and auto-starts its first turn.
 pub(super) async fn handle_spawn(params: &Params) -> Result<ToolResult> {
     let request = SpawnRequest::from_params(params)?;
     let warning = match spawn_validation::validate_spawn_request(&request).await {
@@ -42,10 +44,14 @@ pub(super) async fn handle_spawn(params: &Params) -> Result<ToolResult> {
     {
         return Ok(ToolResult::error(failure_message(&request, &error)));
     }
-    tracing::info!(agent = %request.name, model = %request.model, "Sub-agent spawned");
-    super::bus_publish::announce_working(request.name, format!("spawned ({})", request.model));
-    Ok(ToolResult::success(with_warning(
-        success_message(&request),
-        warning.as_deref(),
-    )))
+    tracing::info!(agent = %request.name, model = %request.model, "Sub-agent spawned, auto-starting first turn");
+    // Auto-start the first turn so the agent begins working immediately (#295).
+    let mut result = spawn_run::kick_off(request.name, request.detach).await?;
+    result.output = format!(
+        "{}\n\nFirst turn dispatched{}.",
+        result.output,
+        if request.detach { " (background)" } else { " (synchronous)" }
+    );
+    let _ = warning;
+    Ok(result)
 }

--- a/src/tool/agent/spawn.rs
+++ b/src/tool/agent/spawn.rs
@@ -47,11 +47,12 @@ pub(super) async fn handle_spawn(params: &Params) -> Result<ToolResult> {
     tracing::info!(agent = %request.name, model = %request.model, "Sub-agent spawned, auto-starting first turn");
     // Auto-start the first turn so the agent begins working immediately (#295).
     let mut result = spawn_run::kick_off(request.name, request.detach).await?;
-    result.output = format!(
-        "{}\n\nFirst turn dispatched{}.",
+    let dispatch = if request.detach { " (background)" } else { " (synchronous)" };
+    let body = format!(
+        "{}\n\n{}\n\nFirst turn dispatched{dispatch}.",
+        success_message(&request),
         result.output,
-        if request.detach { " (background)" } else { " (synchronous)" }
     );
-    let _ = warning;
+    result.output = with_warning(body, warning.as_deref());
     Ok(result)
 }

--- a/src/tool/agent/spawn.rs
+++ b/src/tool/agent/spawn.rs
@@ -40,7 +40,7 @@ pub(super) async fn handle_spawn(params: &Params) -> Result<ToolResult> {
         )));
     }
     if let Err(error) =
-        spawn_store::persist_spawned_agent(request.name, request.instructions, session).await
+        spawn_store::persist_spawned_agent(request.name, request.instructions, session, request.model).await
     {
         return Ok(ToolResult::error(failure_message(&request, &error)));
     }

--- a/src/tool/agent/spawn_detach_tests.rs
+++ b/src/tool/agent/spawn_detach_tests.rs
@@ -1,0 +1,35 @@
+//! Tests that the `detach` field on spawn params is correctly propagated to the
+//! `SpawnRequest`, enabling background-first-turn dispatch (issue #295/#296).
+
+use super::params::Params;
+use super::spawn_request::SpawnRequest;
+use serde_json::json;
+
+fn params(value: serde_json::Value) -> Params {
+    serde_json::from_value(value).expect("params parse")
+}
+
+#[test]
+fn detach_defaults_to_false() {
+    let p = params(json!({
+        "action": "spawn",
+        "name": "reviewer",
+        "instructions": "audit the PR",
+        "__ct_current_model": "zai/glm-5.1",
+    }));
+    let request = SpawnRequest::from_params(&p).expect("spawn request");
+    assert!(!request.detach, "detach should default to false");
+}
+
+#[test]
+fn detach_true_is_propagated() {
+    let p = params(json!({
+        "action": "spawn",
+        "name": "bg-agent",
+        "instructions": "work on issue #213",
+        "model": "zai/glm-5.1",
+        "detach": true,
+    }));
+    let request = SpawnRequest::from_params(&p).expect("spawn request");
+    assert!(request.detach, "detach should be true when explicitly set");
+}

--- a/src/tool/agent/spawn_detach_tests.rs
+++ b/src/tool/agent/spawn_detach_tests.rs
@@ -10,7 +10,7 @@ fn params(value: serde_json::Value) -> Params {
 }
 
 #[test]
-fn detach_defaults_to_false() {
+fn detach_defaults_to_true() {
     let p = params(json!({
         "action": "spawn",
         "name": "reviewer",
@@ -18,18 +18,18 @@ fn detach_defaults_to_false() {
         "__ct_current_model": "zai/glm-5.1",
     }));
     let request = SpawnRequest::from_params(&p).expect("spawn request");
-    assert!(!request.detach, "detach should default to false");
+    assert!(request.detach, "detach should default to true (#296)");
 }
 
 #[test]
-fn detach_true_is_propagated() {
+fn detach_false_is_propagated() {
     let p = params(json!({
         "action": "spawn",
-        "name": "bg-agent",
+        "name": "sync-agent",
         "instructions": "work on issue #213",
         "model": "zai/glm-5.1",
-        "detach": true,
+        "detach": false,
     }));
     let request = SpawnRequest::from_params(&p).expect("spawn request");
-    assert!(request.detach, "detach should be true when explicitly set");
+    assert!(!request.detach, "detach should be false when explicitly set");
 }

--- a/src/tool/agent/spawn_request.rs
+++ b/src/tool/agent/spawn_request.rs
@@ -16,6 +16,7 @@ pub(super) struct SpawnRequest<'a> {
     pub instructions: &'a str,
     pub model: &'a str,
     pub ephemeral: bool,
+    pub detach: bool,
     pub parent_workspace: Option<PathBuf>,
 }
 
@@ -39,6 +40,7 @@ impl<'a> SpawnRequest<'a> {
                 .context("instructions required for spawn")?,
             model,
             ephemeral: params.ephemeral,
+            detach: params.detach,
             parent_workspace: params.parent_workspace.clone(),
         })
     }

--- a/src/tool/agent/spawn_request.rs
+++ b/src/tool/agent/spawn_request.rs
@@ -40,7 +40,7 @@ impl<'a> SpawnRequest<'a> {
                 .context("instructions required for spawn")?,
             model,
             ephemeral: params.ephemeral,
-            detach: params.detach,
+            detach: params.detach_or_default(),
             parent_workspace: params.parent_workspace.clone(),
         })
     }

--- a/src/tool/agent/spawn_run.rs
+++ b/src/tool/agent/spawn_run.rs
@@ -1,0 +1,59 @@
+//! Auto-starts the first model turn after a sub-agent is spawned (issue #295).
+//!
+//! Previously, `spawn` only created a session and stored it — no model call was
+//! ever made until the caller explicitly invoked `message`. This left spawned
+//! agents permanently idle (`no_activity`).
+//!
+//! This module sends a kick-off user message and runs the turn either detached
+//! (background tokio task) or synchronously.
+
+use super::bus_publish;
+use super::event_loop;
+use super::execution_state;
+use super::helpers;
+use super::message_detach;
+use super::message_finalize;
+use super::store;
+use crate::session::SessionEvent;
+use crate::tool::ToolResult;
+use anyhow::{Context, Result};
+use tokio::sync::mpsc;
+
+/// Kick off the first turn for a freshly spawned sub-agent.
+///
+/// When `detach` is true the turn runs in a background task and returns
+/// immediately; otherwise it blocks until the turn completes.
+pub(super) async fn kick_off(name: &str, detach: bool) -> Result<ToolResult> {
+    let Some(_guard) = execution_state::try_start(name) else {
+        return Ok(ToolResult::success(format!(
+            "Spawned @{name}. Agent will start once its current turn finishes."
+        )));
+    };
+    let session = store::get(name)
+        .map(|e| e.session)
+        .context(format!("Agent @{name} vanished after spawn"))?;
+    let registry = helpers::get_registry().await?;
+    bus_publish::announce_working(name, "starting first turn");
+    let (tx, mut rx) = mpsc::channel::<SessionEvent>(256);
+    let mut session_for_task = session.clone();
+    if session_for_task.bus.is_none() {
+        session_for_task.bus = crate::bus::global();
+    }
+    let handle = tokio::spawn(async move {
+        session_for_task
+            .prompt_with_events(KICKOFF_MSG, tx, registry)
+            .await
+            .map(|_| session_for_task)
+    });
+    if detach {
+        return Ok(message_detach::dispatch(
+            name.to_string(), _guard, rx, handle,
+        ));
+    }
+    let r = event_loop::run(&mut rx, handle).await;
+    Ok(message_finalize::finalize(
+        name.to_string(), r.0, r.1, r.2, r.3, r.4,
+    ).await)
+}
+
+const KICKOFF_MSG: &str = "Begin working on your assigned task now.";

--- a/src/tool/agent/spawn_store.rs
+++ b/src/tool/agent/spawn_store.rs
@@ -12,6 +12,7 @@ pub(super) async fn persist_spawned_agent(
     name: &str,
     instructions: &str,
     session: Session,
+    model: &str,
 ) -> Result<()> {
     save_session(name, &session).await?;
     store::insert(
@@ -19,6 +20,9 @@ pub(super) async fn persist_spawned_agent(
         AgentEntry {
             instructions: instructions.to_string(),
             session,
+            parent: None,
+            depth: 0,
+            model_id: Some(model.to_string()),
         },
     );
     Ok(())

--- a/src/tool/agent/spawn_validation_tests.rs
+++ b/src/tool/agent/spawn_validation_tests.rs
@@ -12,6 +12,7 @@ fn request(model: &'static str) -> SpawnRequest<'static> {
         instructions: "test",
         model,
         ephemeral: true,
+        detach: false,
         parent_workspace: None,
     }
 }

--- a/src/tool/agent/store.rs
+++ b/src/tool/agent/store.rs
@@ -18,12 +18,15 @@ use std::collections::HashMap;
 /// # Examples
 ///
 /// ```ignore
-/// let entry = AgentEntry { instructions: "Review".into(), session };
+/// let entry = AgentEntry { instructions: "Review".into(), session, parent: None, depth: 0, model_id: None };
 /// ```
 #[derive(Clone)]
 pub(super) struct AgentEntry {
     pub instructions: String,
     pub session: Session,
+    pub parent: Option<String>,
+    pub depth: u8,
+    pub model_id: Option<String>,
 }
 
 lazy_static::lazy_static! {
@@ -31,56 +34,26 @@ lazy_static::lazy_static! {
 }
 
 /// Inserts or replaces a spawned agent entry.
-///
-/// # Examples
-///
-/// ```ignore
-/// insert("reviewer".into(), entry);
-/// ```
 pub(super) fn insert(name: String, entry: AgentEntry) {
     AGENT_STORE.write().insert(name, entry);
 }
 
 /// Removes a spawned agent entry by name.
-///
-/// # Examples
-///
-/// ```ignore
-/// let removed = remove("reviewer");
-/// ```
 pub(super) fn remove(name: &str) -> Option<AgentEntry> {
     AGENT_STORE.write().remove(name)
 }
 
 /// Returns a cloned spawned-agent entry when present.
-///
-/// # Examples
-///
-/// ```ignore
-/// let entry = get("reviewer");
-/// ```
 pub(super) fn get(name: &str) -> Option<AgentEntry> {
     AGENT_STORE.read().get(name).cloned()
 }
 
 /// Returns whether an agent name is already present in the store.
-///
-/// # Examples
-///
-/// ```ignore
-/// let exists = contains("reviewer");
-/// ```
 pub(super) fn contains(name: &str) -> bool {
     AGENT_STORE.read().contains_key(name)
 }
 
 /// Lists spawned agents as `(name, instructions, message_count)` tuples.
-///
-/// # Examples
-///
-/// ```ignore
-/// let rows = list();
-/// ```
 pub(super) fn list() -> Vec<(String, String, usize)> {
     AGENT_STORE
         .read()
@@ -90,14 +63,18 @@ pub(super) fn list() -> Vec<(String, String, usize)> {
 }
 
 /// Replaces the stored session for a spawned agent when it exists.
-///
-/// # Examples
-///
-/// ```ignore
-/// update_session("reviewer", session);
-/// ```
 pub(super) fn update_session(name: &str, session: Session) {
     if let Some(e) = AGENT_STORE.write().get_mut(name) {
         e.session = session;
     }
+}
+
+/// Lists agents with full metadata for the TUI bridge (#297 Part A).
+pub(super) fn list_with_metadata()
+    -> Vec<(String, String, usize, Option<String>, Option<String>, u8)> {
+    AGENT_STORE.read().iter()
+        .map(|(n, e)| (n.clone(), e.instructions.clone(),
+            e.session.messages.len(), e.model_id.clone(),
+            e.parent.clone(), e.depth))
+        .collect()
 }

--- a/src/tool/agent/tool_schema.rs
+++ b/src/tool/agent/tool_schema.rs
@@ -15,7 +15,7 @@ pub(super) fn agent_tool_parameters() -> Value {
             "message": { "type": "string", "description": "Message to send" },
             "model": { "type": "string", "description": "Model (spawn). Should be free/subscription-eligible; otherwise a cost warning is returned." },
             "ephemeral": { "type": "boolean", "description": "Spawn without durable session persistence; returns an explicit warning." },
-            "detach": { "type": "boolean", "description": "For message: dispatch in the background and return immediately instead of blocking until the sub-agent's turn finishes. Watch progress with action \"status\"." }
+            "detach": { "type": "boolean", "description": "Default true: sub-agent runs in the background and the caller is not blocked. Set false to block until the sub-agent finishes its turn. Watch progress with action \"status\"." }
         },
         "required": ["action"]
     })

--- a/src/tui/app/agents_cmd.rs
+++ b/src/tui/app/agents_cmd.rs
@@ -1,0 +1,48 @@
+//! Unified `/agents` listing — merges TUI-spawned and agent-tool-spawned
+//! sub-agents into a single view (issue #295 / #297 Part A).
+
+use crate::tui::app::state::App;
+
+/// Build the display lines for `/agents`, combining both registries.
+pub fn build_agent_list(app: &App) -> Vec<String> {
+    let mut lines = Vec::new();
+    collect_tui_agents(app, &mut lines);
+    collect_agent_tool_agents(&mut lines);
+    lines
+}
+
+fn collect_tui_agents(app: &App, out: &mut Vec<String>) {
+    for (key, agent) in &app.state.spawned_agents {
+        let msg_count = agent.session.history().len();
+        let model = agent.session.metadata.model.as_deref().unwrap_or("default");
+        let active = if app.state.active_spawned_agent.as_deref() == Some(key.as_str()) {
+            " [active]"
+        } else {
+            ""
+        };
+        out.push(format!(
+            "  {}{} — {} messages — model: {}",
+            agent.name, active, msg_count, model
+        ));
+    }
+}
+
+fn collect_agent_tool_agents(out: &mut Vec<String>) {
+    let snapshots = crate::tool::agent::bridge::list_agent_tool_agents();
+    let existing: std::collections::HashSet<String> =
+        out.iter().filter_map(|l| name_from_line(l)).collect();
+    for snap in snapshots {
+        if existing.contains(&snap.name) {
+            continue;
+        }
+        let model = snap.model_id.as_deref().unwrap_or("default");
+        out.push(format!(
+            "  {} — {} messages — model: {} (agent-tool)",
+            snap.name, snap.message_count, model
+        ));
+    }
+}
+
+fn name_from_line(line: &str) -> Option<String> {
+    line.trim_start().split_whitespace().next().map(str::to_string)
+}

--- a/src/tui/app/commands.rs
+++ b/src/tui/app/commands.rs
@@ -1093,42 +1093,15 @@ fn handle_kill_command(app: &mut App, rest: &str) {
 }
 
 fn handle_agents_command(app: &mut App) {
-    if app.state.spawned_agents.is_empty() {
+    let lines = super::agents_cmd::build_agent_list(app);
+    if lines.is_empty() {
         app.state.status = "No spawned agents.".to_string();
-        push_system_message(app, "No spawned agents. Use /spawn <name> to create one.");
+        push_system_message(app, "No spawned agents. Use /spawn or the agent tool.");
     } else {
-        let count = app.state.spawned_agents.len();
-        let lines: Vec<String> = app
-            .state
-            .spawned_agents
-            .iter()
-            .map(|(key, agent)| {
-                let msg_count = agent.session.history().len();
-                let model = agent.session.metadata.model.as_deref().unwrap_or("default");
-                let active = if app.state.active_spawned_agent.as_deref() == Some(key) {
-                    " [active]"
-                } else {
-                    ""
-                };
-                format!(
-                    "  {}{} — {} messages — model: {}",
-                    agent.name, active, msg_count, model
-                )
-            })
-            .collect();
-
-        let body = lines.join(
-            "
-",
-        );
+        let count = lines.len();
+        let body = lines.join("\n");
         app.state.status = format!("{count} spawned agent(s)");
-        push_system_message(
-            app,
-            format!(
-                "Spawned agents ({count}):
-{body}"
-            ),
-        );
+        push_system_message(app, format!("Spawned agents ({count}):\n{body}"));
     }
 }
 async fn handle_go_command(

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -1,4 +1,5 @@
 pub mod ask;
+pub mod agents_cmd;
 pub mod auto_apply;
 pub mod autochat;
 pub mod background;

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -7,8 +7,7 @@ pub mod bus;
 pub mod codex_sessions;
 pub mod commands;
 pub mod context_status;
-#[cfg(test)]
-mod context_status_tests;
+#[cfg(test)] mod context_status_tests;
 pub mod detach;
 pub mod event_handlers;
 pub mod event_loop;

--- a/src/tui/app/settings.rs
+++ b/src/tui/app/settings.rs
@@ -1,9 +1,18 @@
+//! Settings-panel actions: toggles, cycles, and persistence.
+
 use crate::session::Session;
 use crate::tui::app::commands::set_auto_apply_edits;
 use crate::tui::app::state::App;
 
 #[path = "settings_access_mode.rs"]
 pub mod access_mode;
+#[path = "settings_bedrock.rs"]
+pub mod bedrock;
+#[path = "settings_network.rs"]
+pub mod network;
+
+pub use bedrock::{bedrock_service_tier_label, cycle_bedrock_service_tier};
+pub use network::{network_access_status_message, set_network_access, toggle_network_access};
 
 fn on_off_label(enabled: bool) -> &'static str {
     if enabled { "ON" } else { "OFF" }
@@ -14,25 +23,6 @@ async fn persist(app: &mut App, session: &mut Session, message: String) {
         Ok(()) => app.state.status = message,
         Err(error) => app.state.status = format!("{message} (not persisted: {error})"),
     }
-}
-
-pub fn network_access_status_message(enabled: bool) -> String {
-    format!("TUI network access: {}", on_off_label(enabled))
-}
-
-pub async fn set_network_access(app: &mut App, session: &mut Session, next: bool) {
-    app.state.allow_network = next;
-    session.metadata.allow_network = next;
-    if next {
-        unsafe { std::env::set_var("CODETETHER_SANDBOX_BASH_ALLOW_NETWORK", "1") }
-    } else {
-        unsafe { std::env::remove_var("CODETETHER_SANDBOX_BASH_ALLOW_NETWORK") }
-    }
-    persist(app, session, network_access_status_message(next)).await;
-}
-
-pub async fn toggle_network_access(app: &mut App, session: &mut Session) {
-    set_network_access(app, session, !app.state.allow_network).await;
 }
 
 pub fn autocomplete_status_message(enabled: bool) -> String {
@@ -57,38 +47,6 @@ pub async fn set_use_worktree(app: &mut App, session: &mut Session, next: bool) 
     app.state.use_worktree = next;
     session.metadata.use_worktree = next;
     persist(app, session, worktree_status_message(next)).await;
-}
-
-pub fn bedrock_service_tier_label() -> &'static str {
-    match std::env::var("CODETETHER_BEDROCK_SERVICE_TIER")
-        .unwrap_or_default()
-        .trim()
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "standard" => "standard",
-        "priority" => "priority",
-        _ => "default",
-    }
-}
-
-pub async fn cycle_bedrock_service_tier(app: &mut App, session: &mut Session) {
-    let next = match bedrock_service_tier_label() {
-        "default" => Some("standard"),
-        "standard" => Some("priority"),
-        _ => None,
-    };
-    if let Some(value) = next {
-        unsafe { std::env::set_var("CODETETHER_BEDROCK_SERVICE_TIER", value) }
-    } else {
-        unsafe { std::env::remove_var("CODETETHER_BEDROCK_SERVICE_TIER") }
-    }
-    persist(
-        app,
-        session,
-        format!("Bedrock service tier: {}", bedrock_service_tier_label()),
-    )
-    .await;
 }
 
 pub async fn toggle_selected_setting(app: &mut App, session: &mut Session) {

--- a/src/tui/app/settings.rs
+++ b/src/tui/app/settings.rs
@@ -8,10 +8,17 @@ use crate::tui::app::state::App;
 pub mod access_mode;
 #[path = "settings_bedrock.rs"]
 pub mod bedrock;
+#[path = "settings_bedrock_effort.rs"]
+pub mod bedrock_effort;
+#[path = "settings_dispatch.rs"]
+pub mod dispatch;
 #[path = "settings_network.rs"]
 pub mod network;
 
-pub use bedrock::{bedrock_service_tier_label, cycle_bedrock_service_tier};
+pub use bedrock::bedrock_service_tier_label;
+pub use bedrock::cycle_bedrock_service_tier;
+pub use bedrock_effort::{bedrock_thinking_effort_label, cycle_bedrock_thinking_effort};
+pub use dispatch::toggle_selected_setting;
 pub use network::{network_access_status_message, set_network_access, toggle_network_access};
 
 fn on_off_label(enabled: bool) -> &'static str {
@@ -47,16 +54,4 @@ pub async fn set_use_worktree(app: &mut App, session: &mut Session, next: bool) 
     app.state.use_worktree = next;
     session.metadata.use_worktree = next;
     persist(app, session, worktree_status_message(next)).await;
-}
-
-pub async fn toggle_selected_setting(app: &mut App, session: &mut Session) {
-    match app.state.selected_settings_index {
-        0 => set_auto_apply_edits(app, session, !app.state.auto_apply_edits).await,
-        1 => set_network_access(app, session, !app.state.allow_network).await,
-        2 => set_slash_autocomplete(app, session, !app.state.slash_autocomplete).await,
-        3 => set_use_worktree(app, session, !app.state.use_worktree).await,
-        4 => access_mode::cycle_access_mode(app, session).await,
-        5 => cycle_bedrock_service_tier(app, session).await,
-        _ => {}
-    }
 }

--- a/src/tui/app/settings_bedrock.rs
+++ b/src/tui/app/settings_bedrock.rs
@@ -1,17 +1,13 @@
 //! Bedrock service-tier cycling for the Settings panel.
 
+use crate::provider::bedrock::runtime_config;
 use crate::session::Session;
 use crate::tui::app::state::App;
 
 use super::persist;
 
 pub fn bedrock_service_tier_label() -> &'static str {
-    match std::env::var("CODETETHER_BEDROCK_SERVICE_TIER")
-        .unwrap_or_default()
-        .trim()
-        .to_ascii_lowercase()
-        .as_str()
-    {
+    match runtime_config::service_tier().unwrap_or_default().as_str() {
         "standard" => "standard",
         "priority" => "priority",
         _ => "default",
@@ -20,15 +16,11 @@ pub fn bedrock_service_tier_label() -> &'static str {
 
 pub async fn cycle_bedrock_service_tier(app: &mut App, session: &mut Session) {
     let next = match bedrock_service_tier_label() {
-        "default" => Some("standard"),
-        "standard" => Some("priority"),
+        "default" => Some("standard".to_string()),
+        "standard" => Some("priority".to_string()),
         _ => None,
     };
-    if let Some(value) = next {
-        unsafe { std::env::set_var("CODETETHER_BEDROCK_SERVICE_TIER", value) }
-    } else {
-        unsafe { std::env::remove_var("CODETETHER_BEDROCK_SERVICE_TIER") }
-    }
+    runtime_config::set_service_tier(next);
     persist(
         app,
         session,

--- a/src/tui/app/settings_bedrock.rs
+++ b/src/tui/app/settings_bedrock.rs
@@ -1,0 +1,38 @@
+//! Bedrock service-tier cycling for the Settings panel.
+
+use crate::session::Session;
+use crate::tui::app::state::App;
+
+use super::persist;
+
+pub fn bedrock_service_tier_label() -> &'static str {
+    match std::env::var("CODETETHER_BEDROCK_SERVICE_TIER")
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "standard" => "standard",
+        "priority" => "priority",
+        _ => "default",
+    }
+}
+
+pub async fn cycle_bedrock_service_tier(app: &mut App, session: &mut Session) {
+    let next = match bedrock_service_tier_label() {
+        "default" => Some("standard"),
+        "standard" => Some("priority"),
+        _ => None,
+    };
+    if let Some(value) = next {
+        unsafe { std::env::set_var("CODETETHER_BEDROCK_SERVICE_TIER", value) }
+    } else {
+        unsafe { std::env::remove_var("CODETETHER_BEDROCK_SERVICE_TIER") }
+    }
+    persist(
+        app,
+        session,
+        format!("Bedrock service tier: {}", bedrock_service_tier_label()),
+    )
+    .await;
+}

--- a/src/tui/app/settings_bedrock_effort.rs
+++ b/src/tui/app/settings_bedrock_effort.rs
@@ -1,0 +1,40 @@
+//! Bedrock thinking-effort cycling for the Settings panel.
+//!
+//! Controls the `CODETETHER_BEDROCK_THINKING_EFFORT` env var that feeds
+//! `output_config.effort` on encrypted-reasoning models (Claude Fable 5,
+//! Opus 4.7). Higher effort → more visible reasoning before tool calls.
+
+use crate::session::Session;
+use crate::tui::app::state::App;
+
+use super::persist;
+
+/// Current effort label as shown in the Settings panel.
+pub fn bedrock_thinking_effort_label() -> &'static str {
+    match std::env::var("CODETETHER_BEDROCK_THINKING_EFFORT")
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "low" => "low",
+        "high" => "high",
+        _ => "medium",
+    }
+}
+
+/// Cycle: medium → low → high → medium (default is medium).
+pub async fn cycle_bedrock_thinking_effort(app: &mut App, session: &mut Session) {
+    let next = match bedrock_thinking_effort_label() {
+        "medium" => "low",
+        "low" => "high",
+        _ => "medium",
+    };
+    unsafe { std::env::set_var("CODETETHER_BEDROCK_THINKING_EFFORT", next) };
+    persist(
+        app,
+        session,
+        format!("Bedrock thinking effort: {next}"),
+    )
+    .await;
+}

--- a/src/tui/app/settings_bedrock_effort.rs
+++ b/src/tui/app/settings_bedrock_effort.rs
@@ -1,9 +1,12 @@
 //! Bedrock thinking-effort cycling for the Settings panel.
 //!
-//! Controls the `CODETETHER_BEDROCK_THINKING_EFFORT` env var that feeds
-//! `output_config.effort` on encrypted-reasoning models (Claude Fable 5,
-//! Opus 4.7). Higher effort → more visible reasoning before tool calls.
+//! Controls the thinking effort that feeds `output_config.effort` on
+//! encrypted-reasoning models (Claude Fable 5, Opus 4.7). Higher effort →
+//! more visible reasoning before tool calls. Stored in thread-safe process
+//! state (see [`crate::provider::bedrock::runtime_config`]) rather than a
+//! runtime-mutated env var.
 
+use crate::provider::bedrock::runtime_config;
 use crate::session::Session;
 use crate::tui::app::state::App;
 
@@ -11,12 +14,7 @@ use super::persist;
 
 /// Current effort label as shown in the Settings panel.
 pub fn bedrock_thinking_effort_label() -> &'static str {
-    match std::env::var("CODETETHER_BEDROCK_THINKING_EFFORT")
-        .unwrap_or_default()
-        .trim()
-        .to_ascii_lowercase()
-        .as_str()
-    {
+    match runtime_config::thinking_effort().unwrap_or_default().as_str() {
         "low" => "low",
         "high" => "high",
         _ => "medium",
@@ -30,11 +28,6 @@ pub async fn cycle_bedrock_thinking_effort(app: &mut App, session: &mut Session)
         "low" => "high",
         _ => "medium",
     };
-    unsafe { std::env::set_var("CODETETHER_BEDROCK_THINKING_EFFORT", next) };
-    persist(
-        app,
-        session,
-        format!("Bedrock thinking effort: {next}"),
-    )
-    .await;
+    runtime_config::set_thinking_effort(Some(next.to_string()));
+    persist(app, session, format!("Bedrock thinking effort: {next}")).await;
 }

--- a/src/tui/app/settings_dispatch.rs
+++ b/src/tui/app/settings_dispatch.rs
@@ -1,0 +1,29 @@
+//! Dispatch for the Settings panel toggle/Enter action.
+//!
+//! Maps `selected_settings_index` to the corresponding setting action.
+//! Keeping this in its own module respects the 50-line file limit and
+//! separates dispatch from individual setting implementations.
+
+use crate::session::Session;
+use crate::tui::app::commands::set_auto_apply_edits;
+use crate::tui::app::state::App;
+
+use super::access_mode;
+use super::bedrock::cycle_bedrock_service_tier;
+use super::bedrock_effort::cycle_bedrock_thinking_effort;
+use super::network;
+use super::{set_slash_autocomplete, set_use_worktree};
+
+/// Execute the action for the currently selected settings row.
+pub async fn toggle_selected_setting(app: &mut App, session: &mut Session) {
+    match app.state.selected_settings_index {
+        0 => set_auto_apply_edits(app, session, !app.state.auto_apply_edits).await,
+        1 => network::set_network_access(app, session, !app.state.allow_network).await,
+        2 => set_slash_autocomplete(app, session, !app.state.slash_autocomplete).await,
+        3 => set_use_worktree(app, session, !app.state.use_worktree).await,
+        4 => access_mode::cycle_access_mode(app, session).await,
+        5 => cycle_bedrock_service_tier(app, session).await,
+        6 => cycle_bedrock_thinking_effort(app, session).await,
+        _ => {}
+    }
+}

--- a/src/tui/app/settings_network.rs
+++ b/src/tui/app/settings_network.rs
@@ -1,0 +1,25 @@
+//! Network-access toggle for the Settings panel.
+
+use crate::session::Session;
+use crate::tui::app::state::App;
+
+use super::{on_off_label, persist};
+
+pub fn network_access_status_message(enabled: bool) -> String {
+    format!("TUI network access: {}", on_off_label(enabled))
+}
+
+pub async fn set_network_access(app: &mut App, session: &mut Session, next: bool) {
+    app.state.allow_network = next;
+    session.metadata.allow_network = next;
+    if next {
+        unsafe { std::env::set_var("CODETETHER_SANDBOX_BASH_ALLOW_NETWORK", "1") }
+    } else {
+        unsafe { std::env::remove_var("CODETETHER_SANDBOX_BASH_ALLOW_NETWORK") }
+    }
+    persist(app, session, network_access_status_message(next)).await;
+}
+
+pub async fn toggle_network_access(app: &mut App, session: &mut Session) {
+    set_network_access(app, session, !app.state.allow_network).await;
+}

--- a/src/tui/app/spawn_agent_create.rs
+++ b/src/tui/app/spawn_agent_create.rs
@@ -24,6 +24,9 @@ pub(super) async fn create_agent(app: &mut App, args: SpawnArgs, depth: u8) {
         }
     };
     session.agent = format!("spawned:{}", args.name);
+    // Autonomous sub-agents cannot interactively confirm edits; without this
+    // they loop re-issuing the same pending edit forever (issue #294).
+    session.metadata.auto_apply_edits = true;
     session.add_message(crate::provider::Message {
         role: crate::provider::Role::System,
         content: vec![crate::provider::ContentPart::Text {

--- a/src/tui/app/state/settings_nav.rs
+++ b/src/tui/app/state/settings_nav.rs
@@ -3,7 +3,7 @@
 use crate::tui::models::ViewMode;
 
 impl super::AppState {
-    pub(crate) const SETTINGS_COUNT: usize = 6;
+    pub(crate) const SETTINGS_COUNT: usize = 7;
 
     pub fn settings_select_prev(&mut self) {
         if self.selected_settings_index > 0 {

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -49,6 +49,7 @@ mod tests {
 
         assert!(text.contains("Edit auto-apply"));
         assert!(text.contains("Access mode"));
+        assert!(text.contains("thinking effort"));
         assert!(text.contains("Up / Down selects a setting"));
     }
 }

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -1,3 +1,5 @@
+//! Settings panel rendering: composes rows and draws the widget.
+
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
@@ -7,45 +9,12 @@ use ratatui::{
 use crate::tui::app::state::AppState;
 use crate::tui::status::render_status;
 
+#[path = "settings_lines.rs"]
+mod lines;
 #[path = "settings_rows.rs"]
 mod rows;
 
-use ratatui::text::Line;
-use rows::{access_mode_line, setting_line, value_line};
-
-fn settings_lines(s: &AppState) -> Vec<Line<'static>> {
-    let idx = s.selected_settings_index;
-    vec![
-        Line::from("Settings"),
-        Line::from(""),
-        setting_line("Edit auto-apply", s.auto_apply_edits, idx == 0),
-        Line::from("  Automatically confirms pending edit/multiedit previews in the TUI."),
-        Line::from(""),
-        setting_line("Network access", s.allow_network, idx == 1),
-        Line::from("  Allows sandboxed bash commands in this TUI session to use network access."),
-        Line::from(""),
-        setting_line("Slash autocomplete", s.slash_autocomplete, idx == 2),
-        Line::from("  Enables Tab completion for slash commands in the composer."),
-        Line::from(""),
-        setting_line("Worktree isolation", s.use_worktree, idx == 3),
-        Line::from("  Runs agent work in a git worktree branch, auto-merged on success."),
-        Line::from(""),
-        access_mode_line(idx == 4),
-        Line::from("  Cycles tool access: ask -> approve -> full (Enter to change)."),
-        Line::from(""),
-        value_line(
-            "Bedrock service tier",
-            crate::tui::app::settings::bedrock_service_tier_label().to_string(),
-            idx == 5,
-        ),
-        Line::from("  Cycles Claude on Bedrock service_tier: default -> standard -> priority."),
-        Line::from(""),
-        Line::from("Controls:"),
-        Line::from("  - Up / Down selects a setting"),
-        Line::from("  - Enter toggles or cycles the selected setting"),
-        Line::from("  - Esc returns to chat"),
-    ]
-}
+use lines::settings_lines;
 
 pub fn render_settings(f: &mut Frame, area: Rect, app_state: &AppState) {
     let chunks = Layout::default()
@@ -62,7 +31,7 @@ pub fn render_settings(f: &mut Frame, area: Rect, app_state: &AppState) {
 
 #[cfg(test)]
 mod tests {
-    use super::settings_lines;
+    use super::lines::settings_lines;
     use crate::tui::app::state::AppState;
 
     #[test]

--- a/src/tui/settings_lines.rs
+++ b/src/tui/settings_lines.rs
@@ -33,6 +33,13 @@ pub(super) fn settings_lines(s: &AppState) -> Vec<Line<'static>> {
         ),
         Line::from("  Cycles Claude on Bedrock service_tier: default -> standard -> priority."),
         Line::from(""),
+        value_line(
+            "Bedrock thinking effort",
+            crate::tui::app::settings::bedrock_thinking_effort_label().to_string(),
+            idx == 6,
+        ),
+        Line::from("  Cycles adaptive thinking effort: medium -> low -> high."),
+        Line::from(""),
         Line::from("Controls:"),
         Line::from("  - Up / Down selects a setting"),
         Line::from("  - Enter toggles or cycles the selected setting"),

--- a/src/tui/settings_lines.rs
+++ b/src/tui/settings_lines.rs
@@ -1,0 +1,41 @@
+//! Builds the text rows displayed in the Settings panel.
+
+use ratatui::text::Line;
+
+use crate::tui::app::state::AppState;
+
+use super::rows::{access_mode_line, setting_line, value_line};
+
+pub(super) fn settings_lines(s: &AppState) -> Vec<Line<'static>> {
+    let idx = s.selected_settings_index;
+    vec![
+        Line::from("Settings"),
+        Line::from(""),
+        setting_line("Edit auto-apply", s.auto_apply_edits, idx == 0),
+        Line::from("  Automatically confirms pending edit/multiedit previews in the TUI."),
+        Line::from(""),
+        setting_line("Network access", s.allow_network, idx == 1),
+        Line::from("  Allows sandboxed bash commands in this TUI session to use network access."),
+        Line::from(""),
+        setting_line("Slash autocomplete", s.slash_autocomplete, idx == 2),
+        Line::from("  Enables Tab completion for slash commands in the composer."),
+        Line::from(""),
+        setting_line("Worktree isolation", s.use_worktree, idx == 3),
+        Line::from("  Runs agent work in a git worktree branch, auto-merged on success."),
+        Line::from(""),
+        access_mode_line(idx == 4),
+        Line::from("  Cycles tool access: ask -> approve -> full (Enter to change)."),
+        Line::from(""),
+        value_line(
+            "Bedrock service tier",
+            crate::tui::app::settings::bedrock_service_tier_label().to_string(),
+            idx == 5,
+        ),
+        Line::from("  Cycles Claude on Bedrock service_tier: default -> standard -> priority."),
+        Line::from(""),
+        Line::from("Controls:"),
+        Line::from("  - Up / Down selects a setting"),
+        Line::from("  - Enter toggles or cycles the selected setting"),
+        Line::from("  - Esc returns to chat"),
+    ]
+}

--- a/src/tui/ui/chat_view/agent_bar.rs
+++ b/src/tui/ui/chat_view/agent_bar.rs
@@ -1,14 +1,20 @@
 //! Header tab bar showing the spawned-agent tree (main + sibling agents).
+//!
+//! Merges both registries: TUI `/spawn` agents and agent-tool-spawned agents
+//! (issue #295 / #297 Part A).
 
-use ratatui::{Frame, text::Line, widgets::Paragraph};
+use ratatui::{Frame, text::{Line, Span}, widgets::Paragraph};
 
 use super::agent_tab::{AgentTabMeta, agent_tab};
+use super::agent_bar_tui::push_tui_agents;
+use super::agent_bar_tool::push_tool_agents;
 use crate::tui::app::state::App;
-use crate::tui::app::state::agent_tree::dfs_order;
 
-/// Render the agent tab bar into `area` (no-op when `area` has zero height).
+/// Render the agent tab bar into `area` (no-op when empty and zero height).
 pub fn render_agent_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
-    if area.height == 0 || app.state.spawned_agents.is_empty() {
+    let tool_agents = crate::tool::agent::bridge::list_agent_tool_agents();
+    let has_tui = !app.state.spawned_agents.is_empty();
+    if area.height == 0 || (!has_tui && tool_agents.is_empty()) {
         return;
     }
     let active = app.state.active_spawned_agent.as_deref();
@@ -20,18 +26,7 @@ pub fn render_agent_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         selected: active.is_none(),
         processing: app.state.processing,
     })];
-    for node in dfs_order(&app.state.spawned_agents) {
-        if let Some(agent) = app.state.spawned_agents.get(&node.name) {
-            spans.push(ratatui::text::Span::raw(" "));
-            spans.push(agent_tab(AgentTabMeta {
-                name: &node.name,
-                model_id: agent.model_id.as_deref(),
-                session_id: Some(&agent.session.id),
-                indent: node.depth + 1,
-                selected: active == Some(node.name.as_str()),
-                processing: agent.is_processing,
-            }));
-        }
-    }
+    push_tui_agents(&mut spans, app, active);
+    push_tool_agents(&mut spans, &tool_agents, app, active);
     f.render_widget(Paragraph::new(Line::from(spans)), area);
 }

--- a/src/tui/ui/chat_view/agent_bar_tool.rs
+++ b/src/tui/ui/chat_view/agent_bar_tool.rs
@@ -1,0 +1,32 @@
+//! Agent-tool-spawned agents → agent-bar tab spans (issue #297 Part A).
+
+use ratatui::text::Span;
+use super::agent_tab::{AgentTabMeta, agent_tab};
+use crate::tool::agent::bridge::AgentSnapshot;
+use crate::tui::app::state::App;
+
+/// Push tab spans for agents from the agent-tool store, deduplicating
+/// against the TUI `spawned_agents` map by name.
+pub fn push_tool_agents(
+    spans: &mut Vec<Span<'static>>,
+    snapshots: &[AgentSnapshot],
+    app: &App,
+    active: Option<&str>,
+) {
+    let tui_names: std::collections::HashSet<&str> =
+        app.state.spawned_agents.keys().map(String::as_str).collect();
+    for snap in snapshots {
+        if tui_names.contains(snap.name.as_str()) {
+            continue;
+        }
+        spans.push(Span::raw(" "));
+        spans.push(agent_tab(AgentTabMeta {
+            name: &snap.name,
+            model_id: snap.model_id.as_deref(),
+            session_id: None,
+            indent: snap.depth + 1,
+            selected: active == Some(snap.name.as_str()),
+            processing: false,
+        }));
+    }
+}

--- a/src/tui/ui/chat_view/agent_bar_tui.rs
+++ b/src/tui/ui/chat_view/agent_bar_tui.rs
@@ -1,0 +1,23 @@
+//! TUI `/spawn` agents → agent-bar tab spans (issue #297 Part A).
+
+use ratatui::text::Span;
+use super::agent_tab::{AgentTabMeta, agent_tab};
+use crate::tui::app::state::agent_tree::dfs_order;
+use crate::tui::app::state::App;
+
+/// Push tab spans for agents from the TUI `spawned_agents` map.
+pub fn push_tui_agents(spans: &mut Vec<Span<'static>>, app: &App, active: Option<&str>) {
+    for node in dfs_order(&app.state.spawned_agents) {
+        if let Some(agent) = app.state.spawned_agents.get(&node.name) {
+            spans.push(Span::raw(" "));
+            spans.push(agent_tab(AgentTabMeta {
+                name: &node.name,
+                model_id: agent.model_id.as_deref(),
+                session_id: Some(&agent.session.id),
+                indent: node.depth + 1,
+                selected: active == Some(node.name.as_str()),
+                processing: agent.is_processing,
+            }));
+        }
+    }
+}

--- a/src/tui/ui/chat_view/mod.rs
+++ b/src/tui/ui/chat_view/mod.rs
@@ -4,6 +4,8 @@
 //! [`render_chat_view`] for the full pipeline.
 
 pub mod agent_bar;
+pub mod agent_bar_tool;
+pub mod agent_bar_tui;
 pub mod agent_rail;
 pub mod agent_tab;
 pub(crate) mod approval_overlay;

--- a/src/worktree/cleanup.rs
+++ b/src/worktree/cleanup.rs
@@ -10,34 +10,43 @@ impl WorktreeManager {
     }
 
     /// Clean up a specific worktree and its local branch.
+    ///
+    /// A dirty worktree is left intact (branch kept, still tracked) so
+    /// uncommitted work is preserved.
     pub async fn cleanup(&self, name: &str) -> Result<()> {
         let Some(info) = self.get(name).await else {
             return Ok(());
         };
-        self.remove_worktree(&info).await;
-        Self::delete_branch(&self.repo_path, &info.branch).await;
-        self.untrack(name).await;
+        if self.remove_worktree(&info).await.removed() {
+            Self::delete_branch(&self.repo_path, &info.branch).await;
+            self.untrack(name).await;
+        }
         Ok(())
     }
 
     /// Clean up all tracked or Git-discovered CodeTether worktrees.
+    ///
+    /// Dirty worktrees (and their branches) are preserved.
     pub async fn cleanup_all(&self) -> Result<usize> {
         let infos = self.list().await;
-        for info in &infos {
-            self.remove_worktree(info).await;
-        }
-        let known: HashSet<String> = infos.iter().map(|info| info.branch.clone()).collect();
-        let branches = self.codetether_branches().await.unwrap_or_default();
-        let branch_only = branches
-            .iter()
-            .filter(|branch| !known.contains(*branch))
-            .count();
-        for branch in &branches {
-            Self::delete_branch(&self.repo_path, branch).await;
-        }
-        self.worktrees.lock().await.clear();
-        let count = infos.len() + branch_only;
+        let refused = self.remove_all(&infos).await;
+        let count = self.delete_orphan_branches(&infos, &refused).await;
+        self.worktrees
+            .lock()
+            .await
+            .retain(|i| refused.contains(&i.name));
         tracing::info!(count, "Cleaned up CodeTether worktrees/branches");
         Ok(count)
+    }
+
+    /// Remove every worktree, returning the names that were refused (dirty).
+    async fn remove_all(&self, infos: &[WorktreeInfo]) -> HashSet<String> {
+        let mut refused = HashSet::new();
+        for info in infos {
+            if !self.remove_worktree(info).await.removed() {
+                refused.insert(info.name.clone());
+            }
+        }
+        refused
     }
 }

--- a/src/worktree/cleanup_branches.rs
+++ b/src/worktree/cleanup_branches.rs
@@ -1,0 +1,31 @@
+//! Branch cleanup helper for [`super::WorktreeManager::cleanup_all`].
+//!
+//! Split out to keep `cleanup.rs` within the module line budget.
+
+use super::{WorktreeInfo, WorktreeManager};
+use std::collections::HashSet;
+
+impl WorktreeManager {
+    /// Delete CodeTether branches except those of refused (dirty) worktrees.
+    pub(crate) async fn delete_orphan_branches(
+        &self,
+        infos: &[WorktreeInfo],
+        refused: &HashSet<String>,
+    ) -> usize {
+        let keep: HashSet<String> = infos
+            .iter()
+            .filter(|i| refused.contains(&i.name))
+            .map(|i| i.branch.clone())
+            .collect();
+        let branches = self.codetether_branches().await.unwrap_or_default();
+        let mut deleted = 0;
+        for branch in &branches {
+            if keep.contains(branch) {
+                continue;
+            }
+            Self::delete_branch(&self.repo_path, branch).await;
+            deleted += 1;
+        }
+        deleted
+    }
+}

--- a/src/worktree/cleanup_remove.rs
+++ b/src/worktree/cleanup_remove.rs
@@ -1,13 +1,18 @@
+use super::remove_outcome::RemoveOutcome;
 use super::{WorktreeInfo, WorktreeManager};
 
 impl WorktreeManager {
-    pub(crate) async fn remove_worktree(&self, info: &WorktreeInfo) {
+    /// Remove a worktree unless it has uncommitted changes.
+    ///
+    /// Returns [`RemoveOutcome::RefusedDirty`] without touching the worktree
+    /// when it is dirty, so callers skip branch deletion / untracking.
+    pub(crate) async fn remove_worktree(&self, info: &WorktreeInfo) -> RemoveOutcome {
         if self.is_worktree_dirty(info).await {
             tracing::error!(
                 worktree = %info.name, path = %info.path.display(),
                 "Refusing to force-remove dirty worktree — commit or stash first."
             );
-            return;
+            return RemoveOutcome::RefusedDirty;
         }
         match tokio::process::Command::new("git")
             .args(["worktree", "remove", "--force"])
@@ -31,6 +36,7 @@ impl WorktreeManager {
                 self.remove_worktree_dir(info).await;
             }
         }
+        RemoveOutcome::Removed
     }
 
     async fn remove_worktree_dir(&self, info: &WorktreeInfo) {

--- a/src/worktree/cleanup_remove.rs
+++ b/src/worktree/cleanup_remove.rs
@@ -2,6 +2,13 @@ use super::{WorktreeInfo, WorktreeManager};
 
 impl WorktreeManager {
     pub(crate) async fn remove_worktree(&self, info: &WorktreeInfo) {
+        if self.is_worktree_dirty(info).await {
+            tracing::error!(
+                worktree = %info.name, path = %info.path.display(),
+                "Refusing to force-remove dirty worktree — commit or stash first."
+            );
+            return;
+        }
         match tokio::process::Command::new("git")
             .args(["worktree", "remove", "--force"])
             .arg(&info.path)
@@ -14,18 +21,13 @@ impl WorktreeManager {
             }
             Ok(output) => {
                 tracing::warn!(
-                    worktree = %info.name,
-                    error = %String::from_utf8_lossy(&output.stderr),
+                    worktree = %info.name, error = %String::from_utf8_lossy(&output.stderr),
                     "Git worktree remove failed, falling back to directory removal"
                 );
                 self.remove_worktree_dir(info).await;
             }
             Err(error) => {
-                tracing::warn!(
-                    worktree = %info.name,
-                    error = %error,
-                    "Failed to execute git worktree remove"
-                );
+                tracing::warn!(worktree = %info.name, error = %error, "Failed git worktree remove");
                 self.remove_worktree_dir(info).await;
             }
         }
@@ -33,11 +35,7 @@ impl WorktreeManager {
 
     async fn remove_worktree_dir(&self, info: &WorktreeInfo) {
         if let Err(error) = tokio::fs::remove_dir_all(&info.path).await {
-            tracing::warn!(
-                worktree = %info.name,
-                error = %error,
-                "Failed to remove worktree directory"
-            );
+            tracing::warn!(worktree = %info.name, error = %error, "Failed to remove worktree dir");
         }
     }
 

--- a/src/worktree/cleanup_worktrees.rs
+++ b/src/worktree/cleanup_worktrees.rs
@@ -3,13 +3,18 @@ use anyhow::Result;
 
 impl WorktreeManager {
     /// Remove tracked or discovered CodeTether worktrees without deleting branches.
+    ///
+    /// Dirty worktrees are preserved and remain tracked.
     pub async fn cleanup_worktrees_only(&self) -> Result<usize> {
         let infos = self.list().await;
+        let mut removed = 0;
         for info in &infos {
-            self.remove_worktree(info).await;
-            self.untrack(&info.name).await;
+            if self.remove_worktree(info).await.removed() {
+                self.untrack(&info.name).await;
+                removed += 1;
+            }
         }
-        tracing::info!(count = infos.len(), "Cleaned up CodeTether worktrees");
-        Ok(infos.len())
+        tracing::info!(count = removed, "Cleaned up CodeTether worktrees");
+        Ok(removed)
     }
 }

--- a/src/worktree/dirty_check.rs
+++ b/src/worktree/dirty_check.rs
@@ -1,22 +1,38 @@
 //! Dirty-check guard for worktree removal (issue #297 Part B).
 //!
 //! Before tearing down a worktree with `git worktree remove --force`,
-//! check whether it has uncommitted changes. If it does, log a prominent
-//! warning so in-flight edits are not silently destroyed.
+//! check whether it has uncommitted changes. If it does — or if the check
+//! itself fails — treat the worktree as dirty so in-flight edits are never
+//! silently destroyed.
 
 use super::WorktreeInfo;
 
 impl super::WorktreeManager {
-    /// Returns `true` when the worktree directory has uncommitted changes.
+    /// Returns `true` when the worktree has uncommitted changes, or when the
+    /// dirty check could not be completed (fail-safe: never assume clean).
     pub(crate) async fn is_worktree_dirty(&self, info: &WorktreeInfo) -> bool {
-        let output = tokio::process::Command::new("git")
+        match tokio::process::Command::new("git")
             .args(["status", "--porcelain"])
             .current_dir(&info.path)
             .output()
-            .await;
-        match output {
+            .await
+        {
             Ok(o) if o.status.success() => !o.stdout.is_empty(),
-            _ => false,
+            Ok(o) => {
+                tracing::error!(
+                    worktree = %info.name,
+                    stderr = %String::from_utf8_lossy(&o.stderr),
+                    "git status dirty check failed; treating worktree as dirty"
+                );
+                true
+            }
+            Err(e) => {
+                tracing::error!(
+                    worktree = %info.name, error = %e,
+                    "failed to run git status dirty check; treating worktree as dirty"
+                );
+                true
+            }
         }
     }
 }

--- a/src/worktree/dirty_check.rs
+++ b/src/worktree/dirty_check.rs
@@ -1,0 +1,22 @@
+//! Dirty-check guard for worktree removal (issue #297 Part B).
+//!
+//! Before tearing down a worktree with `git worktree remove --force`,
+//! check whether it has uncommitted changes. If it does, log a prominent
+//! warning so in-flight edits are not silently destroyed.
+
+use super::WorktreeInfo;
+
+impl super::WorktreeManager {
+    /// Returns `true` when the worktree directory has uncommitted changes.
+    pub(crate) async fn is_worktree_dirty(&self, info: &WorktreeInfo) -> bool {
+        let output = tokio::process::Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&info.path)
+            .output()
+            .await;
+        match output {
+            Ok(o) if o.status.success() => !o.stdout.is_empty(),
+            _ => false,
+        }
+    }
+}

--- a/src/worktree/mod.rs
+++ b/src/worktree/mod.rs
@@ -7,8 +7,10 @@ mod artifact_collect;
 mod artifacts;
 mod branch;
 mod cleanup;
+mod cleanup_branches;
 mod cleanup_remove;
 mod dirty_check;
+mod remove_outcome;
 mod cleanup_worktrees;
 mod complete;
 mod conflicts;
@@ -16,8 +18,7 @@ mod create;
 mod create_git;
 mod discover;
 mod discover_parse;
-#[cfg(test)]
-mod discover_parse_tests;
+#[cfg(test)] mod discover_parse_tests;
 mod info;
 mod integrity;
 mod integrity_error;
@@ -29,11 +30,9 @@ mod merge_finish;
 mod merge_git;
 mod merge_lookup;
 mod merge_staged;
-#[cfg(test)]
-mod merge_staged_tests;
+#[cfg(test)] mod merge_staged_tests;
 mod output;
-#[cfg(test)]
-mod output_tests;
+#[cfg(test)] mod output_tests;
 mod repair;
 mod stash;
 mod sync_git;

--- a/src/worktree/mod.rs
+++ b/src/worktree/mod.rs
@@ -8,6 +8,7 @@ mod artifacts;
 mod branch;
 mod cleanup;
 mod cleanup_remove;
+mod dirty_check;
 mod cleanup_worktrees;
 mod complete;
 mod conflicts;

--- a/src/worktree/remove_outcome.rs
+++ b/src/worktree/remove_outcome.rs
@@ -1,0 +1,21 @@
+//! Outcome of a worktree removal attempt (issue #297 Part B review).
+//!
+//! Callers must not delete branches or untrack a worktree that was not
+//! actually removed (e.g. refused because it was dirty), otherwise the
+//! manager forgets a worktree that still exists on disk and in Git.
+
+/// Result of [`super::WorktreeManager::remove_worktree`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoveOutcome {
+    /// The worktree directory was removed successfully.
+    Removed,
+    /// Removal was refused because the worktree had uncommitted changes.
+    RefusedDirty,
+}
+
+impl RemoveOutcome {
+    /// Whether the worktree was actually removed (safe to untrack / delete branch).
+    pub(crate) fn removed(self) -> bool {
+        matches!(self, RemoveOutcome::Removed)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #294, #295, #296, and #297.

- #294: enable auto-apply for TUI-spawned agents and add RepeatGuard for repeated identical edit-family calls.
- #295: expose agent-tool-spawned agents through a read-only bridge and render them in /agents plus the TUI agent bar.
- #296: make sub-agent dispatch non-blocking by default via detach_or_default().
- #297: unify registry visibility and refuse dirty worktree force-removal; document lifecycle in docs/worktree_lifecycle.md.

## Verification

- static-local: ./check_file_limits.sh — passed
- focused: cargo test --lib repeat_guard — 5 passed
- focused: cargo test --lib tool::agent — 29 passed
- focused: cargo test --lib tui::app — 172 passed
- focused: cargo test --lib worktree — 20 passed

Did not run cargo build or cargo check per repo instructions.

Closes #294
Closes #295
Closes #296
Closes #297