### PR TITLE
feat: add durable mux agent task protocol

### DIFF
--- a/docs/mux_agent_tasks.md
+++ b/docs/mux_agent_tasks.md
@@ -1,0 +1,32 @@
+# Mux agent task API
+
+Mux protocol v6 gives every authenticated mux daemon a first-class agent task
+lifecycle. Clients no longer need to type `codetether run` into a PTY, attach a
+terminal, resize a TUI, or scrape completion markers.
+
+Requests use the existing token-authenticated JSON-lines connection:
+
+```json
+{"type":"agent","request":{"action":"start","task_id":"task-1234","prompt":"Inspect the failing route","session_id":null,"max_steps":6}}
+{"type":"agent","request":{"action":"read","task_id":"task-1234","offset":0}}
+{"type":"agent","request":{"action":"cancel","task_id":"task-1234"}}
+```
+
+Responses are structured and retain the task ID:
+
+```json
+{"type":"agent","response":{"status":"accepted","task_id":"task-1234"}}
+{"type":"agent","response":{"status":"output","task_id":"task-1234","data":[123,34],"next_offset":2,"running":true,"exit_code":null}}
+{"type":"agent","response":{"status":"cancelled","task_id":"task-1234"}}
+```
+
+`read` is an event-driven long poll over bounded replay data. Its bytes are the
+same structured JSONL run events used by `codetether run --format jsonl`, so
+clients can display text deltas, tool calls, paths, provenance, and the final
+response without treating terminal narration as agent speech.
+
+The daemon permits one running agent task at a time, retains up to 128 completed
+task streams with a 4 MiB replay bound per task, resumes an optional durable
+session, caps agent steps, runs inside the mux workspace, and cancels the full
+task process group. Protocol versions below v6 remain usable through the legacy
+PTY compatibility adapter while existing mux daemons are rolled forward.

--- a/src/cli/run/jsonl/event.rs
+++ b/src/cli/run/jsonl/event.rs
@@ -10,6 +10,8 @@ pub(super) enum RunEvent<'a> {
     #[serde(rename = "run.failed")] Failed { error: &'a str, #[serde(skip_serializing_if = "Option::is_none")] response: Option<&'a str> },
     #[serde(rename = "run.item_started")] ItemStarted { item_id: &'a str, timestamp_ms: u64 },
     #[serde(rename = "run.item_completed")] ItemCompleted { item_id: &'a str, timestamp_ms: u64 },
+    #[serde(rename = "run.text_chunk")] TextChunk { item_id: &'a str, timestamp_ms: u64, text: &'a str },
+    #[serde(rename = "run.text_complete")] TextComplete { item_id: &'a str, timestamp_ms: u64, text: &'a str },
     #[serde(rename = "run.tool_call_started")] ToolCallStarted { item_id: &'a str, tool_call_id: &'a str, timestamp_ms: u64, name: Option<&'a str>, arguments: Option<&'a str> },
     #[serde(rename = "run.tool_call_completed")] ToolCallCompleted { item_id: &'a str, tool_call_id: &'a str, timestamp_ms: u64, name: Option<&'a str>, success: Option<bool>, duration_ms: Option<u64>, output: Option<&'a str> },
     #[serde(rename = "run.tool_call_metadata")] ToolCallMetadata { item_id: &'a str, tool_call_id: &'a str, timestamp_ms: u64, metadata: &'a serde_json::Value },

--- a/src/cli/run/jsonl/item.rs
+++ b/src/cli/run/jsonl/item.rs
@@ -1,7 +1,33 @@
 #![allow(dead_code)]
 
 use super::event::RunEvent;
+use crate::session::thread_store::ThreadEvent;
 use anyhow::Result;
+
+pub(super) fn from_thread(event: &ThreadEvent) -> Option<RunEvent<'_>> {
+    let item_id = super::thread::field(event, "item_id")?;
+    match event.kind.as_str() {
+        "item.started" => Some(RunEvent::ItemStarted {
+            item_id,
+            timestamp_ms: event.timestamp_ms,
+        }),
+        "item.delta" => Some(RunEvent::TextChunk {
+            item_id,
+            timestamp_ms: event.timestamp_ms,
+            text: super::thread::field(event, "text")?,
+        }),
+        "item.completed" if event.payload.get("text").is_some() => Some(RunEvent::TextComplete {
+            item_id,
+            timestamp_ms: event.timestamp_ms,
+            text: super::thread::field(event, "text")?,
+        }),
+        "item.completed" => Some(RunEvent::ItemCompleted {
+            item_id,
+            timestamp_ms: event.timestamp_ms,
+        }),
+        _ => None,
+    }
+}
 
 pub(in crate::cli::run) fn write_item_started(item_id: &str, timestamp_ms: u64) -> Result<()> {
     super::writer::write_stdout(&RunEvent::ItemStarted {

--- a/src/cli/run/jsonl/tests.rs
+++ b/src/cli/run/jsonl/tests.rs
@@ -8,6 +8,7 @@ mod command;
 mod item;
 mod lifecycle;
 mod patch;
+mod text;
 mod thread;
 mod thread_tool;
 mod tool;

--- a/src/cli/run/jsonl/tests/text.rs
+++ b/src/cli/run/jsonl/tests/text.rs
@@ -1,0 +1,34 @@
+use crate::session::thread_store::ThreadEvent;
+
+use super::super::thread::write_thread_event_to;
+
+fn event(kind: &str, text: &str) -> ThreadEvent {
+    ThreadEvent {
+        event_id: "event-1".into(),
+        thread_id: "thread-1".into(),
+        session_id: "session-1".into(),
+        turn_id: "turn-1".into(),
+        kind: kind.into(),
+        timestamp_ms: 123,
+        payload: serde_json::json!({"item_id": "item-1", "text": text}),
+    }
+}
+
+#[test]
+fn text_delta_is_written_as_a_live_jsonl_chunk() {
+    let mut out = Vec::new();
+    assert!(write_thread_event_to(&mut out, &event("item.delta", "Hello")).unwrap());
+    let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(value["type"], "run.text_chunk");
+    assert_eq!(value["text"], "Hello");
+    assert_eq!(value["item_id"], "item-1");
+}
+
+#[test]
+fn completed_text_is_distinct_from_a_generic_item_completion() {
+    let mut out = Vec::new();
+    assert!(write_thread_event_to(&mut out, &event("item.completed", "Hello")).unwrap());
+    let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(value["type"], "run.text_complete");
+    assert_eq!(value["text"], "Hello");
+}

--- a/src/cli/run/jsonl/thread.rs
+++ b/src/cli/run/jsonl/thread.rs
@@ -24,14 +24,7 @@ pub(in crate::cli::run) fn write_thread_event_to<W: Write>(
 
 fn to_run_event(event: &ThreadEvent) -> Option<RunEvent<'_>> {
     match event.kind.as_str() {
-        "item.started" => Some(RunEvent::ItemStarted {
-            item_id: field(event, "item_id")?,
-            timestamp_ms: event.timestamp_ms,
-        }),
-        "item.completed" => Some(RunEvent::ItemCompleted {
-            item_id: field(event, "item_id")?,
-            timestamp_ms: event.timestamp_ms,
-        }),
+        "item.started" | "item.delta" | "item.completed" => super::item::from_thread(event),
         "tool.started" | "tool.completed" | "tool.metadata" => {
             super::thread_tool::to_run_event(event)
         }

--- a/src/mux/agent_task.rs
+++ b/src/mux/agent_task.rs
@@ -1,0 +1,19 @@
+//! Mux-owned structured CodeTether agent task lifecycle.
+
+mod buffer;
+mod cancel;
+mod entry;
+mod entry_read;
+mod reader;
+mod registry;
+mod registry_start;
+mod spawn;
+mod spawn_group;
+mod store;
+mod validation;
+mod waiter;
+
+#[cfg(test)]
+mod tests;
+
+pub(in crate::mux) use registry::AgentTaskRegistry;

--- a/src/mux/agent_task/buffer.rs
+++ b/src/mux/agent_task/buffer.rs
@@ -1,0 +1,36 @@
+//! Bounded replay storage for structured agent JSONL events.
+
+const OUTPUT_LIMIT: usize = 4 * 1024 * 1024;
+const READ_LIMIT: usize = 64 * 1024;
+
+pub(super) struct TaskBuffer {
+    base: u64,
+    bytes: Vec<u8>,
+}
+
+impl TaskBuffer {
+    pub(super) fn new() -> Self {
+        Self {
+            base: 0,
+            bytes: Vec::new(),
+        }
+    }
+
+    pub(super) fn append(&mut self, data: &[u8]) -> u64 {
+        self.bytes.extend_from_slice(data);
+        if self.bytes.len() > OUTPUT_LIMIT {
+            let remove = self.bytes.len() - OUTPUT_LIMIT;
+            self.bytes.drain(..remove);
+            self.base += remove as u64;
+        }
+        self.base + self.bytes.len() as u64
+    }
+
+    pub(super) fn read(&self, offset: u64) -> (Vec<u8>, u64) {
+        let start = offset.max(self.base);
+        let skip = start.saturating_sub(self.base) as usize;
+        let end = (skip + READ_LIMIT).min(self.bytes.len());
+        let data = self.bytes.get(skip..end).unwrap_or_default().to_vec();
+        (data.clone(), start + data.len() as u64)
+    }
+}

--- a/src/mux/agent_task/cancel.rs
+++ b/src/mux/agent_task/cancel.rs
@@ -1,0 +1,17 @@
+//! Platform cancellation for a mux-owned agent process.
+
+use anyhow::{Result, bail};
+
+#[cfg(unix)]
+pub(super) fn send(pid: u32) -> Result<()> {
+    // SAFETY: kill sends SIGINT to the validated child PID without dereferencing memory.
+    if unsafe { libc::kill(-(pid as i32), libc::SIGINT) } == -1 {
+        bail!(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub(super) fn send(_: u32) -> Result<()> {
+    bail!("mux agent cancellation is not supported on this platform")
+}

--- a/src/mux/agent_task/entry.rs
+++ b/src/mux/agent_task/entry.rs
@@ -1,0 +1,45 @@
+//! Runtime state for one mux-owned agent turn.
+
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use super::buffer::TaskBuffer;
+
+pub(super) struct AgentTask {
+    pub(super) output: Mutex<TaskBuffer>,
+    pub(super) changed: tokio::sync::watch::Sender<u64>,
+    running: AtomicBool,
+    pub(super) exit_code: Mutex<Option<i32>>,
+    pub(super) pid: u32,
+}
+
+impl AgentTask {
+    pub(super) fn new(pid: u32) -> Self {
+        let (changed, _) = tokio::sync::watch::channel(0);
+        Self {
+            output: Mutex::new(TaskBuffer::new()),
+            changed,
+            running: AtomicBool::new(true),
+            exit_code: Mutex::new(None),
+            pid,
+        }
+    }
+
+    pub(super) fn append(&self, data: &[u8]) {
+        let offset = self.output.lock().unwrap().append(data);
+        self.changed.send_replace(offset);
+    }
+
+    pub(super) fn finish(&self, exit_code: i32) {
+        *self.exit_code.lock().unwrap() = Some(exit_code);
+        self.running.store(false, Ordering::Release);
+        self.changed
+            .send_modify(|offset| *offset = offset.saturating_add(1));
+    }
+
+    pub(super) fn running(&self) -> bool {
+        self.running.load(Ordering::Acquire)
+    }
+}

--- a/src/mux/agent_task/entry_read.rs
+++ b/src/mux/agent_task/entry_read.rs
@@ -1,0 +1,21 @@
+//! Event-driven replay reads for one agent task.
+
+use super::entry::AgentTask;
+
+impl AgentTask {
+    pub(super) async fn read(&self, offset: u64) -> (Vec<u8>, u64, bool, Option<i32>) {
+        let mut changed = self.changed.subscribe();
+        let mut chunk = self.output.lock().unwrap().read(offset);
+        if chunk.0.is_empty() && self.running() {
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_secs(5), changed.changed()).await;
+            chunk = self.output.lock().unwrap().read(offset);
+        }
+        (
+            chunk.0,
+            chunk.1,
+            self.running(),
+            *self.exit_code.lock().unwrap(),
+        )
+    }
+}

--- a/src/mux/agent_task/reader.rs
+++ b/src/mux/agent_task/reader.rs
@@ -1,0 +1,22 @@
+//! Asynchronous child output capture into the task replay buffer.
+
+use std::sync::Arc;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use super::entry::AgentTask;
+
+pub(super) fn start<R>(mut reader: R, task: Arc<AgentTask>) -> tokio::task::JoinHandle<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut buffer = vec![0; 8192];
+        loop {
+            match reader.read(&mut buffer).await {
+                Ok(0) | Err(_) => return,
+                Ok(count) => task.append(&buffer[..count]),
+            }
+        }
+    })
+}

--- a/src/mux/agent_task/registry.rs
+++ b/src/mux/agent_task/registry.rs
@@ -1,0 +1,52 @@
+//! Public task-registry operations used by the authenticated mux server.
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Result, anyhow};
+
+use super::{entry::AgentTask, store::TaskStore};
+
+pub(in crate::mux) struct AgentTaskRegistry {
+    pub(super) store: Mutex<TaskStore>,
+}
+
+impl AgentTaskRegistry {
+    pub(in crate::mux) fn new() -> Self {
+        Self {
+            store: Mutex::new(TaskStore::new()),
+        }
+    }
+
+    fn get(&self, id: &str) -> Result<Arc<AgentTask>> {
+        self.store
+            .lock()
+            .unwrap()
+            .get(id)
+            .ok_or_else(|| anyhow!("agent task {id} was not found"))
+    }
+
+    pub(in crate::mux) async fn read(
+        &self,
+        id: &str,
+        offset: u64,
+    ) -> Result<(Vec<u8>, u64, bool, Option<i32>)> {
+        Ok(self.get(id)?.read(offset).await)
+    }
+
+    pub(in crate::mux) fn cancel(&self, id: &str) -> Result<()> {
+        let task = self.get(id)?;
+        if task.running() {
+            super::cancel::send(task.pid)?;
+        }
+        Ok(())
+    }
+
+    pub(in crate::mux) fn cancel_all(&self) {
+        let tasks = self.store.lock().unwrap().values();
+        for task in tasks {
+            if task.running() {
+                let _ = super::cancel::send(task.pid);
+            }
+        }
+    }
+}

--- a/src/mux/agent_task/registry_start.rs
+++ b/src/mux/agent_task/registry_start.rs
@@ -1,0 +1,43 @@
+//! Atomic admission and startup for one mux-owned agent turn.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+use super::{entry::AgentTask, registry::AgentTaskRegistry};
+
+impl AgentTaskRegistry {
+    pub(in crate::mux) fn start(
+        &self,
+        task_id: &str,
+        prompt: &str,
+        session_id: Option<&str>,
+        max_steps: usize,
+        workspace: &Path,
+        mux_name: &str,
+    ) -> Result<()> {
+        super::validation::request(task_id, prompt, session_id, max_steps)?;
+        let mut store = self.store.lock().unwrap();
+        store.prepare(task_id)?;
+        let mut child = super::spawn::child(prompt, session_id, max_steps, workspace, mux_name)?;
+        let pid = child.id().context("mux agent process has no pid")?;
+        let stdout = child
+            .stdout
+            .take()
+            .context("mux agent stdout unavailable")?;
+        let stderr = child
+            .stderr
+            .take()
+            .context("mux agent stderr unavailable")?;
+        let task = Arc::new(AgentTask::new(pid));
+        store.insert(task_id.into(), task.clone());
+        drop(store);
+        let readers = vec![
+            super::reader::start(stdout, task.clone()),
+            super::reader::start(stderr, task.clone()),
+        ];
+        super::waiter::start(child, task, readers);
+        Ok(())
+    }
+}

--- a/src/mux/agent_task/spawn.rs
+++ b/src/mux/agent_task/spawn.rs
@@ -1,0 +1,35 @@
+//! Safe direct process construction for a mux agent turn.
+
+use std::path::Path;
+use std::process::Stdio;
+
+use anyhow::Result;
+
+pub(super) fn child(
+    prompt: &str,
+    session_id: Option<&str>,
+    max_steps: usize,
+    workspace: &Path,
+    mux: &str,
+) -> Result<tokio::process::Child> {
+    let mut command = tokio::process::Command::new(std::env::current_exe()?);
+    command.args([
+        "run",
+        "--format",
+        "jsonl",
+        "--max-steps",
+        &max_steps.to_string(),
+    ]);
+    if let Some(session_id) = session_id {
+        command.args(["--session", session_id]);
+    }
+    command.arg(prompt).arg("--").arg(workspace);
+    command.env(crate::mux::coordination::SESSION_ENV, mux);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    super::spawn_group::isolate(&mut command);
+    command.kill_on_drop(true);
+    Ok(command.spawn()?)
+}

--- a/src/mux/agent_task/spawn_group.rs
+++ b/src/mux/agent_task/spawn_group.rs
@@ -1,0 +1,11 @@
+//! Process-group isolation so cancellation reaches task-owned tool children.
+
+#[cfg(unix)]
+pub(super) fn isolate(command: &mut tokio::process::Command) {
+    use std::os::unix::process::CommandExt;
+
+    command.as_std_mut().process_group(0);
+}
+
+#[cfg(not(unix))]
+pub(super) fn isolate(_: &mut tokio::process::Command) {}

--- a/src/mux/agent_task/store.rs
+++ b/src/mux/agent_task/store.rs
@@ -1,0 +1,55 @@
+//! Bounded lookup and replay retention for mux agent tasks.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+
+use super::entry::AgentTask;
+
+const TASK_LIMIT: usize = 128;
+
+pub(super) struct TaskStore {
+    tasks: HashMap<String, Arc<AgentTask>>,
+    order: VecDeque<String>,
+}
+
+impl TaskStore {
+    pub(super) fn new() -> Self {
+        Self {
+            tasks: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    pub(super) fn prepare(&mut self, task_id: &str) -> Result<()> {
+        if self.tasks.contains_key(task_id) {
+            bail!("agent task {task_id} already exists");
+        }
+        if self.tasks.values().any(|task| task.running()) {
+            bail!("mux agent is already working");
+        }
+        while self.tasks.len() >= TASK_LIMIT {
+            let Some(index) = self.order.iter().position(|id| !self.tasks[id].running()) else {
+                bail!("mux agent task history is full");
+            };
+            if let Some(id) = self.order.remove(index) {
+                self.tasks.remove(&id);
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn insert(&mut self, id: String, task: Arc<AgentTask>) {
+        self.order.push_back(id.clone());
+        self.tasks.insert(id, task);
+    }
+
+    pub(super) fn get(&self, id: &str) -> Option<Arc<AgentTask>> {
+        self.tasks.get(id).cloned()
+    }
+
+    pub(super) fn values(&self) -> Vec<Arc<AgentTask>> {
+        self.tasks.values().cloned().collect()
+    }
+}

--- a/src/mux/agent_task/tests.rs
+++ b/src/mux/agent_task/tests.rs
@@ -1,0 +1,20 @@
+use super::{buffer::TaskBuffer, validation};
+
+#[test]
+fn replay_reads_structured_output_from_requested_offset() {
+    let mut buffer = TaskBuffer::new();
+    buffer.append(b"one\ntwo\n");
+
+    let (data, offset) = buffer.read(4);
+
+    assert_eq!(data, b"two\n");
+    assert_eq!(offset, 8);
+}
+
+#[test]
+fn validation_rejects_unbounded_or_unsafe_tasks() {
+    assert!(validation::request("task-1234", "hello", None, 1).is_ok());
+    assert!(validation::request("bad", "hello", None, 1).is_err());
+    assert!(validation::request("task-1234", "", None, 1).is_err());
+    assert!(validation::request("task-1234", "hello", None, 251).is_err());
+}

--- a/src/mux/agent_task/validation.rs
+++ b/src/mux/agent_task/validation.rs
@@ -1,0 +1,30 @@
+//! Input bounds for authenticated mux agent tasks.
+
+use anyhow::{Result, ensure};
+
+pub(super) fn request(
+    task_id: &str,
+    prompt: &str,
+    session_id: Option<&str>,
+    max_steps: usize,
+) -> Result<()> {
+    ensure!(valid_id(task_id), "invalid agent task id");
+    ensure!(!prompt.trim().is_empty(), "agent prompt is empty");
+    ensure!(prompt.len() <= 64 * 1024, "agent prompt exceeds 64 KiB");
+    ensure!(
+        (1..=250).contains(&max_steps),
+        "max_steps must be between 1 and 250"
+    );
+    ensure!(
+        session_id.is_none_or(valid_id),
+        "invalid durable session id"
+    );
+    Ok(())
+}
+
+fn valid_id(value: &str) -> bool {
+    (8..=128).contains(&value.len())
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+}

--- a/src/mux/agent_task/waiter.rs
+++ b/src/mux/agent_task/waiter.rs
@@ -1,0 +1,24 @@
+//! Child completion projection into mux task state.
+
+use std::sync::Arc;
+
+use super::entry::AgentTask;
+
+pub(super) fn start(
+    mut child: tokio::process::Child,
+    task: Arc<AgentTask>,
+    readers: Vec<tokio::task::JoinHandle<()>>,
+) {
+    tokio::spawn(async move {
+        let exit_code = child
+            .wait()
+            .await
+            .ok()
+            .and_then(|status| status.code())
+            .unwrap_or(1);
+        for reader in readers {
+            let _ = reader.await;
+        }
+        task.finish(exit_code);
+    });
+}

--- a/src/mux/client/render.rs
+++ b/src/mux/client/render.rs
@@ -19,6 +19,7 @@ pub(super) fn response(response: &ServerResponse) -> bool {
         ServerResponse::ProgramAttached { .. }
         | ServerResponse::ProgramOutput { .. }
         | ServerResponse::Coordination { .. }
+        | ServerResponse::Agent { .. }
         | ServerResponse::Acknowledged => {}
     }
     false

--- a/src/mux/control/live/connection.rs
+++ b/src/mux/control/live/connection.rs
@@ -1,0 +1,51 @@
+//! Authenticated event-driven reads from one mux PTY.
+
+use anyhow::{Result, bail};
+use tokio::sync::mpsc::Sender;
+
+use super::MuxLiveOutput;
+use crate::mux::client::MuxConnection;
+use crate::mux::protocol::{ClientRequest, ProgramRequest, ServerResponse};
+
+pub(super) async fn run(name: &str, sender: &Sender<MuxLiveOutput>) -> Result<()> {
+    let record = crate::mux::registry::load(name).await?;
+    let window_id = record.state.active_window;
+    let mut connection = MuxConnection::connect(&record).await?;
+    let response = connection
+        .request(ClientRequest::Program {
+            request: ProgramRequest::Tail { window_id },
+        })
+        .await?;
+    let ServerResponse::ProgramAttached { mut offset, .. } = response else {
+        bail!("mux session {name} has no output tail");
+    };
+    loop {
+        let response = connection
+            .request(ClientRequest::Program {
+                request: ProgramRequest::Read { window_id, offset },
+            })
+            .await?;
+        let ServerResponse::ProgramOutput {
+            data,
+            next_offset,
+            running,
+        } = response
+        else {
+            bail!("mux session {name} returned invalid live output");
+        };
+        offset = next_offset;
+        if !data.is_empty() {
+            sender
+                .send(MuxLiveOutput {
+                    session: name.into(),
+                    data: String::from_utf8_lossy(&data).into_owned(),
+                    offset,
+                    running,
+                })
+                .await?;
+        }
+        if !running {
+            return Ok(());
+        }
+    }
+}

--- a/src/mux/control/live/mod.rs
+++ b/src/mux/control/live/mod.rs
@@ -1,0 +1,20 @@
+//! Native fan-in for event-driven output from every registered mux server.
+
+mod connection;
+mod session;
+mod types;
+
+pub(crate) use types::MuxLiveOutput;
+
+pub(crate) fn subscribe_live_output() -> tokio::sync::mpsc::Receiver<MuxLiveOutput> {
+    let (sender, receiver) = tokio::sync::mpsc::channel(256);
+    tokio::spawn(async move {
+        let Ok(records) = crate::mux::registry::list().await else {
+            return;
+        };
+        for record in records {
+            tokio::spawn(session::follow(record.name, sender.clone()));
+        }
+    });
+    receiver
+}

--- a/src/mux/control/live/session.rs
+++ b/src/mux/control/live/session.rs
@@ -1,0 +1,14 @@
+//! Resilient lifecycle for one mux output subscription.
+
+use tokio::sync::mpsc::Sender;
+
+use super::MuxLiveOutput;
+
+pub(super) async fn follow(name: String, sender: Sender<MuxLiveOutput>) {
+    while !sender.is_closed() {
+        if let Err(error) = super::connection::run(&name, &sender).await {
+            tracing::warn!(session = name, %error, "Mux realtime stream reconnecting");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}

--- a/src/mux/control/live/types.rs
+++ b/src/mux/control/live/types.rs
@@ -1,0 +1,10 @@
+//! Serializable mux output frame exposed by the Rust SSE surface.
+
+/// One bounded output chunk attributed to its original mux session.
+#[derive(Clone, Debug, serde::Serialize)]
+pub(crate) struct MuxLiveOutput {
+    pub session: String,
+    pub data: String,
+    pub offset: u64,
+    pub running: bool,
+}

--- a/src/mux/control/mod.rs
+++ b/src/mux/control/mod.rs
@@ -1,12 +1,14 @@
 //! Reusable mux lifecycle controls for CLI and TUI front ends.
 
 mod list;
+mod live;
 mod mutate;
 mod start;
 mod stop;
 mod summary;
 
 pub(crate) use list::list_sessions;
+pub(crate) use live::subscribe_live_output;
 pub(crate) use mutate::{close_window, create_window, select_window};
 pub(in crate::mux) use start::start_record;
 pub(crate) use start::start_session;

--- a/src/mux/mod.rs
+++ b/src/mux/mod.rs
@@ -15,6 +15,7 @@
 //! codetether mux kill-all
 //! ```
 
+mod agent_task;
 mod client;
 mod command;
 pub(crate) mod control;

--- a/src/mux/protocol/agent_request.rs
+++ b/src/mux/protocol/agent_request.rs
@@ -1,0 +1,28 @@
+//! Structured agent-turn operations accepted by a mux daemon.
+
+use serde::{Deserialize, Serialize};
+
+/// One task lifecycle request scoped to its authenticated mux session.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub(in crate::mux) enum AgentRequest {
+    Start {
+        task_id: String,
+        prompt: String,
+        #[serde(default)]
+        session_id: Option<String>,
+        #[serde(default = "default_max_steps")]
+        max_steps: usize,
+    },
+    Read {
+        task_id: String,
+        offset: u64,
+    },
+    Cancel {
+        task_id: String,
+    },
+}
+
+fn default_max_steps() -> usize {
+    6
+}

--- a/src/mux/protocol/agent_response.rs
+++ b/src/mux/protocol/agent_response.rs
@@ -1,0 +1,26 @@
+//! Structured agent-turn responses emitted by a mux daemon.
+
+use serde::{Deserialize, Serialize};
+
+/// One response from the mux-owned agent task registry.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub(in crate::mux) enum AgentResponse {
+    Accepted {
+        task_id: String,
+    },
+    Output {
+        task_id: String,
+        data: Vec<u8>,
+        next_offset: u64,
+        running: bool,
+        exit_code: Option<i32>,
+    },
+    Cancelled {
+        task_id: String,
+    },
+    Error {
+        task_id: Option<String>,
+        message: String,
+    },
+}

--- a/src/mux/protocol/mod.rs
+++ b/src/mux/protocol/mod.rs
@@ -1,13 +1,17 @@
 //! Versioned JSON-lines protocol used by mux servers and clients.
 
+mod agent_request;
+mod agent_response;
 mod frame;
 mod program_request;
 mod request;
 mod response;
 
+pub(super) use agent_request::AgentRequest;
+pub(super) use agent_response::AgentResponse;
 pub(super) use frame::{read_frame, write_frame};
 pub(super) use program_request::ProgramRequest;
 pub(super) use request::ClientRequest;
 pub(super) use response::ServerResponse;
 
-pub(super) const VERSION: u16 = 4;
+pub(super) const VERSION: u16 = 6;

--- a/src/mux/protocol/program_request.rs
+++ b/src/mux/protocol/program_request.rs
@@ -17,6 +17,9 @@ pub(in crate::mux) enum ProgramRequest {
         columns: u16,
         rows: u16,
     },
+    Tail {
+        window_id: u64,
+    },
     Input {
         window_id: u64,
         data: Vec<u8>,
@@ -30,4 +33,17 @@ pub(in crate::mux) enum ProgramRequest {
         columns: u16,
         rows: u16,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn tail_request_has_a_stable_wire_shape() {
+        let value = serde_json::json!({"action": "tail", "window_id": 7});
+        let request: super::ProgramRequest = serde_json::from_value(value).unwrap();
+        assert!(matches!(
+            request,
+            super::ProgramRequest::Tail { window_id: 7 }
+        ));
+    }
 }

--- a/src/mux/protocol/request.rs
+++ b/src/mux/protocol/request.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use super::ProgramRequest;
+use super::{AgentRequest, ProgramRequest};
 
 /// One authenticated mux control request.
 #[derive(Debug, Deserialize, Serialize)]
@@ -28,6 +28,9 @@ pub(in crate::mux) enum ClientRequest {
     },
     Program {
         request: ProgramRequest,
+    },
+    Agent {
+        request: AgentRequest,
     },
     Coordinate {
         request: crate::mux::lease::CoordinationRequest,

--- a/src/mux/protocol/response.rs
+++ b/src/mux/protocol/response.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::mux::model::MuxSnapshot;
+use crate::mux::{model::MuxSnapshot, protocol::AgentResponse};
 
 /// One mux control response.
 #[derive(Debug, Deserialize, Serialize)]
@@ -29,6 +29,9 @@ pub(in crate::mux) enum ServerResponse {
     },
     Coordination {
         reply: crate::mux::lease::CoordinationReply,
+    },
+    Agent {
+        response: AgentResponse,
     },
     Acknowledged,
     Detached,

--- a/src/mux/pty/mod.rs
+++ b/src/mux/pty/mod.rs
@@ -11,6 +11,7 @@ mod program_wait;
 mod reader;
 mod registry;
 mod registry_io;
+mod registry_tail;
 mod resize;
 mod spawn;
 pub(super) mod terminal_mode;

--- a/src/mux/pty/registry_tail.rs
+++ b/src/mux/pty/registry_tail.rs
@@ -1,0 +1,11 @@
+//! Read-only retained-output discovery without resizing the live PTY.
+
+use anyhow::Result;
+
+use super::{PtyAttach, registry::PtyRegistry};
+
+impl PtyRegistry {
+    pub(in crate::mux) fn tail(&self, id: u64) -> Result<PtyAttach> {
+        Ok(self.get(id)?.attach_state())
+    }
+}

--- a/src/mux/server/agent.rs
+++ b/src/mux/server/agent.rs
@@ -1,0 +1,30 @@
+//! Authenticated structured agent-turn request handling.
+
+use crate::mux::protocol::{AgentRequest, AgentResponse, ServerResponse};
+
+use super::context::ServerContext;
+
+pub(super) async fn apply(context: &ServerContext, request: AgentRequest) -> ServerResponse {
+    let response = match request {
+        AgentRequest::Start {
+            task_id,
+            prompt,
+            session_id,
+            max_steps,
+        } => super::agent_start::apply(context, task_id, prompt, session_id, max_steps).await,
+        AgentRequest::Read { task_id, offset } => {
+            super::agent_read::apply(context, task_id, offset).await
+        }
+        AgentRequest::Cancel { task_id } => context
+            .tasks
+            .cancel(&task_id)
+            .map(|()| AgentResponse::Cancelled {
+                task_id: task_id.clone(),
+            })
+            .unwrap_or_else(|error| AgentResponse::Error {
+                task_id: Some(task_id),
+                message: error.to_string(),
+            }),
+    };
+    ServerResponse::Agent { response }
+}

--- a/src/mux/server/agent_read.rs
+++ b/src/mux/server/agent_read.rs
@@ -1,0 +1,25 @@
+//! Read structured JSONL progress from a mux-owned agent turn.
+
+use crate::mux::protocol::AgentResponse;
+
+use super::context::ServerContext;
+
+pub(super) async fn apply(context: &ServerContext, task_id: String, offset: u64) -> AgentResponse {
+    context
+        .tasks
+        .read(&task_id, offset)
+        .await
+        .map(
+            |(data, next_offset, running, exit_code)| AgentResponse::Output {
+                task_id: task_id.clone(),
+                data,
+                next_offset,
+                running,
+                exit_code,
+            },
+        )
+        .unwrap_or_else(|error| AgentResponse::Error {
+            task_id: Some(task_id),
+            message: error.to_string(),
+        })
+}

--- a/src/mux/server/agent_start.rs
+++ b/src/mux/server/agent_start.rs
@@ -1,0 +1,46 @@
+//! Start one structured agent turn in the mux workspace.
+
+use crate::mux::protocol::AgentResponse;
+
+use super::context::ServerContext;
+
+pub(super) async fn apply(
+    context: &ServerContext,
+    task_id: String,
+    prompt: String,
+    session_id: Option<String>,
+    max_steps: usize,
+) -> AgentResponse {
+    let state = context.state.read().await;
+    let workspace = state
+        .windows
+        .iter()
+        .find(|window| window.id == state.active_window)
+        .map(|window| window.workspace.clone());
+    let mux_name = state.name.clone();
+    drop(state);
+    let Some(workspace) = workspace else {
+        return error(task_id, anyhow::anyhow!("mux has no active workspace"));
+    };
+    context
+        .tasks
+        .start(
+            &task_id,
+            &prompt,
+            session_id.as_deref(),
+            max_steps,
+            &workspace,
+            &mux_name,
+        )
+        .map(|()| AgentResponse::Accepted {
+            task_id: task_id.clone(),
+        })
+        .unwrap_or_else(|failure| error(task_id, failure))
+}
+
+fn error(task_id: String, error: anyhow::Error) -> AgentResponse {
+    AgentResponse::Error {
+        task_id: Some(task_id),
+        message: error.to_string(),
+    }
+}

--- a/src/mux/server/context.rs
+++ b/src/mux/server/context.rs
@@ -16,6 +16,7 @@ pub(super) struct ServerContext {
     pub started_at: DateTime<Utc>,
     pub shutdown: Notify,
     pub programs: PtyRegistry,
+    pub tasks: crate::mux::agent_task::AgentTaskRegistry,
     pub leases: crate::mux::lease::LeaseRegistry,
     pub(super) persist_lock: Mutex<()>,
 }
@@ -29,6 +30,7 @@ impl ServerContext {
             started_at: Utc::now(),
             shutdown: Notify::new(),
             programs: PtyRegistry::new(),
+            tasks: crate::mux::agent_task::AgentTaskRegistry::new(),
             leases: crate::mux::lease::LeaseRegistry::new(),
             persist_lock: Mutex::new(()),
         })

--- a/src/mux/server/dispatch.rs
+++ b/src/mux/server/dispatch.rs
@@ -18,6 +18,7 @@ pub(super) async fn apply(
         ClientRequest::Coordinate { request } => {
             (super::coordination::apply(context, request).await, false)
         }
+        ClientRequest::Agent { request } => (super::agent::apply(context, request).await, false),
         request @ ClientRequest::Program { .. } => {
             (super::program::apply(context, request).await, false)
         }

--- a/src/mux/server/mod.rs
+++ b/src/mux/server/mod.rs
@@ -1,5 +1,8 @@
 //! Authenticated TCP mux server.
 
+mod agent;
+mod agent_read;
+mod agent_start;
 mod connection;
 mod context;
 mod context_persist;
@@ -12,6 +15,7 @@ mod program;
 mod program_operations;
 mod program_request;
 mod program_start;
+mod program_tail;
 mod run;
 mod startup;
 

--- a/src/mux/server/program_request.rs
+++ b/src/mux/server/program_request.rs
@@ -29,6 +29,7 @@ pub(super) async fn execute(
             columns,
             rows,
         } => super::program_operations::attach(context, window_id, columns, rows)?,
+        ProgramRequest::Tail { window_id } => super::program_tail::apply(context, window_id)?,
         ProgramRequest::Input { window_id, data } => {
             context.programs.input(window_id, &data)?;
             ServerResponse::Acknowledged

--- a/src/mux/server/program_tail.rs
+++ b/src/mux/server/program_tail.rs
@@ -1,0 +1,15 @@
+//! Non-mutating discovery of the retained output tail for SSE consumers.
+
+use crate::mux::protocol::ServerResponse;
+
+use super::context::ServerContext;
+
+pub(super) fn apply(context: &ServerContext, id: u64) -> anyhow::Result<ServerResponse> {
+    let tail = context.programs.tail(id)?;
+    Ok(ServerResponse::ProgramAttached {
+        window_id: id,
+        offset: tail.offset,
+        replay_until: tail.replay_until,
+        alternate_screen: tail.alternate_screen,
+    })
+}

--- a/src/mux/server/run.rs
+++ b/src/mux/server/run.rs
@@ -37,6 +37,7 @@ pub(in crate::mux) async fn serve(
     }
     clients.abort_all();
     while clients.join_next().await.is_some() {}
+    context.tasks.cancel_all();
     context.programs.stop_all();
     registry::remove(&name).await?;
     tracing::info!(session = %name, "Mux server stopped");

--- a/src/mux/tests/agent_protocol.rs
+++ b/src/mux/tests/agent_protocol.rs
@@ -1,0 +1,50 @@
+use crate::mux::protocol::{
+    AgentRequest, AgentResponse, ClientRequest, ServerResponse, read_frame, write_frame,
+};
+
+#[tokio::test]
+async fn agent_start_round_trips_over_authenticated_wire_shape() {
+    let request = ClientRequest::Agent {
+        request: AgentRequest::Start {
+            task_id: "task-1234".into(),
+            prompt: "status".into(),
+            session_id: Some("session-1234".into()),
+            max_steps: 3,
+        },
+    };
+    let (mut writer, mut reader) = tokio::io::duplex(1024);
+    write_frame(&mut writer, &request).await.unwrap();
+
+    let decoded: ClientRequest = read_frame(&mut reader).await.unwrap().unwrap();
+
+    assert!(
+        matches!(decoded, ClientRequest::Agent { request: AgentRequest::Start { task_id, .. } } if task_id == "task-1234")
+    );
+}
+
+#[tokio::test]
+async fn agent_output_carries_replay_and_completion_state() {
+    let response = ServerResponse::Agent {
+        response: AgentResponse::Output {
+            task_id: "task-1234".into(),
+            data: b"event\n".to_vec(),
+            next_offset: 6,
+            running: false,
+            exit_code: Some(0),
+        },
+    };
+    let (mut writer, mut reader) = tokio::io::duplex(1024);
+    write_frame(&mut writer, &response).await.unwrap();
+
+    let decoded: ServerResponse = read_frame(&mut reader).await.unwrap().unwrap();
+
+    assert!(matches!(
+        decoded,
+        ServerResponse::Agent {
+            response: AgentResponse::Output {
+                exit_code: Some(0),
+                ..
+            }
+        }
+    ));
+}

--- a/src/mux/tests/mod.rs
+++ b/src/mux/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Focused network mux unit tests.
 
+mod agent_protocol;
 mod model;
 mod multiprocess;
 mod parse;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -831,22 +831,8 @@ pub async fn serve(args: ServeArgs) -> Result<()> {
             "/v1/agent/tasks/{task_id}/output/stream",
             get(stream_agent_task_output),
         )
-        // Worker connectivity (dashboard polls this)
-        .route("/v1/worker/connected", get(list_connected_workers))
-        .route("/v1/agent/workers", get(list_connected_workers))
-        // Worker task lifecycle (what the Rust worker calls)
-        .route(
-            "/v1/worker/tasks/stream",
-            get(worker_modules::worker_task_stream),
-        )
-        .route(
-            "/v1/worker/tasks/claim",
-            post(worker_modules::worker_task_claim),
-        )
-        .route(
-            "/v1/worker/tasks/release",
-            post(worker_modules::worker_task_release),
-        )
+        // Worker lifecycle and Rust-native mux realtime
+        .merge(worker_modules::router())
         // Task dispatch (Knative-backed)
         .route("/v1/tasks/dispatch", post(dispatch_task))
         // Voice REST bridge (dashboard expects REST, server has gRPC)

--- a/src/server/mux_realtime.rs
+++ b/src/server/mux_realtime.rs
@@ -1,0 +1,14 @@
+//! Rust-owned HTTP surface for authoritative mux roster and realtime output.
+
+#[path = "mux_realtime/sessions.rs"]
+mod sessions;
+#[path = "mux_realtime/stream.rs"]
+mod stream;
+
+pub(super) fn router() -> axum::Router<super::super::AppState> {
+    use axum::routing::get;
+
+    axum::Router::new()
+        .route("/v1/bus/stream/mux/sessions", get(sessions::list))
+        .route("/v1/bus/stream/mux", get(stream::output))
+}

--- a/src/server/mux_realtime/sessions.rs
+++ b/src/server/mux_realtime/sessions.rs
@@ -1,0 +1,36 @@
+//! JSON projection of the mux registry, ordered as the primary agent roster.
+
+use axum::{Json, http::StatusCode};
+
+pub(super) async fn list() -> Result<Json<Vec<serde_json::Value>>, StatusCode> {
+    let sessions = crate::mux::control::list_sessions()
+        .await
+        .map_err(|error| {
+            tracing::error!(%error, "Failed to list mux realtime sessions");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    let values = sessions
+        .into_iter()
+        .map(|session| {
+            let windows = session
+                .windows
+                .into_iter()
+                .map(|window| {
+                    serde_json::json!({
+                        "id": window.id,
+                        "title": window.title,
+                        "workspace": window.workspace,
+                    })
+                })
+                .collect::<Vec<_>>();
+            serde_json::json!({
+                "name": session.name,
+                "pid": session.pid,
+                "active_window": session.active_window,
+                "windows": windows,
+                "reachable": session.reachable,
+            })
+        })
+        .collect();
+    Ok(Json(values))
+}

--- a/src/server/mux_realtime/stream.rs
+++ b/src/server/mux_realtime/stream.rs
@@ -1,0 +1,19 @@
+//! Server-sent events sourced directly from Rust mux PTY change signals.
+
+use std::{convert::Infallible, time::Duration};
+
+use axum::response::sse::{Event, KeepAlive, Sse};
+use futures::StreamExt;
+use tokio_stream::wrappers::ReceiverStream;
+
+pub(super) async fn output() -> Sse<impl futures::Stream<Item = Result<Event, Infallible>>> {
+    let receiver = crate::mux::control::subscribe_live_output();
+    let events = ReceiverStream::new(receiver).map(|output| {
+        let data = serde_json::to_string(&output).unwrap_or_else(|_| "{}".into());
+        Ok(Event::default()
+            .event("mux")
+            .id(format!("{}.{}", output.session, output.offset))
+            .data(data))
+    });
+    Sse::new(events).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
+}

--- a/src/server/worker_modules.rs
+++ b/src/server/worker_modules.rs
@@ -1,5 +1,7 @@
 //! Worker route helper modules.
 
+#[path = "mux_realtime.rs"]
+mod mux_realtime;
 #[path = "worker_stream.rs"]
 mod worker_stream;
 #[path = "worker_task_claim.rs"]
@@ -8,6 +10,18 @@ mod worker_task_claim;
 mod worker_task_release;
 #[path = "worker_task_stream.rs"]
 mod worker_task_stream;
+
+pub(super) fn router() -> axum::Router<super::AppState> {
+    use axum::routing::{get, post};
+
+    axum::Router::new()
+        .route("/v1/worker/connected", get(super::list_connected_workers))
+        .route("/v1/agent/workers", get(super::list_connected_workers))
+        .route("/v1/worker/tasks/stream", get(worker_task_stream))
+        .route("/v1/worker/tasks/claim", post(worker_task_claim))
+        .route("/v1/worker/tasks/release", post(worker_task_release))
+        .merge(mux_realtime::router())
+}
 
 pub(super) use worker_task_claim::worker_task_claim;
 pub(super) use worker_task_release::worker_task_release;

--- a/src/session/helper/mod.rs
+++ b/src/session/helper/mod.rs
@@ -40,7 +40,7 @@ pub(crate) mod rlm_background;
 mod rlm_model;
 pub mod router;
 pub mod runtime;
-pub(crate) mod steering;
+pub mod steering;
 pub mod stream;
 pub mod stream_caps;
 pub mod text;

--- a/src/session/helper/steering/guard.rs
+++ b/src/session/helper/steering/guard.rs
@@ -1,18 +1,32 @@
 //! Prompt-run lifetime guard for steering inbox cleanup.
 
 /// Keeps a session inbox open only for the lifetime of one prompt run.
-pub(crate) struct RunGuard(String);
+pub(crate) struct RunGuard {
+    session_id: String,
+    #[cfg(unix)]
+    _endpoint: Option<super::ipc::Endpoint>,
+}
 
 impl RunGuard {
     /// Open the session inbox and return its cleanup guard.
     pub(crate) fn open(session_id: &str) -> Self {
         super::open(session_id);
-        Self(session_id.to_string())
+        #[cfg(unix)]
+        let endpoint = super::ipc::Endpoint::start(session_id)
+            .inspect_err(
+                |error| tracing::warn!(%error, %session_id, "Session steering unavailable"),
+            )
+            .ok();
+        Self {
+            session_id: session_id.to_string(),
+            #[cfg(unix)]
+            _endpoint: endpoint,
+        }
     }
 }
 
 impl Drop for RunGuard {
     fn drop(&mut self) {
-        super::clear(&self.0);
+        super::clear(&self.session_id);
     }
 }

--- a/src/session/helper/steering/ipc.rs
+++ b/src/session/helper/steering/ipc.rs
@@ -1,0 +1,14 @@
+//! Session-addressed local steering transport.
+
+mod client;
+mod connection;
+mod endpoint;
+mod path;
+mod server;
+mod wire;
+
+pub(super) use client::send;
+pub(super) use endpoint::Endpoint;
+
+#[cfg(test)]
+mod tests;

--- a/src/session/helper/steering/ipc/client.rs
+++ b/src/session/helper/steering/ipc/client.rs
@@ -1,0 +1,41 @@
+//! Client for the active owner of a durable session.
+
+use std::io::ErrorKind;
+use std::path::Path;
+
+use anyhow::{Result, ensure};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+use super::wire::{Reply, Request};
+
+pub(in crate::session::helper::steering) async fn send(
+    session_id: &str,
+    text: &str,
+) -> Result<bool> {
+    ensure!(!text.trim().is_empty(), "steering text is empty");
+    ensure!(text.len() <= 64 * 1024, "steering text exceeds 64 KiB");
+    send_to(&super::path::for_session(session_id)?, text).await
+}
+
+pub(super) async fn send_to(path: &Path, text: &str) -> Result<bool> {
+    let stream = match UnixStream::connect(path).await {
+        Ok(stream) => stream,
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::NotFound | ErrorKind::ConnectionRefused
+            ) =>
+        {
+            return Ok(false);
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let (reader, mut writer) = stream.into_split();
+    let mut request = serde_json::to_vec(&Request { text: text.into() })?;
+    request.push(b'\n');
+    writer.write_all(&request).await?;
+    let mut response = String::new();
+    BufReader::new(reader).read_line(&mut response).await?;
+    Ok(serde_json::from_str::<Reply>(&response)?.accepted)
+}

--- a/src/session/helper/steering/ipc/connection.rs
+++ b/src/session/helper/steering/ipc/connection.rs
@@ -1,0 +1,23 @@
+//! One session-steering socket exchange.
+
+use anyhow::Result;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+use super::wire::{Reply, Request};
+use crate::session::helper::steering::SteeringInput;
+
+pub(super) async fn handle(stream: UnixStream, session_id: String) -> Result<()> {
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+    let Some(line) = lines.next_line().await? else {
+        return Ok(());
+    };
+    let request: Request = serde_json::from_str(&line)?;
+    let accepted = !request.text.trim().is_empty()
+        && super::super::push(&session_id, SteeringInput::new(request.text, vec![]));
+    let mut response = serde_json::to_vec(&Reply { accepted })?;
+    response.push(b'\n');
+    writer.write_all(&response).await?;
+    Ok(())
+}

--- a/src/session/helper/steering/ipc/endpoint.rs
+++ b/src/session/helper/steering/ipc/endpoint.rs
@@ -1,0 +1,43 @@
+//! Active session endpoint lifecycle.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use tokio::net::UnixListener;
+
+pub(in crate::session::helper::steering) struct Endpoint {
+    path: PathBuf,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Endpoint {
+    pub(in crate::session::helper::steering) fn start(session_id: &str) -> Result<Self> {
+        Self::start_at(session_id, super::path::for_session(session_id)?)
+    }
+
+    pub(super) fn start_at(session_id: &str, path: PathBuf) -> Result<Self> {
+        clear_stale(&path)?;
+        let listener = UnixListener::bind(&path)
+            .with_context(|| format!("bind session endpoint {}", path.display()))?;
+        let handle = tokio::spawn(super::server::run(listener, session_id.to_string()));
+        Ok(Self { path, handle })
+    }
+}
+
+fn clear_stale(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    if std::os::unix::net::UnixStream::connect(path).is_ok() {
+        bail!("session already has an active owner");
+    }
+    std::fs::remove_file(path)?;
+    Ok(())
+}
+
+impl Drop for Endpoint {
+    fn drop(&mut self) {
+        self.handle.abort();
+        let _ = std::fs::remove_file(&self.path);
+    }
+}

--- a/src/session/helper/steering/ipc/path.rs
+++ b/src/session/helper/steering/ipc/path.rs
@@ -1,0 +1,34 @@
+//! Stable socket paths derived only from durable session identity.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, ensure};
+use directories::ProjectDirs;
+use sha2::{Digest, Sha256};
+
+pub(super) fn for_session(session_id: &str) -> Result<PathBuf> {
+    let root = if let Some(path) = std::env::var_os("CODETETHER_SESSION_RUNTIME_DIR") {
+        PathBuf::from(path)
+    } else {
+        ProjectDirs::from("ai", "codetether", "codetether-agent")
+            .context("CodeTether runtime directory is unavailable")?
+            .data_dir()
+            .join("session-runtime")
+    };
+    for_session_in(&root, session_id)
+}
+
+pub(super) fn for_session_in(root: &Path, session_id: &str) -> Result<PathBuf> {
+    ensure!(
+        (8..=128).contains(&session_id.len())
+            && session_id
+                .chars()
+                .all(|value| value.is_ascii_alphanumeric() || matches!(value, '-' | '_')),
+        "invalid session id"
+    );
+    std::fs::create_dir_all(root)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(root, std::os::unix::fs::PermissionsExt::from_mode(0o700))?;
+    let digest = hex::encode(Sha256::digest(session_id.as_bytes()));
+    Ok(root.join(format!("{}.sock", &digest[..32])))
+}

--- a/src/session/helper/steering/ipc/server.rs
+++ b/src/session/helper/steering/ipc/server.rs
@@ -1,0 +1,17 @@
+//! Accept session-addressed steering connections.
+
+use tokio::net::UnixListener;
+
+pub(super) async fn run(listener: UnixListener, session_id: String) {
+    loop {
+        let Ok((stream, _)) = listener.accept().await else {
+            return;
+        };
+        let session_id = session_id.clone();
+        tokio::spawn(async move {
+            if let Err(error) = super::connection::handle(stream, session_id).await {
+                tracing::warn!(%error, "Session steering connection failed");
+            }
+        });
+    }
+}

--- a/src/session/helper/steering/ipc/tests.rs
+++ b/src/session/helper/steering/ipc/tests.rs
@@ -1,0 +1,26 @@
+use super::{client, endpoint::Endpoint};
+use crate::session::helper::steering::{SteeringInput, queue};
+
+#[tokio::test]
+async fn routes_text_to_the_active_session_owner() {
+    let temp = tempfile::tempdir().unwrap();
+    let session_id = "session-1234";
+    let path = temp.path().join("active.sock");
+    queue::open(session_id);
+    let _endpoint = Endpoint::start_at(session_id, path.clone()).unwrap();
+
+    assert!(client::send_to(&path, "change direction").await.unwrap());
+    let inputs: Vec<SteeringInput> = queue::take(session_id);
+    let (_, text) = inputs.into_iter().next().unwrap().into_message();
+
+    assert_eq!(text, "change direction");
+    queue::clear(session_id);
+}
+
+#[test]
+fn endpoint_path_is_stable_for_a_session() {
+    let temp = tempfile::tempdir().unwrap();
+    let first = super::path::for_session_in(temp.path(), "session-1234").unwrap();
+    let second = super::path::for_session_in(temp.path(), "session-1234").unwrap();
+    assert_eq!(first, second);
+}

--- a/src/session/helper/steering/ipc/wire.rs
+++ b/src/session/helper/steering/ipc/wire.rs
@@ -1,0 +1,13 @@
+//! Local steering wire messages.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+pub(super) struct Request {
+    pub(super) text: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(super) struct Reply {
+    pub(super) accepted: bool,
+}

--- a/src/session/helper/steering/mod.rs
+++ b/src/session/helper/steering/mod.rs
@@ -3,12 +3,50 @@
 mod drain;
 mod guard;
 mod input;
+#[cfg(unix)]
+mod ipc;
 mod queue;
 
 pub(crate) use drain::{drain_into, drain_or_close_into};
 pub(crate) use guard::RunGuard;
 pub(crate) use input::SteeringInput;
 pub(crate) use queue::{clear, open, push};
+
+/// Send trusted user text to whichever process currently owns a session turn.
+///
+/// # Arguments
+///
+/// * `session_id` — Durable CodeTether session identifier.
+/// * `text` — User message to inject at the next safe steering boundary.
+///
+/// # Returns
+///
+/// `true` when an active owner accepted the message, or `false` when idle.
+///
+/// # Errors
+///
+/// Returns an error for invalid input or local IPC failures.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// let accepted = codetether_agent::session::helper::steering::send(
+///     "session-1234",
+///     "Use the safer migration path",
+/// ).await.unwrap();
+/// # let _ = accepted;
+/// # });
+/// ```
+pub async fn send(session_id: &str, text: &str) -> anyhow::Result<bool> {
+    #[cfg(unix)]
+    return ipc::send(session_id, text).await;
+    #[cfg(not(unix))]
+    {
+        let _ = (session_id, text);
+        Ok(false)
+    }
+}
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
- add protocol-v6 mux agent start/read/cancel operations with durable task storage
- stream live mux session events and preserve JSONL text chunks
- document the mux agent task lifecycle and add focused coverage

## Focused gates
- cargo test --lib mux::tests::agent_protocol -- --nocapture
- cargo test --lib mux::agent_task::tests -- --nocapture
- cargo test --lib cli::run::jsonl::tests::text -- --nocapture
- ./check_file_limits.sh
- cargo fmt --all -- --check
- git diff --check