### PR TITLE
fix(worker): prevent task-slot deadlocks

### DIFF
--- a/Dockerfile.worker-prebuilt
+++ b/Dockerfile.worker-prebuilt
@@ -8,9 +8,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /home/codetether
-
 COPY codetether-bin /usr/local/bin/codetether
 RUN chmod +x /usr/local/bin/codetether
+
+# The worker runs as an unprivileged user (uid 1000 in Kubernetes). Its home and
+# working directory must be writable by that user: the agent persists session
+# state and loop-halt diagnostics there, and a root-owned WORKDIR makes every
+# task fail immediately with "Permission denied".
+RUN mkdir -p /home/codetether \
+    && chown -R 1000:1000 /home/codetether \
+    && chmod 0775 /home/codetether
+
+WORKDIR /home/codetether
 
 ENTRYPOINT ["/usr/local/bin/codetether"]

--- a/src/a2a/worker/worker_init.rs
+++ b/src/a2a/worker/worker_init.rs
@@ -14,6 +14,7 @@ use super::{
 };
 
 pub(super) async fn init_worker(args: A2aArgs) -> Result<WorkerContext> {
+    worker_init_helpers::apply_auto_approve_access_mode(&args);
     let server = args.server.trim_end_matches('/').to_string();
     let name = worker_init_helpers::resolve_name(args.name.as_deref());
     let worker_id = resolve_worker_id();

--- a/src/a2a/worker/worker_init_helpers.rs
+++ b/src/a2a/worker/worker_init_helpers.rs
@@ -4,9 +4,63 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::{bus::AgentBus, cli::A2aArgs};
+use crate::{
+    bus::AgentBus,
+    cli::A2aArgs,
+    config::{AccessMode, Config},
+};
 
 use super::{WorkerTaskRuntime, normalize_max_concurrent_tasks, parse_auto_approve, task_timeline};
+
+/// Align the process-wide runtime access mode with the worker's `--auto-approve`
+/// policy.
+///
+/// The worker's own tool registry honours `--auto-approve`, but runtime policy
+/// (which gates `bash`, patches, and other side-effecting tools) reads the
+/// access mode from config. Interactive entrypoints set that override from their
+/// CLI flags; the worker did not, so `--auto-approve all` still produced
+/// "requires approval" tool failures with no human present to approve them,
+/// failing every task that needed to clone or modify a repository.
+pub(super) fn apply_auto_approve_access_mode(args: &A2aArgs) {
+    let access_mode = auto_approve_access_mode(&args.auto_approve);
+    Config::apply_process_access_mode_override(access_mode);
+}
+
+/// Map a worker auto-approve policy onto the equivalent runtime access mode.
+///
+/// Only the unattended `all` policy widens the access mode; `safe` and `none`
+/// leave the configured value untouched so their prompts still apply.
+pub(super) fn auto_approve_access_mode(auto_approve: &str) -> Option<AccessMode> {
+    match auto_approve.trim() {
+        "all" => Some(AccessMode::Full),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod auto_approve_access_mode_tests {
+    use super::auto_approve_access_mode;
+    use crate::config::AccessMode;
+
+    #[test]
+    fn unattended_all_policy_grants_full_access() {
+        assert!(matches!(
+            auto_approve_access_mode("all"),
+            Some(AccessMode::Full)
+        ));
+        assert!(matches!(
+            auto_approve_access_mode(" all "),
+            Some(AccessMode::Full)
+        ));
+    }
+
+    #[test]
+    fn narrower_policies_keep_configured_access_mode() {
+        assert!(auto_approve_access_mode("safe").is_none());
+        assert!(auto_approve_access_mode("none").is_none());
+        assert!(auto_approve_access_mode("").is_none());
+    }
+}
 
 pub(super) fn build_task_runtime(
     args: &A2aArgs,

--- a/src/provider/retry/mod.rs
+++ b/src/provider/retry/mod.rs
@@ -1,13 +1,18 @@
 //! Provider HTTP retry logic.
 //!
-//! Wraps outbound API calls (Z.AI, OpenAI, etc.) with infinite-retry
-//! exponential backoff so transient overload / rate-limit / 5xx errors
-//! never terminate an agentic session. Used by provider `complete` and
-//! `complete_stream` implementations in [`super::zai`].
+//! Wraps outbound API calls (Z.AI, OpenAI, etc.) with bounded exponential
+//! backoff so transient overload / rate-limit / 5xx errors do not terminate
+//! an agentic session, while permanent failures (expired plan, insufficient
+//! balance, suspended account) and exhausted retry budgets surface as errors
+//! instead of looping forever and holding the worker's task slot. Used by
+//! provider `complete` and `complete_stream` implementations in
+//! [`super::zai`].
 mod classify;
 #[cfg(test)]
 mod classify_tests;
 mod send;
+#[cfg(test)]
+mod send_tests;
 mod stream;
 pub(crate) mod timing;
 

--- a/src/provider/retry/send.rs
+++ b/src/provider/retry/send.rs
@@ -1,11 +1,18 @@
-use super::classify::{backoff_delay, is_retryable_message, is_retryable_status};
+use super::classify::{
+    backoff_delay, is_permanent_message, is_retryable_message, is_retryable_status,
+};
 
 /// Send an HTTP request with automatic retry on transient errors.
 ///
-/// Wraps any async request factory in an infinite retry loop with
+/// Wraps any async request factory in a bounded retry loop with
 /// exponential backoff. Used by provider `complete` methods to survive
 /// 429/502/503 responses, Z.AI "temporarily overloaded" errors, and
 /// transient network failures before parsing the JSON body.
+///
+/// Retries stop after `MAX_ATTEMPTS`, and a rate-limit response whose body
+/// reports a permanent condition (expired plan, insufficient balance,
+/// suspended account) bails immediately: no amount of backoff can clear it,
+/// and retrying forever silently occupies the worker's task slot.
 ///
 /// # Arguments
 ///
@@ -55,6 +62,8 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = anyhow::Result<(String, reqwest::StatusCode)>>,
 {
+    const MAX_ATTEMPTS: u32 = 5;
+
     let mut attempt = 0u32;
     loop {
         attempt += 1;
@@ -63,6 +72,12 @@ where
                 return Ok((text, status));
             }
             Ok((text, status)) if is_retryable_status(status) || is_retryable_message(&text) => {
+                if is_permanent_message(&text) {
+                    anyhow::bail!("Non-retryable provider error: {status} {text}");
+                }
+                if attempt >= MAX_ATTEMPTS {
+                    anyhow::bail!("API error after {attempt} attempts: {status} {text}");
+                }
                 let delay = backoff_delay(attempt);
                 tracing::warn!(
                     attempt, %status,
@@ -75,6 +90,14 @@ where
                 anyhow::bail!("API error: {status} {text}");
             }
             Err(e) if is_retryable_message(&e.to_string()) => {
+                if is_permanent_message(&e.to_string()) {
+                    return Err(e);
+                }
+                if attempt >= MAX_ATTEMPTS {
+                    return Err(
+                        e.context(format!("network error persisted after {attempt} attempts"))
+                    );
+                }
                 let delay = backoff_delay(attempt);
                 tracing::warn!(
                     attempt, error = %e,

--- a/src/provider/retry/send_tests.rs
+++ b/src/provider/retry/send_tests.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use super::send::send_with_retry;
+
+/// A permanent 429 (expired plan) must bail on the first attempt instead of
+/// retrying forever and occupying the worker's only task slot.
+#[tokio::test]
+async fn permanent_rate_limit_body_bails_immediately() {
+    let calls = Arc::new(AtomicU32::new(0));
+    let seen = Arc::clone(&calls);
+    let result = send_with_retry(|| {
+        let seen = Arc::clone(&seen);
+        async move {
+            seen.fetch_add(1, Ordering::SeqCst);
+            Ok((
+                String::from(r#"{"error":{"code":"1309","message":"package has expired"}}"#),
+                reqwest::StatusCode::TOO_MANY_REQUESTS,
+            ))
+        }
+    })
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("Non-retryable provider error"),
+        "unexpected error: {message}"
+    );
+}
+
+/// A genuinely transient 429 must stop after the bounded attempt budget rather
+/// than retrying without limit.
+#[tokio::test]
+async fn transient_rate_limit_stops_after_max_attempts() {
+    let calls = Arc::new(AtomicU32::new(0));
+    let seen = Arc::clone(&calls);
+    let result = send_with_retry(|| {
+        let seen = Arc::clone(&seen);
+        async move {
+            seen.fetch_add(1, Ordering::SeqCst);
+            Ok((
+                String::from("Too Many Requests"),
+                reqwest::StatusCode::TOO_MANY_REQUESTS,
+            ))
+        }
+    })
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(calls.load(Ordering::SeqCst), 5);
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("after 5 attempts"),
+        "unexpected error: {message}"
+    );
+}
+
+/// A transient failure that later succeeds must still return the success body.
+#[tokio::test]
+async fn transient_rate_limit_recovers_before_budget() {
+    let calls = Arc::new(AtomicU32::new(0));
+    let seen = Arc::clone(&calls);
+    let (body, status) = send_with_retry(|| {
+        let seen = Arc::clone(&seen);
+        async move {
+            let attempt = seen.fetch_add(1, Ordering::SeqCst) + 1;
+            if attempt < 2 {
+                return Ok((
+                    String::from("Too Many Requests"),
+                    reqwest::StatusCode::TOO_MANY_REQUESTS,
+                ));
+            }
+            Ok((String::from("{\"ok\":true}"), reqwest::StatusCode::OK))
+        }
+    })
+    .await
+    .expect("retry should recover");
+
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body, "{\"ok\":true}");
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}


### PR DESCRIPTION
## Summary
- bound non-streaming provider retries and bail immediately on permanent billing/subscription errors
- map `worker --auto-approve all` to full runtime access so unattended workers do not stall on approval requests
- make the prebuilt worker image workdir writable by Kubernetes uid 1000

## Validation
- `cargo test --lib -- auto_approve_access_mode provider::retry` — 12 passed
- `cargo build --release --bin codetether` — succeeded
- live worker image `sha256:ed17ced3d3df622aacb4b7b1603234de15dc6171cbeb386e19aad3aff2b322e7` ready in `a2a-system`
- exact `openai-codex/gpt-5.6-sol-fast:max` completion returned `OK` with backend opt-in
- private Forgejo clone task completed and enqueued its build task